### PR TITLE
Small typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ FrankenPHP can also be used as a standalone Go library to embed PHP in any app u
 
 ## Getting Started
 
-☢️ FrankenPHP is very experimental, don't use it in production yet, [fill bugs](https://github.com/dunglas/frankenphp/issues) and write patches! ☢️
+☢️ FrankenPHP is very experimental, don't use it in production yet, [file bugs](https://github.com/dunglas/frankenphp/issues) and write patches! ☢️
 
 ```
 docker run -v $PWD:/app/public \


### PR DESCRIPTION
Was reading the docs and saw something small.

I did try to click the Go library documentation thinking it was the docs on how to use this in a normal Go app, but was surprised it was a link to the Go.dev docs. Any plans, I know it’s early, to document integration with a Go app?