### PR TITLE
fix: add authorized directories in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,6 @@
 !**/*.h
 !testdata/*.php
 !testdata/*.txt
+!caddy
+!C-Thread-Pool
+!internal


### PR DESCRIPTION
When [build dev](https://github.com/dunglas/frankenphp/blob/main/CONTRIBUTING.md#with-docker-linux) docker image, build is failed at `RUN cd`.
https://github.com/dunglas/frankenphp/blob/51038bbdf56d4811eae396e88063698c05201bac/dev.Dockerfile#L63-L65
So suggest adding directories required for build to `.dockerignore`. 