### PR TITLE
feat: expose PHP version

### DIFF
--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -82,7 +82,7 @@ func (f *FrankenPHPApp) Start() error {
 		}
 	}
 
-	logger.Info("FrankenPHP started 🐘")
+	logger.Info("FrankenPHP started 🐘", zap.String("php_version", frankenphp.Version().Version))
 
 	return nil
 }

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -34,6 +34,17 @@ static const char *MODULES_TO_RELOAD[] = {
 	NULL
 };
 
+frankenphp_php_version frankenphp_version() {
+	return (frankenphp_php_version){
+		PHP_MAJOR_VERSION,
+		PHP_MINOR_VERSION,
+		PHP_RELEASE_VERSION,
+		PHP_EXTRA_VERSION,
+		PHP_VERSION,
+		PHP_VERSION_ID,
+	};
+}
+
 int frankenphp_check_version() {
 #ifndef ZTS
     return -1;

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -162,6 +162,29 @@ func FromContext(ctx context.Context) (fctx *FrankenPHPContext, ok bool) {
 	return
 }
 
+type PHPVersion struct {
+	MajorVersion   int
+	MinorVersion   int
+	ReleaseVersion int
+	ExtraVersion   string
+	Version        string
+	VersionID      int
+}
+
+// Version returns infos about the PHP version.
+func Version() PHPVersion {
+	cVersion := C.frankenphp_version()
+
+	return PHPVersion{
+		int(cVersion.major_version),
+		int(cVersion.minor_version),
+		int(cVersion.release_version),
+		C.GoString(cVersion.extra_version),
+		C.GoString(cVersion.version),
+		int(cVersion.version_id),
+	}
+}
+
 // Init starts the PHP runtime and the configured workers.
 func Init(options ...Option) error {
 	if requestChan != nil {

--- a/frankenphp.h
+++ b/frankenphp.h
@@ -4,6 +4,16 @@
 #include <stdint.h>
 #include <Zend/zend_types.h>
 
+typedef struct frankenphp_php_version {
+	int major_version;
+	int minor_version;
+	int release_version;
+	const char *extra_version;
+	const char *version;
+	int version_id;
+} frankenphp_php_version;
+
+frankenphp_php_version frankenphp_version();
 int frankenphp_check_version();
 int frankenphp_init(int num_threads);
 

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -593,6 +593,17 @@ func testFlush(t *testing.T, opts *testOptions) {
 		assert.Equal(t, 2, j)
 	}, opts)
 }
+
+func TestVersion(t *testing.T) {
+	v := frankenphp.Version()
+
+	assert.GreaterOrEqual(t, v.MajorVersion, 8)
+	assert.GreaterOrEqual(t, v.MinorVersion, 0)
+	assert.GreaterOrEqual(t, v.ReleaseVersion, 0)
+	assert.GreaterOrEqual(t, v.VersionID, 0)
+	assert.NotEmpty(t, v.Version, 0)
+}
+
 func ExampleServeHTTP() {
 	if err := frankenphp.Init(); err != nil {
 		panic(err)


### PR DESCRIPTION
Add a new function to retrieve the PHP version and display the used version in the logs of the Caddy module.