### PR TITLE
Add Joomla on FrankenPHP Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,4 @@ containing [PHP 8.2](https://www.php.net/releases/8.2/en.php) and most popular P
 * [Sulu](https://sulu.io/blog/running-sulu-with-frankenphp)
 * [WordPress](https://github.com/dunglas/frankenphp-wordpress)
 * [Drupal](https://github.com/dunglas/frankenphp-drupal)
+* [Joomla](https://github.com/alexandreelise/frankenphp-joomla)


### PR DESCRIPTION
Hi, FrankenPHP Team,
This pull request is a suggestion to add Joomla on FrankenPHP as it works too. I tried it and made a docker image for it based on your frankenphp-worpress repo. If you don't mind, please add the Joomla version too on your README.md as an example, besides Wordpress and Drupal.