### PR TITLE
chore: add benchmark showing a 2.5 reduction in memory usage since RC2

### DIFF
--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -618,3 +618,66 @@ func BenchmarkHelloWorld(b *testing.B) {
 		handler(w, req)
 	}
 }
+
+func BenchmarkEcho(b *testing.B) {
+	if err := frankenphp.Init(frankenphp.WithLogger(zap.NewNop())); err != nil {
+		panic(err)
+	}
+	defer frankenphp.Shutdown()
+	cwd, _ := os.Getwd()
+	testDataDir := cwd + "/testdata/"
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		req := frankenphp.NewRequestWithContext(r, testDataDir, nil)
+		if err := frankenphp.ServeHTTP(w, req); err != nil {
+			panic(err)
+		}
+	}
+
+	const body = `{
+		"squadName": "Super hero squad",
+		"homeTown": "Metro City",
+		"formed": 2016,
+		"secretBase": "Super tower",
+		"active": true,
+		"members": [
+		  {
+			"name": "Molecule Man",
+			"age": 29,
+			"secretIdentity": "Dan Jukes",
+			"powers": ["Radiation resistance", "Turning tiny", "Radiation blast"]
+		  },
+		  {
+			"name": "Madame Uppercut",
+			"age": 39,
+			"secretIdentity": "Jane Wilson",
+			"powers": [
+			  "Million tonne punch",
+			  "Damage resistance",
+			  "Superhuman reflexes"
+			]
+		  },
+		  {
+			"name": "Eternal Flame",
+			"age": 1000000,
+			"secretIdentity": "Unknown",
+			"powers": [
+			  "Immortality",
+			  "Heat Immunity",
+			  "Inferno",
+			  "Teleportation",
+			  "Interdimensional travel"
+			]
+		  }
+		]
+	  }`
+
+	r := strings.NewReader(body)
+	req := httptest.NewRequest("POST", "http://example.com/echo.php", r)
+	w := httptest.NewRecorder()
+
+	for i := 0; i < b.N; i++ {
+		r.Reset(body)
+		handler(w, req)
+	}
+}


### PR DESCRIPTION
This benchmark shows that #292 and #293 improve memory usage by a factor of 2.5!
The more data read from the request body or written in the response body, the more significant the improvement!

There is still room for similar improvements in: https://github.com/dunglas/frankenphp/blob/981f954cf2a1c4e7a6fcaa820ce7ff84e4d91b52/frankenphp.go#L509

It would be nice if the memory wasn't allocated once in Go and a second time in C (and then a third time because of how PHP works internally). A possible way to improve this could be to populate the CGI variables directly in C-compatible strings, to avoid copyinv.

# Before #292 and #293.

Memory usage: 14.9 bytes per request.

<details>
Running tool: /opt/homebrew/bin/go test -benchmem -run=^$ -bench ^BenchmarkEcho$ github.com/dunglas/frankenphp -v -count=1

goos: darwin
goarch: arm64
pkg: github.com/dunglas/frankenphp
BenchmarkEcho
BenchmarkEcho-8   	    3514	    342450 ns/op	   15261 B/op	      32 allocs/op
PASS
ok  	github.com/dunglas/frankenphp	2.122s
</details>

# After

5.3 bytes per request.

<details>
Running tool: /opt/homebrew/bin/go test -benchmem -run=^$ -bench ^BenchmarkEcho$ github.com/dunglas/frankenphp -v -count=1

goos: darwin
goarch: arm64
pkg: github.com/dunglas/frankenphp
BenchmarkEcho
BenchmarkEcho-8   	    3565	    335976 ns/op	    5482 B/op	      28 allocs/op
PASS
ok  	github.com/dunglas/frankenphp	2.150s
</details>