### PR TITLE
Allow manual builds

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -5,6 +5,8 @@ on:
       - main
     tags:
       - v*
+  workflow_dispatch:
+    inputs: {}
 jobs:
   docker-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This allows running a manual build on-demand (for example, when a new PHP version is released).