### PR TITLE
ci: create a static build of FrankenPHP

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
       platforms: ${{ steps.matrix.outputs.platforms }}
       metadata: ${{ steps.matrix.outputs.metadata }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -57,7 +57,7 @@ jobs:
           - platform: linux/386
             qemu: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up QEMU
         if: matrix.qemu

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -70,16 +70,15 @@ jobs:
       - name: Fetch libraries sources
         working-directory: static-php-cli/
         run: ./bin/spc fetch --with-php=8.2 -A
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build static libphp
         working-directory: static-php-cli/
         run: ./bin/spc build --enable-zts --build-embed --debug "bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu"
 
-      - name: Set include flags
-        working-directory: static-php-cli/
-        run: echo "CGO_CFLAGS=$(php-config --includes)" >> "$GITHUB_ENV"
-
       - name: Set CGO flags
+        working-directory: static-php-cli/
         run: |
            echo "CGO_CFLAGS=$(./buildroot/bin/php-config --includes | sed s#-I/#-I$PWD/buildroot/#g)" >> "$GITHUB_ENV"
            echo "CGO_LDFLAGS=-framework CoreFoundation -framework SystemConfiguration $(./buildroot/bin/php-config --ldflags) $(./buildroot/bin/php-config --libs)" >> "$GITHUB_ENV"

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Build static libphp
         working-directory: static-php-cli/
-        run: ./bin/spc build --enable-zts --build-embed --debug "bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu"
+        run: ./bin/spc build --enable-zts --build-embed --debug "bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,opcache,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu"
 
       - name: Set CGO flags
         working-directory: static-php-cli/

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -48,7 +48,7 @@ jobs:
         working-directory: static-php-cli/
         run: |
           echo "CGO_CFLAGS=$(sh $PWD/source/php-src/scripts/php-config --includes | sed s#-I/include/php#-I$PWD/source/php-src#g)" >> "$GITHUB_ENV"
-          echo "CGO_LDFLAGS=-L$PWD/source/php-src/libs $(sh $PWD/source/php-src/scripts/php-config --ldflags | sed s#/app#$PWD#g) $(sh $PWD/source/php-src/scripts/php-config --libs | sed -e 's/-lxml2//g' -e s#/app#$PWD#g)" >> "$GITHUB_ENV"
+          echo "CGO_LDFLAGS=-L$PWD/source/php-src/libs $(sh $PWD/source/php-src/scripts/php-config --ldflags | sed s#/app#$PWD#g) $(sh $PWD/source/php-src/scripts/php-config --libs | sed -e 's/-lgcc_s//g' -e s#/app#$PWD#g)" >> "$GITHUB_ENV"
 
       - name: Build
         working-directory: caddy/frankenphp/

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -16,21 +16,13 @@ jobs:
       - name: Clone static-php-cli
         run: git clone https://github.com/dunglas/static-php-cli.git --branch=feat/embed
 
-      - name: Install static-php-cli dependencies
-        working-directory: static-php-cli
-        run: composer install --no-dev -a
-
-      - name: Install missing dependencies
-        working-directory: static-php-cli
-        run: bin/spc doctor --auto-fix
-
       - name: Download libraries sources
         working-directory: static-php-cli
-        run: bin/spc fetch --with-php=${{ matrix.php-versions }} -A 
+        run: bin/spc-alpine-docker fetch --with-php=${{ matrix.php-versions }} -A 
 
       - name: Build static libraries
         working-directory: static-php-cli
-        run: bin/spc build --build-embed --enable-zts --debug "bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,openssl,pcntl,pdo,pdo_mysql,pdo_sqlite,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu"
+        run: bin/spc-alpine-docker build --build-embed --enable-zts --debug "bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,openssl,pcntl,pdo,pdo_mysql,pdo_sqlite,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu"
 
       - name: Set CGO flags
         working-directory: static-php-cli

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,55 @@
+name: Build binary releases
+on: [push, pull_request]
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions: ['8.2']
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+
+      - name: Clone static-php-cli
+        run: git clone https://github.com/dunglas/static-php-cli.git --branch=feat/embed
+
+      - name: Install static-php-cli dependencies
+        working-directory: static-php-cli
+        run: composer install --no-dev -a
+
+      - name: Install missing dependencies
+        working-directory: static-php-cli
+        run: bin/spc doctor --auto-fix
+
+      - name: Download libraries sources
+        working-directory: static-php-cli
+        run: bin/spc fetch --with-php=${{ matrix.php-versions }} -A 
+
+      - name: Build static libraries
+        working-directory: static-php-cli
+        run: bin/spc build --build-embed --enable-zts --debug "bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,openssl,pcntl,pdo,pdo_mysql,pdo_sqlite,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu"
+
+      - name: Set CGO flags
+        working-directory: static-php-cli
+        run: |
+          echo "CGO_CFLAGS=-I$PWD/source/php-src -I$PWD/source/php-src/main -I$PWD/source/php-src/TSRM -I$PWD/source/php-src/Zend -I$PWD/source/php-src/ext -I$PWD/source/php-src/ext/date/lib" >> "$GITHUB_ENV"
+          echo "CGO_LDFLAGS=-L$PWD/source/php-src/libs $(sh $PWD/source/php-src/scripts/php-config --ldflags) $(sh $PWD/source/php-src/scripts/php-config --libs | sed 's/-lgcc_s//g' | tr ' ' '\n' | sort -u | xargs)" >> "$GITHUB_ENV"
+
+      - name: Build
+        working-directory: caddy/frankenphp/
+        run: go build -buildmode=pie -tags "cgo netgo osusergo static_build" -ldflags "-linkmode=external -extldflags -static-pie"
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: frankenphp-linux-php-${{ matrix.php-versions }}-dev
+          path: caddy/frankenphp/frankenphp
+
+      - name: Run library tests
+        run: go test -race -v ./...
+
+      - name: Run Caddy module tests
+        working-directory: caddy/
+        run: go test -race -v ./...

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,7 +1,7 @@
 name: Build binary releases
 on: [push, pull_request]
 jobs:
-  tests:
+  build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -14,11 +14,30 @@ jobs:
           go-version: '1.21'
 
       - name: Clone static-php-cli/
-        run: git clone https://github.com/dunglas/static-php-cli.git --branch=feat/embed
+        run: git clone --depth=1 https://github.com/dunglas/static-php-cli.git --branch=feat/embed
 
-      - name: Download libraries sources
+      - id: cache-composer-deps
+        name: Download cached Composer
+        uses: actions/cache@v3
+        with:
+          path: static-php-cli/vendor
+          key: composer-dependencies
+
+      - if: steps.cache-composer-deps.outputs.cache-hit != 'true'
+        name: Install Composer dependencies
         working-directory: static-php-cli/
-        run: bin/spc-alpine-docker fetch --with-php=${{ matrix.php-versions }} -A 
+        run: composer install --no-dev -a
+
+      - id: cache-download
+        name: Download cached sources
+        uses: actions/cache@v3
+        with:
+          path: static-php-cli/downloads
+          key: php-${{ matrix.php-versions }}-dependencies
+
+      - if: steps.cache-download.outputs.cache-hit != 'true'
+        name: Download sources
+        run: ./bin/spc-alpine-docker download --with-php=${{ matrix.php-versions }} --all
 
       - name: Build static libraries
         working-directory: static-php-cli/
@@ -27,7 +46,7 @@ jobs:
       - name: Set CGO flags
         working-directory: static-php-cli/
         run: |
-          echo "CGO_CFLAGS=$(sh $PWD/source/php-src/scripts/php-config --includes | sed s#/app#$PWD#g)" >> "$GITHUB_ENV"
+          echo "CGO_CFLAGS=$(sh $PWD/source/php-src/scripts/php-config --includes | sed s#-I/include#-I$PWD/source/php-src/include#g)" >> "$GITHUB_ENV"
           echo "CGO_LDFLAGS=-L$PWD/source/php-src/libs $(sh $PWD/source/php-src/scripts/php-config --ldflags | sed s#/app#$PWD#g) $(sh $PWD/source/php-src/scripts/php-config --libs | sed -e 's/-lxml2//g' -e s#/app#$PWD#g)" >> "$GITHUB_ENV"
 
       - name: Build

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -50,11 +50,6 @@ jobs:
     name: Build macOS binaries
     runs-on: macos-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: ['arm64', 'x86_64']
-
     steps:
       - uses: actions/checkout@v3
 
@@ -62,7 +57,7 @@ jobs:
         with:
           go-version: '1.21'
 
-      - run: git clone --depth=1 https://github.com/dunglas/static-php-cli.git --branch=feat/cross-compile-apple
+      - run: git clone --depth=1 https://github.com/dunglas/static-php-cli.git --branch=feat/embed 
 
       - name: Install static-php-cli dependencies
         working-directory: static-php-cli/
@@ -80,9 +75,7 @@ jobs:
 
       - name: Build static libphp
         working-directory: static-php-cli/
-        run: |
-          clang --print-targets
-          ./bin/spc build --arch ${{ matrix.arch }} --enable-zts --build-embed --debug "bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu" || cat source/pkg-config/config.log
+        run: ./bin/spc build --enable-zts --build-embed --debug "bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu"
 
       - name: Set CGO flags
         working-directory: static-php-cli/
@@ -93,11 +86,9 @@ jobs:
       - name: Build FrankenPHP
         working-directory: caddy/frankenphp/
         run: go build -buildmode=pie -tags "cgo netgo osusergo static_build" -ldflags "-linkmode=external -extldflags -static-pie -w -s"
-        env:
-          GOARCH: ${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }}
 
       - name: Upload binary
         uses: actions/upload-artifact@v3
         with:
-          name: frankenphp-mac-${{ matrix.arch }}-dev
+          name: frankenphp-mac-x86_64-dev
           path: caddy/frankenphp/frankenphp

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -11,7 +11,8 @@ on:
   workflow_dispatch:
     inputs: {}
 jobs:
-  build:
+  build-linux:
+    name: Build Linux x86_64 binary
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -42,5 +43,53 @@ jobs:
       - name: Upload binary
         uses: actions/upload-artifact@v3
         with:
-          name: frankenphp-dev
+          name: frankenphp-linux-x86_64-dev
+          path: frankenphp
+
+  build-mac:
+    name: Build macOS binaries
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+
+      - run: git clone --depth=1 https://github.com/dunglas/static-php-cli.git --branch=feat/embed 
+
+      - name: Install static-php-cli dependencies
+        working-directory: static-php-cli/
+        run: composer install --no-dev -a
+
+      - name: Install missing system dependencies
+        run: ./bin/spc doctor --auto-fix
+        working-directory: static-php-cli/
+
+      - name: Fetch libraries sources
+        working-directory: static-php-cli/
+        run: ./bin/spc fetch --with-php=8.2 -A
+
+      - name: Build static libphp
+        working-directory: static-php-cli/
+        run: ./bin/spc build --enable-zts --build-embed --debug "bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu"
+
+      - name: Set include flags
+        working-directory: static-php-cli/
+        run: echo "CGO_CFLAGS=$(php-config --includes)" >> "$GITHUB_ENV"
+
+      - name: Set CGO flags
+        run: |
+           echo "CGO_CFLAGS=$(./buildroot/bin/php-config --includes | sed s#-I/#-I$PWD/buildroot/#g)" >> "$GITHUB_ENV"
+           echo "CGO_LDFLAGS=-framework CoreFoundation -framework SystemConfiguration $(./buildroot/bin/php-config --ldflags) $(./buildroot/bin/php-config --libs)" >> "$GITHUB_ENV"
+
+      - name: Build FrankenPHP
+        working-directory: caddy/frankenphp/
+        run: go build -buildmode=pie -tags "cgo netgo osusergo static_build" -ldflags "-linkmode=external -extldflags -static-pie"
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: frankenphp-mac-x86_64-dev
           path: frankenphp

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,6 +34,7 @@ jobs:
             *.cache-to=type=gha,scope=${{github.ref}}-static-builder
         env:
           VERSION: ${{github.ref_name}}
+          ENV: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Copy binary
         run: docker cp $(docker create --name static-builder dunglas/frankenphp:static-builder):/go/src/app/caddy/frankenphp/frankenphp frankenphp ; docker rm static-builder

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,7 +34,7 @@ jobs:
             *.cache-to=type=gha,scope=${{github.ref}}-static-builder
         env:
           VERSION: ${{github.ref_name}}
-          ENV: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Copy binary
         run: docker cp $(docker create --name static-builder dunglas/frankenphp:static-builder):/go/src/app/caddy/frankenphp/frankenphp frankenphp ; docker rm static-builder

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Set CGO flags
         working-directory: static-php-cli/
         run: |
-          echo "CGO_CFLAGS=$(sh $PWD/source/php-src/scripts/php-config --includes | sed s#-I/include#-I$PWD/source/php-src#g)" >> "$GITHUB_ENV"
+          echo "CGO_CFLAGS=$(sh $PWD/source/php-src/scripts/php-config --includes | sed s#-I/include/php#-I$PWD/source/php-src#g)" >> "$GITHUB_ENV"
           echo "CGO_LDFLAGS=-L$PWD/source/php-src/libs $(sh $PWD/source/php-src/scripts/php-config --ldflags | sed s#/app#$PWD#g) $(sh $PWD/source/php-src/scripts/php-config --libs | sed -e 's/-lxml2//g' -e s#/app#$PWD#g)" >> "$GITHUB_ENV"
 
       - name: Build

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build Linux x86_64 binary
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -51,13 +51,16 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          repository: crazywhalecc/static-php-cli
+          path: static-php-cli
 
       - uses: actions/setup-go@v4
         with:
           go-version: '1.21'
-
-      - run: git clone --depth=1 https://github.com/dunglas/static-php-cli.git --branch=feat/embed 
 
       - name: Install static-php-cli dependencies
         working-directory: static-php-cli/
@@ -75,7 +78,7 @@ jobs:
 
       - name: Build static libphp
         working-directory: static-php-cli/
-        run: ./bin/spc build --enable-zts --build-embed --debug "bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,opcache,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu"
+        run: ./bin/spc build --enable-zts --build-embed --debug "bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,intl,mbstring,mbregex,mysqli,mysqlnd,opcache,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu"
 
       - name: Set CGO flags
         working-directory: static-php-cli/

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -13,22 +13,22 @@ jobs:
         with:
           go-version: '1.21'
 
-      - name: Clone static-php-cli
+      - name: Clone static-php-cli/
         run: git clone https://github.com/dunglas/static-php-cli.git --branch=feat/embed
 
       - name: Download libraries sources
-        working-directory: static-php-cli
+        working-directory: static-php-cli/
         run: bin/spc-alpine-docker fetch --with-php=${{ matrix.php-versions }} -A 
 
       - name: Build static libraries
-        working-directory: static-php-cli
+        working-directory: static-php-cli/
         run: bin/spc-alpine-docker build --build-embed --enable-zts --debug "bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,openssl,pcntl,pdo,pdo_mysql,pdo_sqlite,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu"
 
       - name: Set CGO flags
-        working-directory: static-php-cli
+        working-directory: static-php-cli/
         run: |
-          echo "CGO_CFLAGS=-I$PWD/source/php-src -I$PWD/source/php-src/main -I$PWD/source/php-src/TSRM -I$PWD/source/php-src/Zend -I$PWD/source/php-src/ext -I$PWD/source/php-src/ext/date/lib" >> "$GITHUB_ENV"
-          echo "CGO_LDFLAGS=-L$PWD/source/php-src/libs $(sh $PWD/source/php-src/scripts/php-config --ldflags) $(sh $PWD/source/php-src/scripts/php-config --libs | sed 's/-lgcc_s//g' | tr ' ' '\n' | sort -u | xargs)" >> "$GITHUB_ENV"
+          echo "CGO_CFLAGS=$(sh $PWD/source/php-src/scripts/php-config --includes | sed s#/app#$PWD#g)" >> "$GITHUB_ENV"
+          echo "CGO_LDFLAGS=-L$PWD/source/php-src/libs $(sh $PWD/source/php-src/scripts/php-config --ldflags | sed s#/app#$PWD#g) $(sh $PWD/source/php-src/scripts/php-config --libs | sed -e 's/-lxml2//g' -e s#/app#$PWD#g)" >> "$GITHUB_ENV"
 
       - name: Build
         working-directory: caddy/frankenphp/

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -50,6 +50,11 @@ jobs:
     name: Build macOS binaries
     runs-on: macos-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ['arm64', 'x86_64']
+
     steps:
       - uses: actions/checkout@v3
 
@@ -57,7 +62,7 @@ jobs:
         with:
           go-version: '1.21'
 
-      - run: git clone --depth=1 https://github.com/dunglas/static-php-cli.git --branch=feat/embed 
+      - run: git clone --depth=1 https://github.com/dunglas/static-php-cli.git --branch=feat/cross-compile-apple
 
       - name: Install static-php-cli dependencies
         working-directory: static-php-cli/
@@ -75,7 +80,9 @@ jobs:
 
       - name: Build static libphp
         working-directory: static-php-cli/
-        run: ./bin/spc build --enable-zts --build-embed --debug "bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu"
+        run: |
+          clang --print-targets
+          ./bin/spc build --arch ${{ matrix.arch }} --enable-zts --build-embed --debug "bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu" || cat source/pkg-config/config.log
 
       - name: Set CGO flags
         working-directory: static-php-cli/
@@ -86,9 +93,11 @@ jobs:
       - name: Build FrankenPHP
         working-directory: caddy/frankenphp/
         run: go build -buildmode=pie -tags "cgo netgo osusergo static_build" -ldflags "-linkmode=external -extldflags -static-pie -w -s"
+        env:
+          GOARCH: ${{ matrix.arch == 'arm64' && 'arm64' || 'amd64' }}
 
       - name: Upload binary
         uses: actions/upload-artifact@v3
         with:
-          name: frankenphp-mac-x86_64-dev
+          name: frankenphp-mac-${{ matrix.arch }}-dev
           path: caddy/frankenphp/frankenphp

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,67 +1,45 @@
 name: Build binary releases
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  workflow_dispatch:
+    inputs: {}
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php-versions: ['8.2']
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
         with:
-          go-version: '1.21'
-
-      - name: Clone static-php-cli/
-        run: git clone --depth=1 https://github.com/dunglas/static-php-cli.git --branch=feat/embed
-
-      - id: cache-composer-deps
-        name: Download cached Composer
-        uses: actions/cache@v3
-        with:
-          path: static-php-cli/vendor
-          key: composer-dependencies
-
-      - if: steps.cache-composer-deps.outputs.cache-hit != 'true'
-        name: Install Composer dependencies
-        working-directory: static-php-cli/
-        run: composer install --no-dev -a
-
-      - id: cache-download
-        name: Download cached sources
-        uses: actions/cache@v3
-        with:
-          path: static-php-cli/downloads
-          key: php-${{ matrix.php-versions }}-dependencies
-
-      - if: steps.cache-download.outputs.cache-hit != 'true'
-        name: Download sources
-        working-directory: static-php-cli/
-        run: ./bin/spc-alpine-docker download --with-php=${{ matrix.php-versions }} --all
-
-      - name: Build static libraries
-        working-directory: static-php-cli/
-        run: bin/spc-alpine-docker build --build-embed --enable-zts --debug "bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,openssl,pcntl,pdo,pdo_mysql,pdo_sqlite,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu"
-
-      - name: Set CGO flags
-        working-directory: static-php-cli/
-        run: |
-          echo "CGO_CFLAGS=$(sh $PWD/source/php-src/scripts/php-config --includes | sed s#-I/include/php#-I$PWD/source/php-src#g)" >> "$GITHUB_ENV"
-          echo "CGO_LDFLAGS=-L$PWD/source/php-src/libs $(sh $PWD/source/php-src/scripts/php-config --ldflags | sed s#/app#$PWD#g) $(sh $PWD/source/php-src/scripts/php-config --libs | sed -e 's/-lgcc_s//g' -e s#/app#$PWD#g)" >> "$GITHUB_ENV"
+          version: latest
 
       - name: Build
-        working-directory: caddy/frankenphp/
-        run: go build -buildmode=pie -tags "cgo netgo osusergo static_build" -ldflags "-linkmode=external -extldflags -static-pie"
-
-      - uses: actions/upload-artifact@v3
+        id: build
+        uses: docker/bake-action@v3
         with:
-          name: frankenphp-linux-php-${{ matrix.php-versions }}-dev
-          path: caddy/frankenphp/frankenphp
+          pull: true
+          load: true
+          targets: static-builder
+          set: |
+            *.cache-from=type=gha,scope=${{github.ref}}-static-builder
+            *.cache-from=type=gha,scope=refs/heads/main-static-builder
+            *.cache-to=type=gha,scope=${{github.ref}}-static-builder
+        env:
+          VERSION: ${{github.ref_name}}
 
-      - name: Run library tests
-        run: go test -race -v ./...
+      - name: Copy binary
+        run: docker cp $(docker create --name static-builder dunglas/frankenphp:static-builder):/go/src/app/caddy/frankenphp/frankenphp frankenphp ; docker rm static-builder
 
-      - name: Run Caddy module tests
-        working-directory: caddy/
-        run: go test -race -v ./...
+      - name: Upload binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: frankenphp-dev
+          path: frankenphp

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -16,17 +16,17 @@ jobs:
       - name: Clone static-php-cli/
         run: git clone --depth=1 https://github.com/dunglas/static-php-cli.git --branch=feat/embed
 
-      #- id: cache-composer-deps
-      #  name: Download cached Composer
-      #  uses: actions/cache@v3
-      #  with:
-      #    path: static-php-cli/vendor
-      #    key: composer-dependencies
-#
-      #- if: steps.cache-composer-deps.outputs.cache-hit != 'true'
-      #  name: Install Composer dependencies
-      #  working-directory: static-php-cli/
-      #  run: composer install --no-dev -a
+      - id: cache-composer-deps
+        name: Download cached Composer
+        uses: actions/cache@v3
+        with:
+          path: static-php-cli/vendor
+          key: composer-dependencies
+
+      - if: steps.cache-composer-deps.outputs.cache-hit != 'true'
+        name: Install Composer dependencies
+        working-directory: static-php-cli/
+        run: composer install --no-dev -a
 
       - id: cache-download
         name: Download cached sources
@@ -47,7 +47,7 @@ jobs:
       - name: Set CGO flags
         working-directory: static-php-cli/
         run: |
-          echo "CGO_CFLAGS=$(sh $PWD/source/php-src/scripts/php-config --includes | sed s#-I/include#-I$PWD/source/php-src/include#g)" >> "$GITHUB_ENV"
+          echo "CGO_CFLAGS=$(sh $PWD/source/php-src/scripts/php-config --includes | sed s#-I/include#-I$PWD/source/php-src#g)" >> "$GITHUB_ENV"
           echo "CGO_LDFLAGS=-L$PWD/source/php-src/libs $(sh $PWD/source/php-src/scripts/php-config --ldflags | sed s#/app#$PWD#g) $(sh $PWD/source/php-src/scripts/php-config --libs | sed -e 's/-lxml2//g' -e s#/app#$PWD#g)" >> "$GITHUB_ENV"
 
       - name: Build

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -16,17 +16,17 @@ jobs:
       - name: Clone static-php-cli/
         run: git clone --depth=1 https://github.com/dunglas/static-php-cli.git --branch=feat/embed
 
-      - id: cache-composer-deps
-        name: Download cached Composer
-        uses: actions/cache@v3
-        with:
-          path: static-php-cli/vendor
-          key: composer-dependencies
-
-      - if: steps.cache-composer-deps.outputs.cache-hit != 'true'
-        name: Install Composer dependencies
-        working-directory: static-php-cli/
-        run: composer install --no-dev -a
+      #- id: cache-composer-deps
+      #  name: Download cached Composer
+      #  uses: actions/cache@v3
+      #  with:
+      #    path: static-php-cli/vendor
+      #    key: composer-dependencies
+#
+      #- if: steps.cache-composer-deps.outputs.cache-hit != 'true'
+      #  name: Install Composer dependencies
+      #  working-directory: static-php-cli/
+      #  run: composer install --no-dev -a
 
       - id: cache-download
         name: Download cached sources
@@ -37,6 +37,7 @@ jobs:
 
       - if: steps.cache-download.outputs.cache-hit != 'true'
         name: Download sources
+        working-directory: static-php-cli/
         run: ./bin/spc-alpine-docker download --with-php=${{ matrix.php-versions }} --all
 
       - name: Build static libraries

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -86,10 +86,10 @@ jobs:
 
       - name: Build FrankenPHP
         working-directory: caddy/frankenphp/
-        run: go build -buildmode=pie -tags "cgo netgo osusergo static_build" -ldflags "-linkmode=external -extldflags -static-pie"
+        run: go build -buildmode=pie -tags "cgo netgo osusergo static_build" -ldflags "-linkmode=external -extldflags -static-pie -w -s"
 
       - name: Upload binary
         uses: actions/upload-artifact@v3
         with:
           name: frankenphp-mac-x86_64-dev
-          path: frankenphp
+          path: caddy/frankenphp/frankenphp

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         php-versions: ['8.2', '8.3']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v4
         with:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -107,5 +107,5 @@ target "static-builder" {
     args = {
         FRANKENPHP_VERSION = VERSION
     }
-    secret = ["type=env,id=GITHUB_TOKEN"]
+    secret = ["id=github-token,env=GITHUB_TOKEN"]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -54,7 +54,6 @@ function "__semver" {
     result = v == {} ? [clean_tag(VERSION)] : v.prerelease == null ? ["latest", v.major, "${v.major}.${v.minor}", "${v.major}.${v.minor}.${v.patch}"] : ["${v.major}.${v.minor}.${v.patch}-${v.prerelease}"]
 }
 
-
 target "default" {
     name = "${tgt}-php-${replace(php-version, ".", "-")}-${os}"
     matrix = {

--- a/docs/compile.md
+++ b/docs/compile.md
@@ -1,5 +1,10 @@
 # Compile From Sources
 
+This document explain how to create a FrankenPHP build that will load PHP as a dymanic library.
+This is the recommended method.
+
+Alternatively, [creating static builds](static.md) is also possible.
+
 ## Install PHP
 
 FrankenPHP is compatible with the PHP 8.2 and superior.

--- a/docs/static.md
+++ b/docs/static.md
@@ -42,6 +42,9 @@ GITHUB_TOKEN="xxx" docker --load buildx bake static-builder
 
 ## macOS
 
+Note: only a very limited subset of extensions are currently available for static builds on macOS
+because of a weird linking issue.
+
 Run the following command to create a static binary for macOS:
 
 ```console

--- a/docs/static.md
+++ b/docs/static.md
@@ -44,22 +44,22 @@ GITHUB_TOKEN="xxx" docker --load buildx bake static-builder
 
 ## macOS
 
-Note: only a very limited subset of extensions are currently available for static builds on macOS
-because of a weird linking issue.
-
 Run the following command to create a static binary for macOS:
 
 ```console
 git clone --depth=1 https://github.com/dunglas/static-php-cli.git --branch=feat/embed 
 cd static-php-cli
 composer install --no-dev -a
-./bin/spc doctor
+./bin/spc doctor --auto-fix
 ./bin/spc fetch --with-php=8.2 -A
-./bin/spc build --enable-zts --build-embed --debug "opcache"
+./bin/spc build --enable-zts --build-embed --debug "bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwri
+ter,zip,zlib,apcu"
 export CGO_CFLAGS="$(./buildroot/bin/php-config --includes | sed s#-I/#-I$PWD/buildroot/#g)"
-export CGO_LDFLAGS="-L$PWD/buildroot/lib $(./buildroot/bin/php-config --ldflags) $(./buildroot/bin/php-config --libs)"
+export CGO_LDFLAGS="-framework CoreFoundation -framework SystemConfiguration $(./buildroot/bin/php-config --ldflags) $(./buildroot/bin/php-config --libs)"
 
 git clone --depth=1 https://github.com/dunglas/frankenphp.git
 cd frankenphp/caddy/frankenphp
 go build -buildmode=pie -tags "cgo netgo osusergo static_build" -ldflags "-linkmode=external -extldflags -static-pie"
 ```
+
+See [the list of supported extensions](https://static-php-cli.zhamao.me/en/guide/extensions.html).

--- a/docs/static.md
+++ b/docs/static.md
@@ -5,23 +5,37 @@ it's possible to create a static build of FrankenPHP thanks to the great [static
 
 With this method, a single, portable, binary will contain the PHP interpreter, the Caddy web server and FrankenPHP!
 
-## Build Instructions
+## Linux
+
+We provide a Docker image to build a Linux static binary:
 
 ```console
-git clone https://github.com/dunglas/static-php-cli.git --branch=feat/embed
-cd static-php-cli
-bin/spc-alpine-docker fetch --with-php=8.2 -A
-bin/spc-alpine-docker build --build-embed --enable-zts --debug "bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,openssl,pcntl,pdo,pdo_mysql,pdo_sqlite,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu"
-export CGO_CFLAGS="$(sh $PWD/source/php-src/scripts/php-config --includes | sed s#-I/include/php#-I$PWD/source/php-src#g)"
-export CGO_LDFLAGS="-L$PWD/source/php-src/libs $(sh $PWD/source/php-src/scripts/php-config --ldflags) $(sh $PWD/source/php-src/scripts/php-config --libs | sed 's/-lgcc_s//g')"
-
-cd ..
-
-git clone https://github.com/dunglas/frankenphp
-cd frankenphp/caddy/frankenphp
-go build -buildmode=pie -tags "cgo netgo osusergo static_build" -ldflags "-linkmode=external -extldflags -static-pie"
+docker buildx bake --load static-builder
+docker cp $(docker create --name static-builder dunglas/frankenphp:static-builder):/go/src/app/caddy/frankenphp/frankenphp frankenphp ; docker rm static-builder
 ```
 
-The `frankenphp` file in the current directory is a static build of FrankenPHP!
+The resulting static binary is named `frankenphp` and is available in the current directory.
 
-Customize the extensions to build using [the command generator](https://static-php-cli.zhamao.me/en/guide/cli-generator.html).
+If you want to build the static binary without Docker, take a look to the `static-builder.Dockerfile` file.
+
+### Custom Extensions
+
+By default, most popular PHP extensions are compiled.
+
+To reduce the size of the binary and to reduce the attack surface, you can choose the list of extensions to build using the `PHP_EXTENSIONS` Docker ARG.
+
+For instance, run the following command to only build the `opcache` extension:
+
+```console
+docker buildx bake --load --set static-builder.args.PHP_EXTENSIONS=opcache static-builder
+# ...
+```
+
+### GitHub Token
+
+If you hit the GitHub API rate limit, set a GitHub Personal Access Token in an environment variable named `GITHUB_TOKEN`:
+
+```console
+GITHUB_TOKEN="xxx" docker --load buildx bake static-builder
+# ...
+```

--- a/docs/static.md
+++ b/docs/static.md
@@ -1,0 +1,25 @@
+# Create a Static Build
+
+Instead of using a local installation of the PHP library,
+it's possible to create a static build of FrankenPHP thanks to the great [static-php-cli project](https://github.com/crazywhalecc/static-php-cli) (despite its name, this project support all SAPIs, not only CLI).
+
+With this method, a single, portable, binary will contain the PHP interpreter, the Caddy web server and FrankenPHP!
+
+## Build Instructions
+
+```console
+git clone https://github.com/dunglas/static-php-cli.git --branch=feat/embed
+cd static-php-cli
+bin/spc-alpine-docker fetch --with-php=8.2 -A
+bin/spc-alpine-docker build --build-embed --enable-zts --debug "bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,openssl,pcntl,pdo,pdo_mysql,pdo_sqlite,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu"
+export CGO_CFLAGS="-I$PWD/source/php-src -I$PWD/source/php-src/main -I$PWD/source/php-src/TSRM -I$PWD/source/php-src/Zend -I$PWD/source/php-src/ext -I$PWD/source/php-src/ext/date/lib"
+export CGO_LDFLAGS="-L$PWD/source/php-src/libs $(sh $PWD/source/php-src/scripts/php-config --ldflags) $(sh $PWD/source/php-src/scripts/php-config --libs | sed 's/-lgcc_s//g' | tr ' ' '\n' | sort -u | xargs)"
+
+cd ..
+
+git clone https://github.com/dunglas/frankenphp
+cd frankenphp/caddy/frankenphp
+go build -buildmode=pie -tags "cgo netgo osusergo static_build" -ldflags "-linkmode=external -extldflags -static-pie"
+```
+
+The `frankenphp` file in the current directory is a static build of FrankenPHP!

--- a/docs/static.md
+++ b/docs/static.md
@@ -12,8 +12,8 @@ git clone https://github.com/dunglas/static-php-cli.git --branch=feat/embed
 cd static-php-cli
 bin/spc-alpine-docker fetch --with-php=8.2 -A
 bin/spc-alpine-docker build --build-embed --enable-zts --debug "bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,openssl,pcntl,pdo,pdo_mysql,pdo_sqlite,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu"
-export CGO_CFLAGS="-I$PWD/source/php-src -I$PWD/source/php-src/main -I$PWD/source/php-src/TSRM -I$PWD/source/php-src/Zend -I$PWD/source/php-src/ext -I$PWD/source/php-src/ext/date/lib"
-export CGO_LDFLAGS="-L$PWD/source/php-src/libs $(sh $PWD/source/php-src/scripts/php-config --ldflags) $(sh $PWD/source/php-src/scripts/php-config --libs | sed 's/-lgcc_s//g' | tr ' ' '\n' | sort -u | xargs)"
+export CGO_CFLAGS="$(sh $PWD/source/php-src/scripts/php-config --includes | sed s#-I/include/php#-I$PWD/source/php-src#g)"
+export CGO_LDFLAGS="-L$PWD/source/php-src/libs $(sh $PWD/source/php-src/scripts/php-config --ldflags) $(sh $PWD/source/php-src/scripts/php-config --libs | sed 's/-lgcc_s//g')"
 
 cd ..
 
@@ -23,3 +23,5 @@ go build -buildmode=pie -tags "cgo netgo osusergo static_build" -ldflags "-linkm
 ```
 
 The `frankenphp` file in the current directory is a static build of FrankenPHP!
+
+Customize the extensions to build using [the command generator](https://static-php-cli.zhamao.me/en/guide/cli-generator.html).

--- a/docs/static.md
+++ b/docs/static.md
@@ -47,13 +47,12 @@ GITHUB_TOKEN="xxx" docker --load buildx bake static-builder
 Run the following command to create a static binary for macOS:
 
 ```console
-git clone --depth=1 https://github.com/dunglas/static-php-cli.git --branch=feat/embed 
+git clone --depth=1 https://github.com/crazywhalecc/static-php-cli.git
 cd static-php-cli
 composer install --no-dev -a
 ./bin/spc doctor --auto-fix
 ./bin/spc fetch --with-php=8.2 -A
-./bin/spc build --enable-zts --build-embed --debug "bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwri
-ter,zip,zlib,apcu"
+./bin/spc build --enable-zts --build-embed --debug "bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,intl,mbstring,mbregex,mysqli,mysqlnd,opcache,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu"
 export CGO_CFLAGS="$(./buildroot/bin/php-config --includes | sed s#-I/#-I$PWD/buildroot/#g)"
 export CGO_LDFLAGS="-framework CoreFoundation -framework SystemConfiguration $(./buildroot/bin/php-config --ldflags) $(./buildroot/bin/php-config --libs)"
 

--- a/docs/static.md
+++ b/docs/static.md
@@ -27,9 +27,11 @@ To reduce the size of the binary and to reduce the attack surface, you can choos
 For instance, run the following command to only build the `opcache` extension:
 
 ```console
-docker buildx bake --load --set static-builder.args.PHP_EXTENSIONS=opcache static-builder
+docker buildx bake --load --set static-builder.args.PHP_EXTENSIONS=opcache,pdo_sqlite static-builder
 # ...
 ```
+
+See [the list of supported extensions](https://static-php-cli.zhamao.me/en/guide/extensions.html).
 
 ### GitHub Token
 

--- a/docs/static.md
+++ b/docs/static.md
@@ -39,3 +39,22 @@ If you hit the GitHub API rate limit, set a GitHub Personal Access Token in an e
 GITHUB_TOKEN="xxx" docker --load buildx bake static-builder
 # ...
 ```
+
+## macOS
+
+Run the following command to create a static binary for macOS:
+
+```console
+git clone --depth=1 https://github.com/dunglas/static-php-cli.git --branch=feat/embed 
+cd static-php-cli
+composer install --no-dev -a
+./bin/spc doctor
+./bin/spc fetch --with-php=8.2 -A
+./bin/spc build --enable-zts --build-embed --debug "opcache"
+export CGO_CFLAGS="$(./buildroot/bin/php-config --includes | sed s#-I/#-I$PWD/buildroot/#g)"
+export CGO_LDFLAGS="-L$PWD/buildroot/lib $(./buildroot/bin/php-config --ldflags) $(./buildroot/bin/php-config --libs)"
+
+git clone --depth=1 https://github.com/dunglas/frankenphp.git
+cd frankenphp/caddy/frankenphp
+go build -buildmode=pie -tags "cgo netgo osusergo static_build" -ldflags "-linkmode=external -extldflags -static-pie"
+```

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -12,13 +12,18 @@ package frankenphp
 // Use PHP includes corresponding to your PHP installation by running:
 //
 //   export CGO_CFLAGS=$(php-config --includes)
+//   export CGO_LDFLAGS=$(php-config --ldflags --libs)
+//
+// We also set these flags for hardening: https://github.com/docker-library/php/blob/master/8.2/bookworm/zts/Dockerfile#L57-L59
 
-// #cgo pkg-config: libxml-2.0 sqlite3
-// #cgo CFLAGS: -Wall -Werror
+// #cgo darwin pkg-config: libxml-2.0 sqlite3
+// #cgo CFLAGS: -Wall -Werror -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
 // #cgo CFLAGS: -I/usr/local/include/php -I/usr/local/include/php/main -I/usr/local/include/php/TSRM -I/usr/local/include/php/Zend -I/usr/local/include/php/ext -I/usr/local/include/php/ext/date/lib
 // #cgo linux CFLAGS: -D_GNU_SOURCE
+// #cgo CPPFLAGS: -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
 // #cgo darwin LDFLAGS: -L/opt/homebrew/opt/libiconv/lib -liconv
-// #cgo LDFLAGS: -L/usr/local/lib -L/usr/lib -lphp -lresolv -ldl -lm -lutil
+// #cgo linux LDFLAGS: -Wl,-O1
+// #cgo LDFLAGS: -pie -L/usr/local/lib -L/usr/lib -lphp -lresolv -ldl -lm -lutil
 // #include <stdlib.h>
 // #include <stdint.h>
 // #include <php_variables.h>

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -335,7 +335,6 @@ func testSession(t *testing.T, opts *testOptions) {
 func TestPhpInfo_module(t *testing.T) { testPhpInfo(t, nil) }
 func TestPhpInfo_worker(t *testing.T) { testPhpInfo(t, &testOptions{workerScript: "phpinfo.php"}) }
 func testPhpInfo(t *testing.T, opts *testOptions) {
-	t.Skip()
 	var logOnce sync.Once
 	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, i int) {
 		req := httptest.NewRequest("GET", fmt.Sprintf("http://example.com/phpinfo.php?i=%d", i), nil)

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -335,6 +335,7 @@ func testSession(t *testing.T, opts *testOptions) {
 func TestPhpInfo_module(t *testing.T) { testPhpInfo(t, nil) }
 func TestPhpInfo_worker(t *testing.T) { testPhpInfo(t, &testOptions{workerScript: "phpinfo.php"}) }
 func testPhpInfo(t *testing.T, opts *testOptions) {
+	t.Skip()
 	var logOnce sync.Once
 	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, i int) {
 		req := httptest.NewRequest("GET", fmt.Sprintf("http://example.com/phpinfo.php?i=%d", i), nil)

--- a/static-builder.Dockerfile
+++ b/static-builder.Dockerfile
@@ -64,6 +64,7 @@ COPY caddy caddy
 COPY C-Thread-Pool C-Thread-Pool
 
 RUN cd caddy/frankenphp && \
+    PATH="/static-php-cli/buildroot/bin:$PATH" \
     CGO_CFLAGS="$(php-config --includes | sed s#-I/#-I/static-php-cli/buildroot/#g)" \
     CGO_LDFLAGS="-L/static-php-cli/buildroot/lib $(php-config --ldflags) $(php-config --libs | sed -e 's/-lgcc_s//g')" \
     go build -buildmode=pie -tags "cgo netgo osusergo static_build" -ldflags "-linkmode=external -extldflags -static-pie -s -w -X 'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP $FRANKENPHP_VERSION Caddy'"

--- a/static-builder.Dockerfile
+++ b/static-builder.Dockerfile
@@ -64,7 +64,6 @@ COPY caddy caddy
 COPY C-Thread-Pool C-Thread-Pool
 
 RUN cd caddy/frankenphp && \
-    PATH="/static-php-cli/buildroot/bin:$PATH" \
-    CGO_CFLAGS="$(php-config --includes | sed s#-I/#-I/static-php-cli/buildroot/#g)" \
-    CGO_LDFLAGS="-L/static-php-cli/buildroot/lib $(php-config --ldflags) $(php-config --libs | sed -e 's/-lgcc_s//g')" \
+    CGO_CFLAGS="$(/static-php-cli/buildroot/bin/php-config --includes | sed s#-I/#-I/static-php-cli/buildroot/#g)" \
+    CGO_LDFLAGS="-L/static-php-cli/buildroot/lib $(/static-php-cli/buildroot/bin/php-config --ldflags) $(/static-php-cli/buildroot/bin/php-config --libs | sed -e 's/-lgcc_s//g')" \
     go build -buildmode=pie -tags "cgo netgo osusergo static_build" -ldflags "-linkmode=external -extldflags -static-pie -s -w -X 'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP $FRANKENPHP_VERSION Caddy'"

--- a/static-builder.Dockerfile
+++ b/static-builder.Dockerfile
@@ -3,7 +3,7 @@ FROM golang-base
 
 ARG FRANKENPHP_VERSION='dev'
 ARG PHP_VERSION='8.2'
-ARG PHP_EXTENSIONS='bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,opcache,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu'
+ARG PHP_EXTENSIONS='bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,intl,mbstring,mbregex,mysqli,mysqlnd,opcache,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu'
 
 RUN apk update; \
     apk add --no-cache \
@@ -50,7 +50,7 @@ COPY --from=composer/composer:2-bin --link /composer /usr/bin/composer
 
 WORKDIR /static-php-cli
 
-RUN git clone --depth=1 https://github.com/dunglas/static-php-cli.git --branch=feat/embed . && \
+RUN git clone --depth=1 https://github.com/crazywhalecc/static-php-cli . && \
     composer install --no-cache --no-dev --classmap-authoritative
 
 RUN --mount=type=secret,id=github-token GITHUB_TOKEN=$(cat /run/secrets/github-token) ./bin/spc download --with-php=$PHP_VERSION --all

--- a/static-builder.Dockerfile
+++ b/static-builder.Dockerfile
@@ -65,5 +65,5 @@ COPY C-Thread-Pool C-Thread-Pool
 
 RUN cd caddy/frankenphp && \
     CGO_CFLAGS="$(/static-php-cli/buildroot/bin/php-config --includes | sed s#-I/#-I/static-php-cli/buildroot/#g)" \
-    CGO_LDFLAGS="-L/static-php-cli/buildroot/lib $(/static-php-cli/buildroot/bin/php-config --ldflags) $(/static-php-cli/buildroot/bin/php-config --libs | sed -e 's/-lgcc_s//g')" \
+    CGO_LDFLAGS="$(/static-php-cli/buildroot/bin/php-config --ldflags) $(/static-php-cli/buildroot/bin/php-config --libs | sed -e 's/-lgcc_s//g')" \
     go build -buildmode=pie -tags "cgo netgo osusergo static_build" -ldflags "-linkmode=external -extldflags -static-pie -s -w -X 'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP $FRANKENPHP_VERSION Caddy'"

--- a/static-builder.Dockerfile
+++ b/static-builder.Dockerfile
@@ -1,0 +1,68 @@
+# syntax=docker/dockerfile:1
+FROM golang-base
+
+ARG FRANKENPHP_VERSION='dev'
+ARG PHP_VERSION='8.2'
+
+RUN apk update; \
+    apk add --no-cache \
+        autoconf \
+        automake \
+        bash \
+        binutils \
+        bison \
+        build-base \
+        cmake \
+        composer \
+        curl \
+        file \
+        flex \
+        g++ \
+        gcc \
+        git \
+        jq \
+        libgcc \
+        libstdc++ \
+        linux-headers \
+        m4 \
+        make \
+        php81 \
+        php81-common \
+        php81-pcntl \
+        php81-phar \
+        php81-posix \
+        php81-tokenizer \
+        php81-xml \
+        pkgconfig \
+        wget \
+        xz
+
+WORKDIR /static-php-cli
+
+RUN git clone --depth=1 https://github.com/dunglas/static-php-cli.git --branch=feat/embed . && \
+    composer install --no-cache --no-dev --classmap-authoritative
+
+RUN --mount=type=secret,id=github-token GITHUB_TOKEN=$(cat /run/secrets/github-token) ./bin/spc download --with-php=$PHP_VERSION --all
+
+RUN ./bin/spc build --build-embed --enable-zts --debug "bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,openssl,pcntl,pdo,pdo_mysql,pdo_sqlite,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu"
+
+RUN echo "CGO_CFLAGS=$CGO_CFLAGS"
+
+WORKDIR /go/src/app
+
+COPY go.mod go.sum ./
+RUN go mod graph | awk '{if ($1 !~ "@") print $2}' | xargs go get
+
+RUN mkdir caddy && cd caddy
+COPY caddy/go.mod caddy/go.sum ./caddy/
+
+RUN cd caddy && go mod graph | awk '{if ($1 !~ "@") print $2}' | xargs go get
+
+COPY *.* ./
+COPY caddy caddy
+COPY C-Thread-Pool C-Thread-Pool
+
+RUN cd caddy/frankenphp && \
+    CGO_CFLAGS="$(sh /static-php-cli/source/php-src/scripts/php-config --includes | sed s#-I/include/php#-I/static-php-cli/source/php-src#g)" \
+    CGO_LDFLAGS="-L/static-php-cli/source/php-src/libs $(sh /static-php-cli/source/php-src/scripts/php-config --ldflags) $(sh /static-php-cli/source/php-src/scripts/php-config --libs | sed -e 's/-lgcc_s//g')" \
+    go build -buildmode=pie -tags "cgo netgo osusergo static_build" -ldflags "-linkmode=external -extldflags -static-pie -s -w -X 'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP $FRANKENPHP_VERSION Caddy'"

--- a/static-builder.Dockerfile
+++ b/static-builder.Dockerfile
@@ -29,11 +29,13 @@ RUN apk update; \
         make \
         php81 \
         php81-common \
+        php81-dom \
         php81-pcntl \
         php81-phar \
         php81-posix \
         php81-tokenizer \
         php81-xml \
+        php81-xmlwriter \
         pkgconfig \
         wget \
         xz
@@ -41,7 +43,7 @@ RUN apk update; \
 WORKDIR /static-php-cli
 
 RUN git clone --depth=1 https://github.com/dunglas/static-php-cli.git --branch=feat/embed . && \
-    composer install --no-cache --no-dev --classmap-authoritative
+    COMPOSER_ALLOW_SUPERUSER=1 composer install --no-dev --classmap-authoritative --no-cache
 
 RUN --mount=type=secret,id=github-token GITHUB_TOKEN=$(cat /run/secrets/github-token) ./bin/spc download --with-php=$PHP_VERSION --all
 

--- a/static-builder.Dockerfile
+++ b/static-builder.Dockerfile
@@ -14,7 +14,6 @@ RUN apk update; \
         bison \
         build-base \
         cmake \
-        composer \
         curl \
         file \
         flex \
@@ -27,23 +26,32 @@ RUN apk update; \
         linux-headers \
         m4 \
         make \
-        php81 \
-        php81-common \
-        php81-dom \
-        php81-pcntl \
-        php81-phar \
-        php81-posix \
-        php81-tokenizer \
-        php81-xml \
-        php81-xmlwriter \
+        php82 \
+        php82-common \
+        php82-dom \
+        php82-mbstring \
+        php82-openssl \
+        php82-pcntl \
+        php82-phar \
+        php82-posix \
+        php82-tokenizer \
+        php82-xml \
+        php82-xmlwriter \
         pkgconfig \
         wget \
-        xz
+        xz ; \
+    ln -sf /usr/bin/php82 /usr/bin/php
+
+# https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
+ENV COMPOSER_ALLOW_SUPERUSER=1
+ENV PATH="${PATH}:/root/.composer/vendor/bin"
+
+COPY --from=composer/composer:2-bin --link /composer /usr/bin/composer
 
 WORKDIR /static-php-cli
 
 RUN git clone --depth=1 https://github.com/dunglas/static-php-cli.git --branch=feat/embed . && \
-    COMPOSER_ALLOW_SUPERUSER=1 composer install --no-dev --classmap-authoritative --no-cache
+    composer install --no-cache --no-dev --classmap-authoritative
 
 RUN --mount=type=secret,id=github-token GITHUB_TOKEN=$(cat /run/secrets/github-token) ./bin/spc download --with-php=$PHP_VERSION --all
 

--- a/static-builder.Dockerfile
+++ b/static-builder.Dockerfile
@@ -3,6 +3,7 @@ FROM golang-base
 
 ARG FRANKENPHP_VERSION='dev'
 ARG PHP_VERSION='8.2'
+ARG PHP_EXTENSIONS='bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu'
 
 RUN apk update; \
     apk add --no-cache \
@@ -44,9 +45,7 @@ RUN git clone --depth=1 https://github.com/dunglas/static-php-cli.git --branch=f
 
 RUN --mount=type=secret,id=github-token GITHUB_TOKEN=$(cat /run/secrets/github-token) ./bin/spc download --with-php=$PHP_VERSION --all
 
-RUN ./bin/spc build --build-embed --enable-zts --debug "bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,openssl,pcntl,pdo,pdo_mysql,pdo_sqlite,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu"
-
-RUN echo "CGO_CFLAGS=$CGO_CFLAGS"
+RUN ./bin/spc build --build-embed --enable-zts --debug "$PHP_EXTENSIONS"
 
 WORKDIR /go/src/app
 

--- a/static-builder.Dockerfile
+++ b/static-builder.Dockerfile
@@ -3,7 +3,7 @@ FROM golang-base
 
 ARG FRANKENPHP_VERSION='dev'
 ARG PHP_VERSION='8.2'
-ARG PHP_EXTENSIONS='bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu'
+ARG PHP_EXTENSIONS='bcmath,calendar,ctype,curl,dba,dom,exif,filter,fileinfo,gd,iconv,mbstring,mbregex,mysqli,mysqlnd,opcache,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib,apcu'
 
 RUN apk update; \
     apk add --no-cache \


### PR DESCRIPTION
Creates static builds of FrankenPHP that contains the PHP interpreter. These binary releases of FrankenPHP can be used without having a local installation of PHP!

Closes #82.
Relies on https://github.com/crazywhalecc/static-php-cli/pull/153.