### PR TITLE
Fixing docker build bug in main Dockerfile relating to a COPY command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ COPY caddy/go.mod caddy/go.sum ./caddy/
 
 RUN cd caddy && go mod graph | awk '{if ($1 !~ "@") print $2}' | xargs go get
 
-COPY *.* .
+COPY *.* ./
 COPY caddy caddy
 COPY C-Thread-Pool C-Thread-Pool
 COPY internal internal


### PR DESCRIPTION
On ubuntu 22.04 with Docker version 20.10.17, build 100c701,

`docker build .`

was failing on step 15 with:
  Step 15/37 : COPY *.* .
  When using COPY with more than one source file, the destination must be a directory and end with a /