### PR TITLE
Extend Container build to support multiple PHP version

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -45,11 +45,15 @@ jobs:
     strategy:
       matrix:
         dockerfile: [ "Dockerfile", "Dockerfile.alpine" ]
+        php-version:
+          - 8.2
         include:
           - dockerfile: Dockerfile
             flavor: ""
           - dockerfile: Dockerfile.alpine
             flavor: "-alpine"
+          - php-version: 8.2
+            base-image-tag: 8.2.0RC6-zts
     steps:
       - uses: actions/checkout@v3
         with:
@@ -69,7 +73,7 @@ jobs:
           # list of Docker images to use as base name for tags
           images: ${{secrets.IMAGE_NAME}}
           flavor: |
-            suffix=${{matrix.flavor}}
+            suffix=${{matrix.php-version}}-${{matrix.flavor}}
           # generate Docker tags based on the following events/attributes
           tags: |
             type=schedule
@@ -104,3 +108,4 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: 'php_base_tag=${{ matrix.base-image-tag }}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM php:8.2.0RC6-zts-bullseye AS builder
+ARG php_base_tag=8.2.0RC6-zts
+
+FROM php:${php_base_tag}-bullseye AS builder
 
 COPY --from=golang:bullseye /usr/local/go/bin/go /usr/local/bin/go
 COPY --from=golang:bullseye /usr/local/go /usr/local/go
@@ -45,7 +47,7 @@ RUN cd caddy/frankenphp && \
 
 ENTRYPOINT ["/bin/bash","-c"]
 
-FROM php:8.2.0RC6-zts-bullseye AS final
+FROM php:${php_base_tag}-bullseye AS final
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,6 @@
-FROM php:8.2.0RC6-zts-alpine3.16 AS builder
+ARG php_base_tag=8.2.0RC6-zts
+
+FROM php:${php_base_tag}-alpine3.16 AS builder
 
 COPY --from=golang:alpine3.16 /usr/local/go/bin/go /usr/local/bin/go
 COPY --from=golang:alpine3.16 /usr/local/go /usr/local/go
@@ -44,7 +46,7 @@ RUN cd caddy/frankenphp && \
 
 ENTRYPOINT ["/bin/sh","-c"]
 
-FROM php:8.2.0RC6-zts-alpine3.16 AS final
+FROM php:${php_base_tag}-alpine3.16 AS final
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 


### PR DESCRIPTION
This extends the Container build to support multiple versions of PHP in the FrankenPHP container images. This will make the build future proof on the one hand, so adding new versions of PHP will become a one-line change.

On the other hand, this will also make it possible to add a specifig PHP version tag to the container image.

Closes #112 