### PR TITLE
docs: add WordPress example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,12 @@ Go to `https://localhost`, and enjoy!
 * [Early Hints support (103 HTTP status code)](docs/early-hints.md)
 * [Real-time](docs/mercure.md)
 * [Configuration](docs/config.md)
-* [Demo app (Symfony) and benchmarks](https://github.com/dunglas/frankenphp-demo)
-* [Building Docker images](docs/docker.md)
 * [Compile from sources](docs/compile.md)
+* [Building Docker images](docs/docker.md)
 * [Go library documentation](https://pkg.go.dev/github.com/dunglas/frankenphp)
 * [Contributing and debugging](CONTRIBUTING.md)
+
+## Examples and Skeletons
+
+* [Symfony apps](https://github.com/dunglas/frankenphp-demo)
+* [Wordpress](https://github.com/dunglas/frankenphp-wordpress)


### PR DESCRIPTION
Closes #34.