### PR TITLE
docs: fix typos

### DIFF
--- a/C-Thread-Pool/thpool.c
+++ b/C-Thread-Pool/thpool.c
@@ -211,7 +211,7 @@ void thpool_wait(thpool_* thpool_p){
 
 /* Destroy the threadpool */
 void thpool_destroy(thpool_* thpool_p){
-	/* No need to destory if it's NULL */
+	/* No need to destroy if it's NULL */
 	if (thpool_p == NULL) return ;
 
 	volatile int threads_total = thpool_p->num_threads_alive;
@@ -260,7 +260,7 @@ void thpool_pause(thpool_* thpool_p) {
 /* Resume all threads in threadpool */
 void thpool_resume(thpool_* thpool_p) {
     // resuming a single threadpool hasn't been
-    // implemented yet, meanwhile this supresses
+    // implemented yet, meanwhile this suppresses
     // the warnings
     (void)thpool_p;
 
@@ -322,7 +322,7 @@ static void thread_hold(int sig_id) {
 */
 static void* thread_do(struct thread* thread_p){
 
-	/* Set thread name for profiling and debuging */
+	/* Set thread name for profiling and debugging */
 	char thread_name[16] = {0};
 	snprintf(thread_name, 16, "thpool-%d", thread_p->id);
 

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -244,7 +244,7 @@ PHP_FUNCTION(frankenphp_handle_request) {
 		zval_ptr_dtor(&retval);
 	}
 
-	/* If an exception occured, print the message to the client before closing the connection */
+	/* If an exception occurred, print the message to the client before closing the connection */
 	if (EG(exception))
 		zend_exception_error(EG(exception), E_ERROR);
 

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -118,7 +118,7 @@ type FrankenPHPContext struct {
 	ResolveRootSymlink bool
 
 	// CGI-like environment variables that will be available in $_SERVER.
-	// This map is populated automatically, exisiting key are never replaced.
+	// This map is populated automatically, existing key are never replaced.
 	Env map[string]string
 
 	// The logger associated with the current request
@@ -260,7 +260,7 @@ func Init(options ...Option) error {
 	}
 
 	for _, w := range opt.workers {
-		// TODO: start all the worker in parallell to reduce the boot time
+		// TODO: start all the worker in parallel to reduce the boot time
 		if err := startWorkers(w.fileName, w.num); err != nil {
 			return err
 		}


### PR DESCRIPTION
Hey,

This PR will fix : 

- 3 typos in `C-Thread-Pool/thpool.c`
- 1 typo in `frankenphp.c`
- 2 typos in `frankenphp.go`



Best! :robot: