### PR TITLE
perf: read the request body directly in the memory allocated by PHP

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -599,7 +599,7 @@ func go_sapi_flush(rh C.uintptr_t) bool {
 func go_read_post(rh C.uintptr_t, cBuf *C.char, countBytes C.size_t) (readBytes C.size_t) {
 	r := cgo.Handle(rh).Value().(*http.Request)
 
-	p := make([]byte, countBytes)
+	p := unsafe.Slice((*byte)(unsafe.Pointer(cBuf)), countBytes)
 	var err error
 	for readBytes < countBytes && err == nil {
 		var n int
@@ -611,10 +611,6 @@ func go_read_post(rh C.uintptr_t, cBuf *C.char, countBytes C.size_t) (readBytes 
 		// invalid Read on closed Body may happen because of https://github.com/golang/go/issues/15527
 		fc, _ := FromContext(r.Context())
 		fc.Logger.Error("error while reading the request body", zap.Error(err))
-	}
-
-	if readBytes != 0 {
-		C.memcpy(unsafe.Pointer(cBuf), unsafe.Pointer(&p[0]), C.size_t(readBytes))
 	}
 
 	return


### PR DESCRIPTION
Currently, we allocate the memory needed to read the HTTP request body in Go, and then we copy it into the memory allocated by PHP (in C). This is wasted memory and CPU.

This patch makes FrankenPHP directly in the memory allocated by Go.