### PR TITLE
Push latest when pushing main branch

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -91,7 +91,7 @@ jobs:
           push: true
           pull: true
           target: final
-          platforms: linux/amd64,linux/arm64
+          #platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           builder: ${{ steps.buildx.outputs.name }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Docker Login
         uses: docker/login-action@v2
         with:
-          registry: ${{secrets.REGISTRY_LOGIN_SERVER:docker.io}}
+          registry: ${{secrets.REGISTRY_LOGIN_SERVER:"docker.io"}}
           username: ${{secrets.REGISTRY_USERNAME}}
           password: ${{secrets.REGISTRY_PASSWORD}}
 

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Docker Login
         uses: docker/login-action@v2
         with:
-          registry: ${{secrets.REGISTRY_LOGIN_SERVER:"docker.io"}}
+          #registry: ${{secrets.REGISTRY_LOGIN_SERVER}}
           username: ${{secrets.REGISTRY_USERNAME}}
           password: ${{secrets.REGISTRY_PASSWORD}}
 
@@ -71,6 +71,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
             type=sha
 
       - name: Set up Docker Buildx

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Docker Login
         uses: docker/login-action@v2
         with:
-          #registry: ${{secrets.REGISTRY_LOGIN_SERVER}}
+          registry: ${{secrets.REGISTRY_LOGIN_SERVER:docker.io}}
           username: ${{secrets.REGISTRY_USERNAME}}
           password: ${{secrets.REGISTRY_PASSWORD}}
 

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -91,7 +91,7 @@ jobs:
           push: true
           pull: true
           target: final
-          #platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           builder: ${{ steps.buildx.outputs.name }}


### PR DESCRIPTION
This change will push the `latest` tag to Docker when `main` updates in this repo.

The last push from my fork can be seen here: https://hub.docker.com/repository/docker/withinboredom/frankenphp/general