### PR TITLE
[docs] Updated docker-compose configuration in docs

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -71,7 +71,8 @@ services:
     image: dunglas/frankenphp
     # uncomment the following line if you want to use a custom Dockerfile
     #build: .
-    restart: always
+    # uncomment the following line if you want to run this in a production environment
+    # restart: always
     ports:
       - 80:80
       - 443:443


### PR DESCRIPTION
I removed the default `restart: always` option as it froze my laptop my accident by going wild this morning after rebooting, coming back from SFCon :sweat_smile: 
I think the restart:always option should only be used in a production-ish environment, while in dev it should probably crash cleanly.