### PR TITLE
fix: properly cleanup workersReadyWG

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -300,6 +300,7 @@ func Shutdown() {
 	close(done)
 	shutdownWG.Wait()
 	requestChan = nil
+	workersReadyWG = sync.WaitGroup{}
 
 	logger.Debug("FrankenPHP shut down")
 }

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -282,11 +282,8 @@ func Init(options ...Option) error {
 		return MainThreadCreationError
 	}
 
-	for _, w := range opt.workers {
-		// TODO: start all the worker in parallell to reduce the boot time
-		if err := startWorkers(w.fileName, w.num); err != nil {
-			return err
-		}
+	if err := initWorkers(opt.workers); err != nil {
+		return err
 	}
 
 	logger.Debug("FrankenPHP started")
@@ -300,6 +297,8 @@ func Shutdown() {
 	close(done)
 	shutdownWG.Wait()
 	requestChan = nil
+
+	// Always reset the WaitGroup to ensure we're in a clean state
 	workersReadyWG = sync.WaitGroup{}
 
 	logger.Debug("FrankenPHP shut down")

--- a/worker.go
+++ b/worker.go
@@ -17,8 +17,18 @@ import (
 var (
 	workersRequestChans sync.Map // map[fileName]chan *http.Request
 	workersReadyWG      sync.WaitGroup
-	workersWG           sync.WaitGroup
 )
+
+// TODO: start all the worker in parallell to reduce the boot time
+func initWorkers(opt []workerOpt) error {
+	for _, w := range opt {
+		if err := startWorkers(w.fileName, w.num); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
 
 func startWorkers(fileName string, nbWorkers int) error {
 	absFileName, err := filepath.Abs(fileName)

--- a/worker.go
+++ b/worker.go
@@ -35,7 +35,7 @@ func startWorkers(fileName string, nbWorkers int) error {
 	workersReadyWG.Add(nbWorkers)
 
 	var (
-		m      sync.Mutex
+		m      sync.RWMutex
 		errors []error
 	)
 


### PR DESCRIPTION
The worker can crash at any moment (ex: when the PHP timeout is reached), without calling `workersReadyWG.Done()`.
It's usually not an issue because we wait only during startup, except when we shutdown and then startup again FrankenPHP without killing the process (ex: in tests, or with Caddy). Resetting the WaitGroup on shutdown fixes the issue.