### PR TITLE
perf: reduce the number of calls to cgo to set the headers

### DIFF
--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -235,6 +235,7 @@ func testHeaders(t *testing.T, opts *testOptions) {
 		assert.Equal(t, 201, resp.StatusCode)
 		assert.Equal(t, "bar", resp.Header.Get("Foo"))
 		assert.Equal(t, "bar2", resp.Header.Get("Foo2"))
+		assert.Empty(t, resp.Header.Get("Invalid"))
 		assert.Equal(t, fmt.Sprintf("%d", i), resp.Header.Get("I"))
 	}, opts)
 }

--- a/testdata/headers.php
+++ b/testdata/headers.php
@@ -5,6 +5,7 @@ require_once __DIR__.'/_executor.php';
 return function () {
     header('Foo: bar');
     header('Foo2: bar2');
+    header('Invalid');
     header('I: ' . ($_GET['i'] ?? 'i not set'));
     http_response_code(201);
     


### PR DESCRIPTION
Calls to Go functions from C (and to C functions from Go) are expensive. With this patch, FrankenPHP is now able to pass all headers to Go in just 1 call, while n+1 calls (n = the number of headers) were previously necessary.

This patch also increases a bit the code coverage.