### PR TITLE
Don't require secrets for running tests

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -27,7 +27,7 @@ jobs:
           push: false
           pull: true
           target: builder
-          tags: ${{secrets.REGISTRY_LOGIN_SERVER}}/${{ secrets.REGISTRY_USERNAME }}/frankenphp:${{ github.sha }}-builder
+          tags: frankenphp:${{ github.sha }}-builder
           builder: ${{ steps.buildx.outputs.name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -36,7 +36,7 @@ jobs:
       - name: Run tests
         run: |
           docker load -i /tmp/.builder.tar
-          docker run --rm ${{secrets.REGISTRY_LOGIN_SERVER}}/${{ secrets.REGISTRY_USERNAME }}/frankenphp:${{ github.sha }}-builder "go test"
+          docker run --rm frankenphp:${{ github.sha }}-builder "go test"
   push-image:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,7 @@ jobs:
           push: false
           pull: true
           target: builder
-          tags: ${{secrets.REGISTRY_LOGIN_SERVER}}/${{ secrets.REGISTRY_USERNAME }}/frankenphp:${{ github.sha }}-builder
+          tags: frankenphp:${{ github.sha }}-builder
           builder: ${{ steps.buildx.outputs.name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -34,7 +34,7 @@ jobs:
       - name: Run tests
         run: |
           docker load -i /tmp/.builder.tar
-          docker run --rm ${{secrets.REGISTRY_LOGIN_SERVER}}/${{ secrets.REGISTRY_USERNAME }}/frankenphp:${{ github.sha }}-builder "go test"
+          docker run --rm frankenphp:${{ github.sha }}-builder "go test"
   push-image:
     runs-on: ubuntu-latest
     steps:
@@ -42,20 +42,13 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Docker Login
-        uses: docker/login-action@v2
-        with:
-          registry: ${{secrets.REGISTRY_LOGIN_SERVER}}
-          username: ${{secrets.REGISTRY_USERNAME}}
-          password: ${{secrets.REGISTRY_PASSWORD}}
-
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
           # list of Docker images to use as base name for tags
           images: |
-            ${{ secrets.REGISTRY_LOGIN_SERVER }}/${{ secrets.REGISTRY_REPO }}/frankenphp
+            frankenphp
           # generate Docker tags based on the following events/attributes
           tags: |
             type=schedule
@@ -80,7 +73,7 @@ jobs:
         with:
           context: ./
           file: Dockerfile
-          push: true
+          push: false
           pull: true
           target: final
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
I just noticed that secrets aren't shared with forks, so tests fail to run. This will at least allow tests to run on PRs from other forks.