### PR TITLE
minor: fix indent for Caddyfile

### DIFF
--- a/caddy/frankenphp/Caddyfile
+++ b/caddy/frankenphp/Caddyfile
@@ -1,6 +1,6 @@
 {
 	# Debug
-    {$CADDY_DEBUG}
+	{$CADDY_DEBUG}
 
 	frankenphp {
 		#worker /path/to/your/worker.php


### PR DESCRIPTION
Will fix the warning `{"level":"warn","ts":1692516460.69793,"msg":"Caddyfile input is not formatted; run 'caddy fmt --overwrite' to fix inconsistencies","adapter":"caddyfile","file":"/etc/Caddyfile","line":3}
`