### PR TITLE
Allow to add other ini files 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ RUN git clone --depth=1 --single-branch --branch=frankenphp-8.2 https://github.c
     ./configure \
         --enable-embed=static \
         --enable-zts \
-        --disable-zend-signals && \
+        --disable-zend-signals \
+        --with-config-file-scan-dir=/usr/local/lib/php/ && \
     make -j$(nproc) && \
     make install && \
     rm -Rf php-src/ && \


### PR DESCRIPTION
Allows users to add php.ini files to `/usr/local/lib/php/` without rebuilding the image (could be done with a simple volume)