### PR TITLE
feat: honor GOMAXPROCS and set it automatically in containers

### DIFF
--- a/caddy/frankenphp/main.go
+++ b/caddy/frankenphp/main.go
@@ -4,6 +4,8 @@ package main
 import (
 	caddycmd "github.com/caddyserver/caddy/v2/cmd"
 
+	_ "go.uber.org/automaxprocs"
+
 	// plug in Caddy modules here.
 	_ "github.com/caddyserver/caddy/v2/modules/standard"
 	_ "github.com/dunglas/frankenphp/caddy"

--- a/caddy/go.mod
+++ b/caddy/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/dunglas/frankenphp v0.0.0-20230718125822-91f66201513a
 	github.com/dunglas/mercure/caddy v0.14.10
 	github.com/dunglas/vulcain/caddy v0.4.3
+	go.uber.org/automaxprocs v1.5.3
 	go.uber.org/zap v1.25.0
 )
 

--- a/caddy/go.sum
+++ b/caddy/go.sum
@@ -887,6 +887,7 @@ github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
+github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
@@ -1212,6 +1213,8 @@ go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/automaxprocs v1.5.3 h1:kWazyxZUrS3Gs4qUpbwo5kEIMGe/DAvi5Z4tl2NW4j8=
+go.uber.org/automaxprocs v1.5.3/go.mod h1:eRbA25aqJrxAbsLO0xy5jVwPt7FQnRgjW+efnwa1WM0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -235,24 +235,24 @@ func Init(options ...Option) error {
 		loggerMu.Unlock()
 	}
 
-	numCPU := runtime.NumCPU()
+	maxProcs := runtime.GOMAXPROCS(0)
 
 	var numWorkers int
 	for i, w := range opt.workers {
 		if w.num <= 0 {
 			// https://github.com/dunglas/frankenphp/issues/126
-			opt.workers[i].num = numCPU * 2
+			opt.workers[i].num = maxProcs * 2
 		}
 
 		numWorkers += opt.workers[i].num
 	}
 
 	if opt.numThreads <= 0 {
-		if numWorkers >= numCPU {
+		if numWorkers >= maxProcs {
 			// Start at least as many threads as workers, and keep a free thread to handle requests in non-worker mode
 			opt.numThreads = numWorkers + 1
 		} else {
-			opt.numThreads = numCPU
+			opt.numThreads = maxProcs
 		}
 	} else if opt.numThreads <= numWorkers {
 		return NotEnoughThreads


### PR DESCRIPTION
Honor the `GOMAXPROCS` settings and set its value to match Linux container CPU quota using https://github.com/uber-go/automaxprocs.
This should improve the performance in containers: https://github.com/golang/go/issues/33803

Similar PR for upstream Caddy: https://github.com/caddyserver/caddy/pull/5711