### PR TITLE
refactor: faster $_SERVER variables creation

### DIFF
--- a/frankenphp.h
+++ b/frankenphp.h
@@ -46,12 +46,9 @@ int frankenphp_update_server_context(
 	char *auth_password,
 	int proto_num
 );
-int frankenphp_worker_reset_server_context();
-uintptr_t frankenphp_clean_server_context();
 int frankenphp_request_startup();
-int frankenphp_execute_script(const char *file_name);
-uintptr_t frankenphp_request_shutdown();
-void frankenphp_register_bulk_variables(char **variables, size_t size, zval *track_vars_array);
+int frankenphp_execute_script(char *file_name);
+void frankenphp_register_bulk_variables(char *known_variables[27], char **dynamic_variables, size_t size, zval *track_vars_array);
 
 int frankenphp_execute_script_cli(char *script, int argc, char **argv);
 

--- a/internal/testserver/main.go
+++ b/internal/testserver/main.go
@@ -20,12 +20,11 @@ func main() {
 	defer frankenphp.Shutdown()
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		cwd, err := os.Getwd()
-		if err != nil {
+		req, err := frankenphp.NewRequestWithContext(r)
+		if err == nil {
 			panic(err)
 		}
 
-		req := frankenphp.NewRequestWithContext(r, cwd, nil)
 		if err := frankenphp.ServeHTTP(w, req); err != nil {
 			panic(err)
 		}

--- a/request_options.go
+++ b/request_options.go
@@ -1,0 +1,72 @@
+package frankenphp
+
+import (
+	"path/filepath"
+
+	"go.uber.org/zap"
+)
+
+// RequestOption instances allow to configure a FrankenPHP Request.
+type RequestOption func(h *FrankenPHPContext) error
+
+// WithRequestDocumentRoot sets the root directory of the PHP application.
+// if resolveSymlink is true, oath declared as root directory will be resolved
+// to its absolute value after the evaluation of any symbolic links.
+// Due to the nature of PHP opcache, root directory path is cached: when
+// using a symlinked directory as root this could generate errors when
+// symlink is changed without PHP being restarted; enabling this
+// directive will set $_SERVER['DOCUMENT_ROOT'] to the real directory path.
+func WithRequestDocumentRoot(documentRoot string, resolveSymlink bool) RequestOption {
+	return func(o *FrankenPHPContext) error {
+		// make sure file root is absolute
+		root, err := filepath.Abs(documentRoot)
+		if err != nil {
+			return err
+		}
+
+		if resolveSymlink {
+			if root, err = filepath.EvalSymlinks(root); err != nil {
+				return err
+			}
+		}
+
+		o.documentRoot = root
+
+		return nil
+	}
+}
+
+// The path in the URL will be split into two, with the first piece ending
+// with the value of SplitPath. The first piece will be assumed as the
+// actual resource (CGI script) name, and the second piece will be set to
+// PATH_INFO for the CGI script to use.
+//
+// Future enhancements should be careful to avoid CVE-2019-11043,
+// which can be mitigated with use of a try_files-like behavior
+// that 404s if the fastcgi path info is not found.
+func WithRequestSplitPath(splitPath []string) RequestOption {
+	return func(o *FrankenPHPContext) error {
+		o.splitPath = splitPath
+
+		return nil
+	}
+}
+
+// WithEnv set CGI-like environment variables that will be available in $_SERVER.
+// Values set with WithEnv always have priority over automatically populated values.
+func WithRequestEnv(env map[string]string) RequestOption {
+	return func(o *FrankenPHPContext) error {
+		o.env = env
+
+		return nil
+	}
+}
+
+// WithLogger sets the logger associated with the current request
+func WithRequestLogger(logger *zap.Logger) RequestOption {
+	return func(o *FrankenPHPContext) error {
+		o.logger = logger
+
+		return nil
+	}
+}

--- a/worker_test.go
+++ b/worker_test.go
@@ -98,7 +98,11 @@ func ExampleServeHTTP_workers() {
 	defer frankenphp.Shutdown()
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		req := frankenphp.NewRequestWithContext(r, "/path/to/document/root", nil)
+		req, err := frankenphp.NewRequestWithContext(r, frankenphp.WithRequestDocumentRoot("/path/to/document/root", false))
+		if err != nil {
+			panic(err)
+		}
+
 		if err := frankenphp.ServeHTTP(w, req); err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
This patch changes how $_SERVER variables are populated to minimize allocations.
Also, reduce the number of switches between C and Go.

According to the benchmark introduced in https://github.com/dunglas/frankenphp/pull/298, this change improves memory usage by 38% compared to `main`, and from 78% compared to RC3.

Benchmark:

<details>
<pre>
goos: darwin
goarch: arm64
pkg: github.com/dunglas/frankenphp
BenchmarkEcho
BenchmarkEcho-8   	    3571	    330508 ns/op	    3404 B/op	      24 allocs/op
PASS
ok  	github.com/dunglas/frankenphp	1.916s
</pre>
</details>

Some string data are still copied from C to Go. I tried to avoid that by using `unsafe.StringData)(` but didn't manage to get something that works because it looks not possible to pin pointers returned by `unsafe.StringData()`