### PR TITLE
fix: ensure that SERVER_PORT is always defined

### DIFF
--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -180,7 +180,7 @@ func testServerVariable(t *testing.T, opts *testOptions) {
 		assert.Contains(t, strBody, "[SERVER_SOFTWARE] => FrankenPHP")
 		assert.Contains(t, strBody, "[REQUEST_TIME_FLOAT]")
 		assert.Contains(t, strBody, "[REQUEST_TIME]")
-		assert.Contains(t, strBody, "[REQUEST_TIME]")
+		assert.Contains(t, strBody, "[SERVER_PORT] => 80")
 	}, opts)
 }
 


### PR DESCRIPTION
This is mandatory by the spec, and necessary to use XDebug with PHPStorm.
#168 contains a bug preventing the fix from working as expected.

Closes #141.