### PR TITLE
fix PHP version comparing to work with versions like: 9.0 / 9.1

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -274,7 +274,7 @@ func Init(options ...Option) error {
 
 	config := Config()
 
-	if config.Version.MajorVersion < 8 || config.Version.MinorVersion < 2 {
+	if config.Version.MajorVersion < 8 || (config.Version.MajorVersion == 8 && config.Version.MinorVersion < 2) {
 		return InvalidPHPVersionError
 	}
 


### PR DESCRIPTION
I think 8.2 is the lowest compatible PHP version, so it should be working with 9.0 / 9.1 in the future ?
