### PR TITLE
Use RC5 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,80 +1,140 @@
-FROM php:8.2.0RC4-zts-bullseye AS php-base
+FROM php:8.2.0RC5-zts-bullseye AS php-base
 
-# Note that this image is based on the official PHP image, once 8.3 is released, this stage can likely be removed
-
-RUN rm -Rf /usr/local/include/php/ /usr/local/lib/libphp.* /usr/local/lib/php/ /usr/local/php/
-
-ENV PHPIZE_DEPS \
-    autoconf \
-    dpkg-dev \
-    file \
-    g++ \
-    gcc \
-    libc-dev \
-    make \
-    pkg-config \
-    re2c
-
-RUN apt-get update && \
-    apt-get -y --no-install-recommends install \
-    $PHPIZE_DEPS \
-    libargon2-dev \
-    libcurl4-openssl-dev \
-    libonig-dev \
-    libreadline-dev \
-    libsodium-dev \
-    libsqlite3-dev \
-    libssl-dev \
-    libxml2-dev \
-    zlib1g-dev \
-    bison \
-    git \
-    && \
-    apt-get clean
-
-RUN git clone --depth=1 --single-branch --branch=PHP-8.2 https://github.com/php/php-src.git && \
-    cd php-src && \
-    # --enable-embed is only necessary to generate libphp.so, we don't use this SAPI directly
-    ./buildconf && \
-    ./configure \
-        --enable-embed \
-        --enable-zts \
-        --disable-zend-signals \
-    	# --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
-    	--enable-mysqlnd \
-     	# make sure invalid --configure-flags are fatal errors instead of just warnings
-    	--enable-option-checking=fatal \
-    	# https://github.com/docker-library/php/issues/439
-    	--with-mhash \
-    	# https://github.com/docker-library/php/issues/822
-    	--with-pic \
-    	# --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
-    	--enable-ftp \
-    	# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
-    	--enable-mbstring \
-    	# https://wiki.php.net/rfc/argon2_password_hash
-    	--with-password-argon2 \
-    	# https://wiki.php.net/rfc/libsodium
-    	--with-sodium=shared \
-    	# always build against system sqlite3 (https://github.com/php/php-src/commit/6083a387a81dbbd66d6316a3a12a63f06d5f7109)
+# rebuild PHP until https://github.com/docker-library/php/pull/1331 is merged
+RUN set -eux; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libargon2-dev \
+		libcurl4-openssl-dev \
+		libonig-dev \
+		libreadline-dev \
+		libsodium-dev \
+		libsqlite3-dev \
+		libssl-dev \
+		libxml2-dev \
+		zlib1g-dev \
+	; \
+	\
+	export \
+		CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
+	; \
+	docker-php-source extract; \
+	cd /usr/src/php; \
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+	debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+	./configure \
+		--build="$gnuArch" \
+		--with-config-file-path="$PHP_INI_DIR" \
+		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
+		\
+# make sure invalid --configure-flags are fatal errors instead of just warnings
+		--enable-option-checking=fatal \
+		\
+# https://github.com/docker-library/php/issues/439
+		--with-mhash \
+		\
+# https://github.com/docker-library/php/issues/822
+		--with-pic \
+		\
+# --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
+		--enable-ftp \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
+# --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
+		--enable-mysqlnd \
+# https://wiki.php.net/rfc/argon2_password_hash
+		--with-password-argon2 \
+# https://wiki.php.net/rfc/libsodium
+		--with-sodium=shared \
+# always build against system sqlite3 (https://github.com/php/php-src/commit/6083a387a81dbbd66d6316a3a12a63f06d5f7109)
 		--with-pdo-sqlite=/usr \
 		--with-sqlite3=/usr \
+		\
 		--with-curl \
 		--with-iconv \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
-    	# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
 		--disable-phpdbg \
-        --with-config-file-path="$PHP_INI_DIR" \
-        --with-config-file-scan-dir="$PHP_INI_DIR/conf.d" && \
-    make -j$(nproc) && \
-    make install && \
-    rm -Rf php-src/ && \
-    echo "Creating src archive for building extensions\n" && \
-    tar -c -f /usr/src/php.tar.xz -J /php-src/ && \
-    ldconfig && \
-    php --version
+		\
+# in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
+		--with-pear \
+		\
+# bundled pcre does not support JIT on s390x
+# https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
+		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \
+		--with-libdir="lib/$debMultiarch" \
+		\
+		--disable-cgi \
+		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
+		--enable-zts \
+# https://externals.io/message/118859
+        --disable-zend-signals \
+	; \
+	make -j "$(nproc)"; \
+	find -type f -name '*.a' -delete; \
+	make install; \
+	find \
+		/usr/local \
+		-type f \
+		-perm '/0111' \
+		-exec sh -euxc ' \
+			strip --strip-all "$@" || : \
+		' -- '{}' + \
+	; \
+	make clean; \
+	\
+# https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)
+	cp -v php.ini-* "$PHP_INI_DIR/"; \
+	\
+	cd /; \
+	docker-php-source delete; \
+	\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
+	find /usr/local -type f -executable -exec ldd '{}' ';' \
+		| awk '/=>/ { print $(NF-1) }' \
+		| sort -u \
+		| xargs -r dpkg-query --search \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -r apt-mark manual \
+	; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+# update pecl channel definitions https://github.com/docker-library/php/issues/443
+	pecl update-channels; \
+	rm -rf /tmp/pear ~/.pearrc; \
+	\
+# smoke test
+	php --version
+
+
+# This is required to link the frankenPHP binary to the PHP binary
+RUN apt-get update && \
+    apt-get -y --no-install-recommends install \
+        libargon2-dev \
+        libcurl4-openssl-dev \
+        libonig-dev \
+        libreadline-dev \
+        libsodium-dev \
+        libsqlite3-dev \
+        libssl-dev \
+        libxml2-dev \
+        zlib1g-dev \
+        && \
+        apt-get clean
 
 FROM php-base AS builder
 
@@ -108,7 +168,7 @@ RUN cd caddy/frankenphp && \
 
 ENTRYPOINT ["/bin/bash","-c"]
 
-FROM php:8.2.0RC4-zts-bullseye AS final
+FROM php-base AS final
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 
@@ -119,13 +179,6 @@ RUN echo '<?php phpinfo();' > /app/public/index.php
 
 COPY --from=builder /usr/local/bin/frankenphp /usr/local/bin/frankenphp
 COPY --from=builder /etc/Caddyfile /etc/Caddyfile
-
-COPY --from=php-base /usr/local/include/php/ /usr/local/include/php
-COPY --from=php-base /usr/local/lib/libphp.* /usr/local/lib
-COPY --from=php-base /usr/local/lib/php/ /usr/local/lib/php
-COPY --from=php-base /usr/local/php/ /usr/local/php
-COPY --from=php-base /usr/local/bin/ /usr/local/bin
-COPY --from=php-base /usr/src /usr/src
 
 RUN sed -i 's/php/frankenphp run/g' /usr/local/bin/docker-php-entrypoint
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -120,6 +120,10 @@ RUN set -eux; \
 # smoke test
 	php --version
 
+FROM php-base AS builder
+
+COPY --from=golang:bullseye /usr/local/go/bin/go /usr/local/bin/go
+COPY --from=golang:bullseye /usr/local/go /usr/local/go
 
 # This is required to link the frankenPHP binary to the PHP binary
 RUN apt-get update && \
@@ -135,11 +139,6 @@ RUN apt-get update && \
         zlib1g-dev \
         && \
         apt-get clean
-
-FROM php-base AS builder
-
-COPY --from=golang:bullseye /usr/local/go/bin/go /usr/local/bin/go
-COPY --from=golang:bullseye /usr/local/go /usr/local/go
 
 WORKDIR /go/src/app
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,86 +1,137 @@
-FROM php:8.2.0RC4-zts-alpine3.16 AS php-base
+FROM php:8.2.0RC5-zts-alpine3.16 AS php-base
 
-# Note that this image is based on the official PHP image, once 8.3 is released, this stage can likely be removed
-
-RUN rm -Rf /usr/local/include/php/ /usr/local/lib/libphp.* /usr/local/lib/php/ /usr/local/php/
-
-ENV PHPIZE_DEPS \
-    autoconf \
-    dpkg-dev dpkg \
-    file \
-    g++ \
-    gcc \
-    libc-dev \
-    make \
-    pkgconf \
-    re2c
-
-RUN apk add --no-cache --virtual .build-deps \
-    $PHPIZE_DEPS \
-    argon2-dev \
-    coreutils \
-    curl-dev \
-    readline-dev \
-    libsodium-dev \
-    sqlite-dev \
-    openssl-dev \
-    libxml2-dev \
-    gnu-libiconv-dev \
-    linux-headers \
-    oniguruma-dev \
-    bison \
-    git
-
-RUN git clone --depth=1 --single-branch --branch=PHP-8.2 https://github.com/php/php-src.git
-
-WORKDIR /php-src/
-
-# --enable-embed is only necessary to generate libphp.so, we don't use this SAPI directly
-RUN ./buildconf
-RUN ./configure \
-        --enable-embed \
-        --enable-zts \
-        --disable-zend-signals \
-    	# --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
-    	--enable-mysqlnd \
-     	# make sure invalid --configure-flags are fatal errors instead of just warnings
-    	--enable-option-checking=fatal \
-    	# https://github.com/docker-library/php/issues/439
-    	--with-mhash \
-    	# https://github.com/docker-library/php/issues/822
-    	--with-pic \
-    	# --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
-    	--enable-ftp \
-    	# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
-    	--enable-mbstring \
-    	# https://wiki.php.net/rfc/argon2_password_hash
-    	--with-password-argon2 \
-    	# https://wiki.php.net/rfc/libsodium
-    	--with-sodium=shared \
-    	# always build against system sqlite3 (https://github.com/php/php-src/commit/6083a387a81dbbd66d6316a3a12a63f06d5f7109)
+RUN set -eux; \
+	apk add --no-cache --virtual .build-deps \
+		$PHPIZE_DEPS \
+		argon2-dev \
+		coreutils \
+		curl-dev \
+		gnu-libiconv-dev \
+		libsodium-dev \
+		libxml2-dev \
+		linux-headers \
+		oniguruma-dev \
+		openssl-dev \
+		readline-dev \
+		sqlite-dev \
+	; \
+	\
+# make sure musl's iconv doesn't get used (https://www.php.net/manual/en/intro.iconv.php)
+	rm -vf /usr/include/iconv.h; \
+	\
+	export \
+		CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
+	; \
+	docker-php-source extract; \
+	cd /usr/src/php; \
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+	./configure \
+		--build="$gnuArch" \
+		--with-config-file-path="$PHP_INI_DIR" \
+		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
+		\
+# make sure invalid --configure-flags are fatal errors instead of just warnings
+		--enable-option-checking=fatal \
+		\
+# https://github.com/docker-library/php/issues/439
+		--with-mhash \
+		\
+# https://github.com/docker-library/php/issues/822
+		--with-pic \
+		\
+# --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
+		--enable-ftp \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
+# --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
+		--enable-mysqlnd \
+# https://wiki.php.net/rfc/argon2_password_hash
+		--with-password-argon2 \
+# https://wiki.php.net/rfc/libsodium
+		--with-sodium=shared \
+# always build against system sqlite3 (https://github.com/php/php-src/commit/6083a387a81dbbd66d6316a3a12a63f06d5f7109)
 		--with-pdo-sqlite=/usr \
 		--with-sqlite3=/usr \
+		\
 		--with-curl \
-		--with-iconv \
+		--with-iconv=/usr \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
-    	# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
 		--disable-phpdbg \
-        --with-config-file-path="$PHP_INI_DIR" \
-        --with-config-file-scan-dir="$PHP_INI_DIR/conf.d"
-RUN make -j$(nproc)
-RUN make install
-RUN rm -Rf /php-src/
-RUN echo "Creating src archive for building extensions\n"
-RUN tar -c -f /usr/src/php.tar.xz -J /php-src/
-#RUN ldconfig
-RUN php --version
+		\
+# in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
+		--with-pear \
+		\
+# bundled pcre does not support JIT on s390x
+# https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
+		$(test "$gnuArch" = 's390x-linux-musl' && echo '--without-pcre-jit') \
+		\
+		--disable-cgi \
+		\
+		--enable-embed \
+		--enable-zts \
+# https://externals.io/message/118859
+		--disable-zend-signals \
+	; \
+	make -j "$(nproc)"; \
+	find -type f -name '*.a' -delete; \
+	make install; \
+	find \
+		/usr/local \
+		-type f \
+		-perm '/0111' \
+		-exec sh -euxc ' \
+			strip --strip-all "$@" || : \
+		' -- '{}' + \
+	; \
+	make clean; \
+	\
+# https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)
+	cp -v php.ini-* "$PHP_INI_DIR/"; \
+	\
+	cd /; \
+	docker-php-source delete; \
+	\
+	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --no-cache $runDeps; \
+	\
+	apk del --no-network .build-deps; \
+	\
+# update pecl channel definitions https://github.com/docker-library/php/issues/443
+	pecl update-channels; \
+	rm -rf /tmp/pear ~/.pearrc; \
+	\
+# smoke test
+	php --version
 
 FROM php-base AS builder
 
 COPY --from=golang:alpine3.16 /usr/local/go/bin/go /usr/local/bin/go
 COPY --from=golang:alpine3.16 /usr/local/go /usr/local/go
+
+RUN apk add --no-cache --virtual .build-deps \
+		$PHPIZE_DEPS \
+		argon2-dev \
+		coreutils \
+		curl-dev \
+		gnu-libiconv-dev \
+		libsodium-dev \
+		libxml2-dev \
+		linux-headers \
+		oniguruma-dev \
+		openssl-dev \
+		readline-dev \
+		sqlite-dev
 
 WORKDIR /go/src/app
 
@@ -109,7 +160,7 @@ RUN cd caddy/frankenphp && \
 
 ENTRYPOINT ["/bin/sh","-c"]
 
-FROM php:8.2.0RC4-zts-alpine3.16 AS final
+FROM php-base AS final
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 
@@ -120,13 +171,6 @@ RUN echo '<?php phpinfo();' > /app/public/index.php
 
 COPY --from=builder /usr/local/bin/frankenphp /usr/local/bin/frankenphp
 COPY --from=builder /etc/Caddyfile /etc/Caddyfile
-
-COPY --from=php-base /usr/local/include/php/ /usr/local/include/php
-COPY --from=php-base /usr/local/lib/libphp.* /usr/local/lib
-COPY --from=php-base /usr/local/lib/php/ /usr/local/lib/php
-COPY --from=php-base /usr/local/php/ /usr/local/php
-COPY --from=php-base /usr/local/bin/ /usr/local/bin
-COPY --from=php-base /usr/src /usr/src
 
 RUN sed -i 's/php/frankenphp run/g' /usr/local/bin/docker-php-entrypoint
 


### PR DESCRIPTION
This migrates to the new RC5 image instead of cloning `master` of `php-src`.

New image sizes:

- alpine: 60.14 MiB
- debian: 190.31 MiB