### PR TITLE
feat: add CLI support 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,10 @@ jobs:
         env:
           GOEXPERIMENT: cgocheck2
       -
+        name: Build testcli binary
+        working-directory: internal/testcli/
+        run: go build
+      -
         name: Run library tests
         run: go test -race -v ./...
       -

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /caddy/frankenphp/frankenphp
 /internal/testserver/testserver
+internal/testcli/testcli
 .idea/
 .vscode/
 __debug_bin

--- a/caddy/php-cli.go
+++ b/caddy/php-cli.go
@@ -1,0 +1,36 @@
+package caddy
+
+import (
+	"errors"
+	"os"
+
+	caddycmd "github.com/caddyserver/caddy/v2/cmd"
+	"github.com/dunglas/frankenphp"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	caddycmd.RegisterCommand(caddycmd.Command{
+		Name:  "php-cli",
+		Usage: "script.php [args ...]",
+		Short: "Runs a PHP command",
+		Long: `
+Executes a PHP script similarly to the CLI SAPI.`,
+		CobraFunc: func(cmd *cobra.Command) {
+			cmd.RunE = caddycmd.WrapCommandFuncForCobra(cmdPHPCLI)
+		},
+	})
+}
+
+func cmdPHPCLI(fs caddycmd.Flags) (int, error) {
+	args := fs.Args()
+	if len(args) < 1 {
+		return 1, errors.New("the path to the PHP script is required")
+	}
+
+	status := frankenphp.ExecuteScriptCLI(args[0], args)
+	os.Exit(status)
+
+	return status, nil
+}

--- a/caddy/php-cli.go
+++ b/caddy/php-cli.go
@@ -18,13 +18,14 @@ func init() {
 		Long: `
 Executes a PHP script similarly to the CLI SAPI.`,
 		CobraFunc: func(cmd *cobra.Command) {
+			cmd.DisableFlagParsing = true
 			cmd.RunE = caddycmd.WrapCommandFuncForCobra(cmdPHPCLI)
 		},
 	})
 }
 
 func cmdPHPCLI(fs caddycmd.Flags) (int, error) {
-	args := fs.Args()
+	args := os.Args[2:]
 	if len(args) < 1 {
 		return 1, errors.New("the path to the PHP script is required")
 	}

--- a/caddy/php-server.go
+++ b/caddy/php-server.go
@@ -23,7 +23,7 @@ import (
 func init() {
 	caddycmd.RegisterCommand(caddycmd.Command{
 		Name:  "php-server",
-		Usage: "[--domain <example.com>] [--root <path>] [--listen <addr>] [--access-log]",
+		Usage: "[--domain <example.com>] [--root <path>] [--listen <addr>] [--access-log] [--debug] [--no-compress]",
 		Short: "Spins up a production-ready PHP server",
 		Long: `
 A simple but production-ready PHP server. Useful for quick deployments,

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -12,6 +12,7 @@
 #include <Zend/zend_types.h>
 #include <Zend/zend_exceptions.h>
 #include <Zend/zend_interfaces.h>
+#include <sapi/embed/php_embed.h>
 #include <ext/standard/head.h>
 #include <ext/spl/spl_exceptions.h>
 
@@ -660,6 +661,21 @@ int frankenphp_execute_script(const char* file_name)
 	} zend_end_try();
 
 	zend_destroy_file_handle(&file_handle);
+
+	return status;
+}
+
+int frankenphp_execute_script_cli(char *script, int argc, char **argv) {
+	int status;
+
+	PHP_EMBED_START_BLOCK(argc, argv)
+
+	zend_file_handle file_handle;
+	zend_stream_init_filename(&file_handle, script);
+
+	status = php_execute_script(&file_handle);
+
+	PHP_EMBED_END_BLOCK()
 
 	return status;
 }

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -755,10 +755,10 @@ static void * execute_script_cli(void *arg) {
 	php_embed_module.pretty_name = "PHP CLI embedded in FrankenPHP";
 	php_embed_module.register_server_variables = sapi_cli_register_variables;
 
-    php_embed_init(cli_argc, cli_argv);
+	php_embed_init(cli_argc, cli_argv);
 
 	cli_register_file_handles(false);
-    zend_first_try {
+	zend_first_try {
 		zend_file_handle file_handle;
 		zend_stream_init_filename(&file_handle, cli_script);
 

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -666,9 +666,86 @@ int frankenphp_execute_script(const char* file_name)
 }
 
 // Use global variables to store CLI arguments to prevent useless allocations
-char *cliScript;
-int cliArgc;
-char **cliArgv;
+static char *cli_script;
+static int cli_argc;
+static char **cli_argv;
+
+// Adapted from https://github.com/php/php-src/sapi/cli/php_cli.c (The PHP Group, The PHP License)
+static void cli_register_file_handles(bool no_close) /* {{{ */
+{
+	php_stream *s_in, *s_out, *s_err;
+	php_stream_context *sc_in=NULL, *sc_out=NULL, *sc_err=NULL;
+	zend_constant ic, oc, ec;
+
+	s_in  = php_stream_open_wrapper_ex("php://stdin",  "rb", 0, NULL, sc_in);
+	s_out = php_stream_open_wrapper_ex("php://stdout", "wb", 0, NULL, sc_out);
+	s_err = php_stream_open_wrapper_ex("php://stderr", "wb", 0, NULL, sc_err);
+
+	if (s_in==NULL || s_out==NULL || s_err==NULL) {
+		if (s_in) php_stream_close(s_in);
+		if (s_out) php_stream_close(s_out);
+		if (s_err) php_stream_close(s_err);
+		return;
+	}
+
+	if (no_close) {
+		s_in->flags |= PHP_STREAM_FLAG_NO_CLOSE;
+		s_out->flags |= PHP_STREAM_FLAG_NO_CLOSE;
+		s_err->flags |= PHP_STREAM_FLAG_NO_CLOSE;
+	}
+
+	//s_in_process = s_in;
+
+	php_stream_to_zval(s_in,  &ic.value);
+	php_stream_to_zval(s_out, &oc.value);
+	php_stream_to_zval(s_err, &ec.value);
+
+	ZEND_CONSTANT_SET_FLAGS(&ic, CONST_CS, 0);
+	ic.name = zend_string_init_interned("STDIN", sizeof("STDIN")-1, 0);
+	zend_register_constant(&ic);
+
+	ZEND_CONSTANT_SET_FLAGS(&oc, CONST_CS, 0);
+	oc.name = zend_string_init_interned("STDOUT", sizeof("STDOUT")-1, 0);
+	zend_register_constant(&oc);
+
+	ZEND_CONSTANT_SET_FLAGS(&ec, CONST_CS, 0);
+	ec.name = zend_string_init_interned("STDERR", sizeof("STDERR")-1, 0);
+	zend_register_constant(&ec);
+}
+/* }}} */
+
+static void sapi_cli_register_variables(zval *track_vars_array) /* {{{ */
+{
+	size_t len;
+	char   *docroot = "";
+
+	/* In CGI mode, we consider the environment to be a part of the server
+	 * variables
+	 */
+	php_import_environment_variables(track_vars_array);
+
+	/* Build the special-case PHP_SELF variable for the CLI version */
+	len = strlen(cli_script);
+	if (sapi_module.input_filter(PARSE_SERVER, "PHP_SELF", &cli_script, len, &len)) {
+		php_register_variable("PHP_SELF", cli_script, track_vars_array);
+	}
+	if (sapi_module.input_filter(PARSE_SERVER, "SCRIPT_NAME", &cli_script, len, &len)) {
+		php_register_variable("SCRIPT_NAME", cli_script, track_vars_array);
+	}
+	/* filenames are empty for stdin */
+	if (sapi_module.input_filter(PARSE_SERVER, "SCRIPT_FILENAME", &cli_script, len, &len)) {
+		php_register_variable("SCRIPT_FILENAME", cli_script, track_vars_array);
+	}
+	if (sapi_module.input_filter(PARSE_SERVER, "PATH_TRANSLATED", &cli_script, len, &len)) {
+		php_register_variable("PATH_TRANSLATED", cli_script, track_vars_array);
+	}
+	/* just make it available */
+	len = 0U;
+	if (sapi_module.input_filter(PARSE_SERVER, "DOCUMENT_ROOT", &docroot, len, &len)) {
+		php_register_variable("DOCUMENT_ROOT", docroot, track_vars_array);
+	}
+}
+/* }}} */
 
 static void * execute_script_cli(void *arg) {
 	void *exit_status;
@@ -676,11 +753,14 @@ static void * execute_script_cli(void *arg) {
 	// The SAPI name "cli" is hardcoded into too many programs... let's usurp it.
 	php_embed_module.name = "cli";
 	php_embed_module.pretty_name = "PHP CLI embedded in FrankenPHP";
+	php_embed_module.register_server_variables = sapi_cli_register_variables;
 
-    php_embed_init(cliArgc, cliArgv);
+    php_embed_init(cli_argc, cli_argv);
+
+	cli_register_file_handles(false);
     zend_first_try {
 		zend_file_handle file_handle;
-		zend_stream_init_filename(&file_handle, cliScript);
+		zend_stream_init_filename(&file_handle, cli_script);
 
 		php_execute_script(&file_handle);
 	} zend_end_try();
@@ -697,9 +777,9 @@ int frankenphp_execute_script_cli(char *script, int argc, char **argv) {
 	int err;
 	void *exit_status;
 
-	cliScript = script;
-	cliArgc = argc;
-	cliArgv = argv;
+	cli_script = script;
+	cli_argc = argc;
+	cli_argv = argv;
 
 	// Start the script in a dedicated thread to prevent conflicts between Go and PHP signal handlers
 	err = pthread_create(&thread, NULL, execute_script_cli, NULL);

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -672,6 +672,8 @@ int frankenphp_execute_script_cli(char *script, int argc, char **argv) {
 
 	int exit_status;
 
+	// The SAPI name "cli" is hardcoded into too many programs... let's usurp it.
+	php_embed_module.name = "cli";
 	php_embed_module.pretty_name = "PHP CLI embedded in FrankenPHP";
 
     php_embed_init(argc, argv);

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -667,7 +667,9 @@ func go_log(message *C.char, level C.int) {
 	}
 }
 
-func ExecuteScriptCLI(script string, args []string) error {
+// ExecuteScriptCLI executes the PHP script passed as parameter.
+// It returns the exit status code of the script.
+func ExecuteScriptCLI(script string, args []string) int {
 	cScript := C.CString(script)
 	defer C.free(unsafe.Pointer(cScript))
 
@@ -677,11 +679,5 @@ func ExecuteScriptCLI(script string, args []string) error {
 		argv[i] = C.CString(arg)
 	}
 
-	runtime.LockOSThread()
-
-	if C.frankenphp_execute_script_cli(cScript, argc, (**C.char)(unsafe.Pointer(&argv[0]))) == -1 {
-		return fmt.Errorf("error exuction script %s", script)
-	}
-
-	return nil
+	return int(C.frankenphp_execute_script_cli(cScript, argc, (**C.char)(unsafe.Pointer(&argv[0]))))
 }

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -666,3 +666,22 @@ func go_log(message *C.char, level C.int) {
 		l.Info(m, zap.Stringer("syslog_level", syslogLevel(level)))
 	}
 }
+
+func ExecuteScriptCLI(script string, args []string) error {
+	cScript := C.CString(script)
+	defer C.free(unsafe.Pointer(cScript))
+
+	argc := C.int(len(args))
+	argv := make([]*C.char, argc)
+	for i, arg := range args {
+		argv[i] = C.CString(arg)
+	}
+
+	runtime.LockOSThread()
+
+	if C.frankenphp_execute_script_cli(cScript, argc, (**C.char)(unsafe.Pointer(&argv[0]))) == -1 {
+		return fmt.Errorf("error exuction script %s", script)
+	}
+
+	return nil
+}

--- a/frankenphp.h
+++ b/frankenphp.h
@@ -53,4 +53,6 @@ int frankenphp_execute_script(const char *file_name);
 uintptr_t frankenphp_request_shutdown();
 void frankenphp_register_bulk_variables(char **variables, size_t size, zval *track_vars_array);
 
+int frankenphp_execute_script_cli(char *script, int argc, char **argv);
+
 #endif

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -588,3 +588,9 @@ func testFiberNoCgo(t *testing.T, opts *testOptions) {
 		assert.Equal(t, string(body), fmt.Sprintf("Fiber %d", i))
 	}, opts)
 }
+
+func TestExecuteScriptCLI(t *testing.T) {
+	cwd, _ := os.Getwd()
+
+	assert.Nil(t, frankenphp.ExecuteScriptCLI(cwd+"/testdata/command.php", []string{"foo", "bar"}))
+}

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -553,6 +554,11 @@ func testFiberNoCgo(t *testing.T, opts *testOptions) {
 }
 
 func TestExecuteScriptCLI(t *testing.T) {
+	path, err := exec.LookPath("go")
+	assert.NoError(t, err)
+	t.Logf("Go path: %s\n", path)
+	t.Logf("Go arch: %s\n", runtime.GOARCH)
+
 	cmd := exec.Command("go", "run", "internal/testcli/main.go", "testdata/command.php", "foo", "bar")
 	stdoutStderr, err := cmd.CombinedOutput()
 	assert.Error(t, err)

--- a/internal/testcli/main.go
+++ b/internal/testcli/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/dunglas/frankenphp"
+)
+
+func main() {
+	if len(os.Args) <= 1 {
+		log.Println("Usage: testcli script.php")
+		os.Exit(1)
+	}
+
+	os.Exit(frankenphp.ExecuteScriptCLI(os.Args[1], os.Args))
+}

--- a/testdata/command.php
+++ b/testdata/command.php
@@ -1,0 +1,3 @@
+<?php
+
+echo "From the CLI\n";

--- a/testdata/command.php
+++ b/testdata/command.php
@@ -1,3 +1,6 @@
 <?php
 
+var_dump($argv);
 echo "From the CLI\n";
+
+exit(3);

--- a/testdata/command.php
+++ b/testdata/command.php
@@ -1,6 +1,6 @@
 <?php
 
-var_dump($argv);
+var_dump($argv, $_SERVER);
 echo "From the CLI\n";
 
 exit(3);


### PR DESCRIPTION
This patch allows FrankenPHP to execute CLI scripts. This is especially useful when using the static binary to run Composer, Symfony or Laravel commands.

Continuation of #4.