### PR TITLE
fix: signals handling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,63 +1,56 @@
 # Contributing
 
-## Running the test suite
-
-    go test -race -v ./...
-
-## Debugging
+## Compiling PHP
 ### With Docker (Linux)
 
 Build the dev Docker image:
 
-    docker build -t frankenphp-dev Dockerfile.dev 
-    docker run -p 8080:8080 -p 443:443 -v $PWD:/go/src/app -it frankenphp-dev bash
+    docker -t frankenphp-dev -f Dockerfile.dev .
+    docker run -p 8080:8080 -p 443:443 -v $PWD:/go/src/app -it frankenphp-dev
 
 The image contains the usual development tools (Go, GDB, Valgrind, Neovim...).
-#### Caddy module
-
-Build Caddy with the FrankenPHP Caddy module:
-
-    cd /go/src/app/caddy/frankenphp/
-    go build
-
-Run the Caddy with the FrankenPHP Caddy module:
-
-    cd /go/src/app/testdata/
-    ../caddy/frankenphp/frankenphp run
-
-#### Minimal test server
-
-Build the minimal test server:
-
-    cd /go/src/app/internal/testserver/
-    go build
-
-Run the test server:
-
-    cd /go/src/app/testdata/
-    ../internal/testserver/testserver
-
-The server is listening on `127.0.0.1:8080`:
-
-    curl http://127.0.0.1:8080/phpinfo.php
 
 ### Without Docker (Linux and macOS)
 
-Compile PHP:
+[Follow the instructions to compile from sources](docs/compile.md) and pass the `--debug` configuration flag.
 
-    ./configure --enable-debug --enable-zts
-    make -j6
-    sudo make install
+## Running the test suite
+
+    go test -race -v ./...
+
+## Caddy module
+
+Build Caddy with the FrankenPHP Caddy module:
+
+    cd caddy/frankenphp/
+    go build
+    cd ../../
+
+Run the Caddy with the FrankenPHP Caddy module:
+
+    cd testdata/
+    ../caddy/frankenphp/frankenphp run
+
+The server is listening on `127.0.0.1:8080`:
+
+    curl -vk https://localhosy/phpinfo.php
+
+## Minimal test server
 
 Build the minimal test server:
 
     cd internal/testserver/
     go build
+    cd ../../
 
-Run the test app:
+Run the test server:
 
-    cd ../../testdata/
+    cd testdata/
     ../internal/testserver/testserver
+
+The server is listening on `127.0.0.1:8080`:
+
+    curl -v http://127.0.0.1:8080/phpinfo.php
 
 ## Misc Dev Resources
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,10 @@ RUN apt-get update && \
 
 RUN git clone --depth=1 --single-branch --branch=frankenphp-8.2 https://github.com/dunglas/php-src.git && \
     cd php-src && \
-    #export CFLAGS="-DNO_SIGPROF" && \
     # --enable-embed is only necessary to generate libphp.so, we don't use this SAPI directly
     ./buildconf && \
     ./configure \
-        --enable-embed=static \
+        --enable-embed \
         --enable-zts \
         --disable-zend-signals && \
     make -j$(nproc) && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -36,18 +36,17 @@ RUN apt-get update && \
     && \
     apt-get clean 
 
-RUN git clone --depth=1 --single-branch --branch=frankenphp-8.2 https://github.com/dunglas/php-src.git && \
+RUN git clone --depth=1 https://github.com/php/php-src.git && \
     cd php-src && \
     git checkout frankenphp-8.2 && \
-    export CFLAGS="-DNO_SIGPROF" && \
     # --enable-embed is only necessary to generate libphp.so, we don't use this SAPI directly
     ./buildconf && \
     ./configure \
-        --enable-embed=static \
+        --enable-embed \
         --enable-zts \
         --disable-zend-signals \
         --enable-debug && \
-    make -j6 && \
+    make -j$(nproc) && \
     make install && \
     ldconfig && \
     php --version
@@ -59,3 +58,5 @@ WORKDIR /go/src/app
 COPY . .
 
 RUN go get -d -v ./...
+
+CMD [ "zsh" ]

--- a/docs/compile.md
+++ b/docs/compile.md
@@ -39,7 +39,6 @@ echo 'export PATH="/opt/homebrew/opt/bison/bin:$PATH"' >> ~/.zshrc
 Then run the configure script:
 
 ```
-export CFLAGS="-DNO_SIGPROF"
 ./configure \
     --enable-embed=static \
     --enable-zts \
@@ -58,7 +57,7 @@ if needed.
 Finally, compile PHP:
 
 ```
-make -j6
+make -j$(nproc)
 make install
 ```
 

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -5,7 +5,7 @@
 // [FrankenPHP app server]: https://frankenphp.dev
 package frankenphp
 
-// #cgo CFLAGS: -DNO_SIGPROF -Wall
+// #cgo CFLAGS: -Wall
 // #cgo CFLAGS: -I/usr/local/include/php -I/usr/local/include/php/Zend -I/usr/local/include/php/TSRM -I/usr/local/include/php/main
 // #cgo LDFLAGS: -L/usr/local/lib -L/opt/homebrew/opt/libiconv/lib -L/usr/lib -lphp -lxml2 -lresolv -lsqlite3 -ldl -lm -lutil
 // #cgo darwin LDFLAGS: -liconv
@@ -41,6 +41,7 @@ var (
 	InvalidRequestError         = errors.New("not a FrankenPHP request")
 	AlreaydStartedError         = errors.New("FrankenPHP is already started")
 	InvalidPHPVersionError      = errors.New("FrankenPHP is only compatible with PHP 8.2+")
+	ZendSignalsError            = errors.New("Zend Signals are enabled, recompible PHP with --disable-zend-signals")
 	MainThreadCreationError     = errors.New("error creating the main thread")
 	RequestContextCreationError = errors.New("error during request context creation")
 	RequestStartupError         = errors.New("error during PHP request startup")
@@ -203,6 +204,9 @@ func Init(options ...Option) error {
 
 	case -2:
 		return InvalidPHPVersionError
+
+	case -3:
+		return ZendSignalsError
 	}
 
 	shutdownWG.Add(1)


### PR DESCRIPTION
Zend Signals is useless (and currently broken) with ZTS (https://github.com/php/php-src/issues/9649#issuecomment-1264330874, https://github.com/php/php-src/pull/5591#issuecomment-650064098), and timeouts are fundamentally broken on ZTS (https://bugs.php.net/bug.php?id=79464).

This PR disables these features.

`set_time_limit` is useless anyway because it's better handled at Caddy level. `max_execution_time` could be useful if it's fixed in PHP core.