### PR TITLE
fix: ensure there is always a free thread for non-worker scripts

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -558,9 +558,8 @@ static void *manager_thread(void *arg) {
 	free(arg);
 
 	uintptr_t rh;
-	while ((rh = go_fetch_request())) {
+	while ((rh = go_fetch_request()))
 		thpool_add_work(thpool, go_execute_script, (void *) rh);
-	}
 
 	/* channel closed, shutdown gracefully */
 	thpool_wait(thpool);

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -39,9 +39,6 @@ func runTest(t *testing.T, test func(func(http.ResponseWriter, *http.Request), *
 	if opts == nil {
 		opts = &testOptions{}
 	}
-	if opts.nbWorkers == 0 {
-		opts.nbWorkers = 2
-	}
 	if opts.nbParrallelRequests == 0 {
 		opts.nbParrallelRequests = 100
 	}

--- a/testdata/Caddyfile
+++ b/testdata/Caddyfile
@@ -1,7 +1,7 @@
 {
 	debug
 	frankenphp {
-		#worker ./phpinfo.php
+		worker ./phpinfo.php
 	}
 }
 

--- a/worker_test.go
+++ b/worker_test.go
@@ -49,6 +49,19 @@ func TestWorkerDie(t *testing.T) {
 	}, &testOptions{workerScript: "die.php", nbWorkers: 1, nbParrallelRequests: 10})
 }
 
+func TestNonWorkerModeAlwaysWorks(t *testing.T) {
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, i int) {
+		req := httptest.NewRequest("GET", "http://example.com/index.php", nil)
+		w := httptest.NewRecorder()
+		handler(w, req)
+
+		resp := w.Result()
+		body, _ := io.ReadAll(resp.Body)
+
+		assert.Contains(t, string(body), "I am by birth a Genevese")
+	}, &testOptions{workerScript: "phpinfo.php"})
+}
+
 func ExampleServeHTTP_workers() {
 	if err := frankenphp.Init(
 		frankenphp.WithWorkers("worker1.php", 4),


### PR DESCRIPTION
Closes #104, #100, https://github.com/dunglas/frankenphp-drupal/pull/9#issuecomment-1313403266