### PR TITLE
add start-group and end-group around php-config libs

### DIFF
--- a/static-builder.Dockerfile
+++ b/static-builder.Dockerfile
@@ -77,7 +77,7 @@ COPY C-Thread-Pool C-Thread-Pool
 
 RUN cd caddy/frankenphp && \
     CGO_CFLAGS="$(/static-php-cli/buildroot/bin/php-config --includes | sed s#-I/#-I/static-php-cli/buildroot/#g)" \
-    CGO_LDFLAGS="-DFRANKENPHP_VERSION=$FRANKENPHP_VERSION $(/static-php-cli/buildroot/bin/php-config --ldflags) $(/static-php-cli/buildroot/bin/php-config --libs | sed -e 's/-lgcc_s//g')" \
+    CGO_LDFLAGS="-DFRANKENPHP_VERSION=$FRANKENPHP_VERSION $(/static-php-cli/buildroot/bin/php-config --ldflags) -Wl,--start-group $(/static-php-cli/buildroot/bin/php-config --libs | sed -e 's/-lgcc_s//g') -Wl,--end-group" \
     LIBPHP_VERSION="$(/static-php-cli/buildroot/bin/php-config --version)" \
     go build -buildmode=pie -tags "cgo netgo osusergo static_build" -ldflags "-linkmode=external -extldflags -static-pie -s -w -X 'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP $FRANKENPHP_VERSION PHP $LIBPHP_VERSION Caddy'" && \
     ./frankenphp version


### PR DESCRIPTION
don't be dependent on php not messing up when compiling the embed sapi