### PR TITLE
Fix #46

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -9,6 +9,7 @@ package frankenphp
 //go:generate rm -rf C-Thread-Pool/.git C-Thread-Pool/.circleci C-Thread-Pool/docs C-Thread-Pool/tests
 
 // #cgo CFLAGS: -Wall
+// #cgo CFLAGS: -fsplit-stack
 // #cgo CFLAGS: -I/usr/local/include/php -I/usr/local/include/php/Zend -I/usr/local/include/php/TSRM -I/usr/local/include/php/main
 // #cgo LDFLAGS: -L/usr/local/lib -L/opt/homebrew/opt/libiconv/lib -L/usr/lib -lphp -lxml2 -lresolv -lsqlite3 -ldl -lm -lutil
 // #cgo darwin LDFLAGS: -liconv

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -536,6 +536,23 @@ func testEarlyHints(t *testing.T, opts *testOptions) {
 	}, opts)
 }
 
+func TestFiberBasic_module(t *testing.T) { testFiberBasic(t, &testOptions{}) }
+func TestFiberBasic_worker(t *testing.T) {
+	testFiberBasic(t, &testOptions{workerScript: "fiber-basic.php"})
+}
+func testFiberBasic(t *testing.T, opts *testOptions) {
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, i int) {
+		req := httptest.NewRequest("GET", fmt.Sprintf("http://example.com/fiber-basic.php?i=%d", i), nil)
+		w := httptest.NewRecorder()
+		handler(w, req)
+
+		resp := w.Result()
+		body, _ := io.ReadAll(resp.Body)
+
+		assert.Contains(t, string(body), "OK")
+	}, opts)
+}
+
 type streamResponseRecorder struct {
 	*httptest.ResponseRecorder
 	writeCallback func(buf []byte)

--- a/testdata/fiber-basic.php
+++ b/testdata/fiber-basic.php
@@ -1,0 +1,10 @@
+<?php
+require_once __DIR__.'/_executor.php';
+
+return function(){
+    $fiber = new Fiber(function(){
+        echo "OK";
+    });
+    $fiber->start();
+};
+


### PR DESCRIPTION
This is the bare minimum required to make fibers work within the go runtime; The go runtime uses split stacks.