### PR TITLE
chore: switch back to upstream C-Thread-Pool lib

### DIFF
--- a/C-Thread-Pool/thpool.c
+++ b/C-Thread-Pool/thpool.c
@@ -323,8 +323,8 @@ static void thread_hold(int sig_id) {
 static void* thread_do(struct thread* thread_p){
 
 	/* Set thread name for profiling and debuging */
-	char thread_name[32] = {0};
-	snprintf(thread_name, 32, "thread-pool-%d", thread_p->id);
+	char thread_name[16] = {0};
+	snprintf(thread_name, 16, "thpool-%d", thread_p->id);
 
 #if defined(__linux__)
 	/* Use prctl instead to prevent using _GNU_SOURCE flag and implicit declaration */

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -6,7 +6,7 @@
 package frankenphp
 
 //go:generate rm -Rf C-Thread-Pool/
-//go:generate git clone --branch=feat/mac-os-compat --depth=1 git@github.com:dunglas/C-Thread-Pool.git
+//go:generate git clone --depth=1 git@github.com:Pithikos/C-Thread-Pool.git
 //go:generate rm -Rf C-Thread-Pool/.git C-Thread-Pool/.circleci C-Thread-Pool/docs C-Thread-Pool/tests
 
 // #cgo CFLAGS: -Wall


### PR DESCRIPTION
Use the upstream library instead of my fork now that the needed patches have been merged: https://github.com/Pithikos/C-Thread-Pool/pull/113