### PR TITLE
fix: don't flush if the request body hasn't been read entirely

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -547,6 +547,13 @@ func go_sapi_flush(rh C.uintptr_t) bool {
 		return true
 	}
 
+	if r.ProtoMajor == 1 {
+		if _, err := r.Body.Read(nil); err != nil {
+			// Don't flush until the whole body has been read to prevent https://github.com/golang/go/issues/15527
+			return false
+		}
+	}
+
 	flusher.Flush()
 
 	return false


### PR DESCRIPTION
Follows #121. Mitigate https://github.com/golang/go/issues/15527.