### PR TITLE
Chore: Use `Trim()` to remove `[]` from IPv6 addresses

### DIFF
--- a/cgi.go
+++ b/cgi.go
@@ -35,8 +35,7 @@ func populateEnv(request *http.Request) error {
 		}
 
 		// Remove [] from IPv6 addresses
-		ip = strings.Replace(ip, "[", "", 1)
-		ip = strings.Replace(ip, "]", "", 1)
+		ip = strings.Trim(ip, "[]")
 
 		if _, ok := fc.Env["REMOTE_ADDR"]; !ok {
 			fc.Env["REMOTE_ADDR"] = ip


### PR DESCRIPTION
I know that for small strings like an IPv6 address, one approach over the other doesn't make much of a difference. But by using `Trim()`, we eliminate one function call.

This is just my personal take :nail_care:, so feel free to close this if you prefer the original version. :blush: 