### PR TITLE
Yet another workflow change :)

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -49,7 +49,7 @@ jobs:
           - dockerfile: Dockerfile
             flavor: ""
           - dockerfile: Dockerfile.alpine
-            flavor: "alpine"
+            flavor: "-alpine"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -69,7 +69,7 @@ jobs:
           # list of Docker images to use as base name for tags
           images: ${{secrets.IMAGE_NAME}}
           flavor: |
-            suffix: {{matrix.flavor}}
+            suffix=${{matrix.flavor}}
           # generate Docker tags based on the following events/attributes
           tags: |
             type=schedule

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -45,6 +45,11 @@ jobs:
     strategy:
       matrix:
         dockerfile: [ "Dockerfile", "Dockerfile.alpine" ]
+        include:
+          - dockerfile: Dockerfile
+            flavor: ""
+          - dockerfile: Dockerfile.alpine
+            flavor: "alpine"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -63,6 +68,8 @@ jobs:
         with:
           # list of Docker images to use as base name for tags
           images: ${{secrets.IMAGE_NAME}}
+          flavor: |
+            suffix: {{matrix.flavor}}
           # generate Docker tags based on the following events/attributes
           tags: |
             type=schedule

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,7 +58,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           flavor: |
-            suffix: {{matrix.flavor}}
+            suffix: ${{matrix.flavor}}
             suffixLatest: true
           # list of Docker images to use as base name for tags
           images: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,6 +43,11 @@ jobs:
     strategy:
       matrix:
         dockerfile: [ "Dockerfile", "Dockerfile.alpine" ]
+        include:
+          - dockerfile: Dockerfile
+            flavor: ""
+          - dockerfile: Dockerfile.alpine
+            flavor: "-alpine"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -52,6 +57,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
+          flavor: |
+            suffix: {{matrix.flavor}}
+            suffixLatest: true
           # list of Docker images to use as base name for tags
           images: |
             frankenphp

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,7 +59,6 @@ jobs:
         with:
           flavor: |
             suffix=${{matrix.flavor}}
-            suffixLatest=true
           # list of Docker images to use as base name for tags
           images: |
             frankenphp
@@ -71,6 +70,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=raw,value=latest
             type=sha
 
       - name: Set up Docker Buildx

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,8 +58,8 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           flavor: |
-            suffix: ${{matrix.flavor}}
-            suffixLatest: true
+            suffix=${{matrix.flavor}}
+            suffixLatest=true
           # list of Docker images to use as base name for tags
           images: |
             frankenphp


### PR DESCRIPTION
Depending on which build finishes first, either the alpine version or the Debian version will be in the "latest" tag. This change will push a `-alpine` version and make the Debian version the default.

:sigh: this stuff is tricky.