### PR TITLE
add PHP_SELF to $_SERVER

### DIFF
--- a/cgi.go
+++ b/cgi.go
@@ -69,6 +69,8 @@ func populateEnv(request *http.Request) error {
 	scriptName := fpath
 
 	docURI := fpath
+
+
 	// split "actual path" from "path info" if configured
 	if splitPos := splitPos(fc, fpath); splitPos > -1 {
 		docURI = fpath[:splitPos]
@@ -87,6 +89,10 @@ func populateEnv(request *http.Request) error {
 		scriptName = "/" + scriptName
 	}
 
+	
+	if _, ok := fc.Env["PHP_SELF"]; !ok {
+		fc.Env["PHP_SELF"] = fpath
+	}
 	if _, ok := fc.Env["DOCUMENT_URI"]; !ok {
 		fc.Env["DOCUMENT_URI"] = docURI
 	}

--- a/cgi.go
+++ b/cgi.go
@@ -69,8 +69,6 @@ func populateEnv(request *http.Request) error {
 	scriptName := fpath
 
 	docURI := fpath
-
-
 	// split "actual path" from "path info" if configured
 	if splitPos := splitPos(fc, fpath); splitPos > -1 {
 		docURI = fpath[:splitPos]
@@ -88,7 +86,6 @@ func populateEnv(request *http.Request) error {
 	if scriptName != "" && !strings.HasPrefix(scriptName, "/") {
 		scriptName = "/" + scriptName
 	}
-
 	
 	if _, ok := fc.Env["PHP_SELF"]; !ok {
 		fc.Env["PHP_SELF"] = fpath

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -106,7 +106,7 @@ func TestServerVariable_worker(t *testing.T) {
 }
 func testServerVariable(t *testing.T, opts *testOptions) {
 	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, i int) {
-		req := httptest.NewRequest("GET", fmt.Sprintf("http://example.com/server-variable.php?foo=a&bar=b&i=%d#hash", i), nil)
+		req := httptest.NewRequest("GET", fmt.Sprintf("http://example.com/server-variable.php/baz/bat?foo=a&bar=b&i=%d#hash", i), nil)
 		req.SetBasicAuth("kevin", "password")
 		w := httptest.NewRecorder()
 		handler(w, req)
@@ -122,10 +122,10 @@ func testServerVariable(t *testing.T, opts *testOptions) {
 		assert.Contains(t, strBody, "[PHP_AUTH_PW] => password")
 		assert.Contains(t, strBody, "[HTTP_AUTHORIZATION] => Basic a2V2aW46cGFzc3dvcmQ=")
 		assert.Contains(t, strBody, "[DOCUMENT_ROOT]")
+		assert.Contains(t, strBody, "[PHP_SELF] => /server-variable.php/baz/bat")
 		assert.Contains(t, strBody, "[CONTENT_TYPE]")
 		assert.Contains(t, strBody, fmt.Sprintf("[QUERY_STRING] => foo=a&bar=b&i=%d#hash", i))
-		assert.Contains(t, strBody, fmt.Sprintf("[REQUEST_URI] => /server-variable.php?foo=a&bar=b&i=%d#hash", i))
-		assert.Contains(t, strBody, "[SCRIPT_NAME]")
+		assert.Contains(t, strBody, fmt.Sprintf("[REQUEST_URI] => /server-variable.php/baz/bat?foo=a&bar=b&i=%d#hash", i))
 		assert.Contains(t, strBody, "[CONTENT_LENGTH]")
 		assert.Contains(t, strBody, "[REMOTE_ADDR]")
 		assert.Contains(t, strBody, "[REMOTE_PORT]")


### PR DESCRIPTION
#34 To make WordPress work you need $_SERVER["PHP_SELF"] to be the filepath of the php file currently executing.