### PR TITLE
fix(caddy): ModuleInfo.New() warning

### DIFF
--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -58,7 +58,7 @@ type FrankenPHPApp struct {
 func (a FrankenPHPApp) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
 		ID:  "frankenphp",
-		New: func() caddy.Module { return a },
+		New: func() caddy.Module { return &a },
 	}
 }
 


### PR DESCRIPTION
Fix this Caddy warning:

> [WARNING] ModuleInfo.New() for module 'frankenphp' did not return a pointer, so we are using reflection to make a pointer instead; please fix this by using new(Type) or &Type notation in your module's New() function.