### PR TITLE
feat: Upgrade to PHP 8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ docker run -v $PWD:/app/public \
 Go to `https://localhost`, and enjoy!
 
 If you prefer not to use Docker, we provide standalone FrankenPHP binaries for Linux and macOS
-containing [PHP 8.2](https://www.php.net/releases/8.2/en.php) and most popular PHP extensions: [Download FrankenPHP](https://github.com/dunglas/frankenphp/releases)
+containing [PHP 8.3](https://www.php.net/releases/8.3/en.php) and most popular PHP extensions: [Download FrankenPHP](https://github.com/dunglas/frankenphp/releases)
 
 > Note: do not attempt to use `https://127.0.0.1`. Use `localhost` and accept the self-signed certificate. Caddy has an automatic TLS handling that auto-trusts some local-based hostnames like `localhost`, but it does not apply to IP addresses. More details [on Caddy's "automatic https" docs](https://caddyserver.com/docs/automatic-https#hostname-requirements).
 

--- a/dev-alpine.Dockerfile
+++ b/dev-alpine.Dockerfile
@@ -37,7 +37,7 @@ RUN apk add --no-cache \
     libtool && \
     echo 'set auto-load safe-path /' > /root/.gdbinit
 
-RUN git clone --branch=PHP-8.2 https://github.com/php/php-src.git && \
+RUN git clone --branch=PHP-8.3 https://github.com/php/php-src.git && \
     cd php-src && \
     # --enable-embed is only necessary to generate libphp.so, we don't use this SAPI directly
     ./buildconf --force && \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update && \
     && \
     apt-get clean 
 
-RUN git clone --branch=PHP-8.2 https://github.com/php/php-src.git && \
+RUN git clone --branch=PHP-8.3 https://github.com/php/php-src.git && \
     cd php-src && \
     # --enable-embed is only necessary to generate libphp.so, we don't use this SAPI directly
     ./buildconf --force && \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -24,9 +24,9 @@ function "tag" {
     params = [version, os, php-version, tgt]
     result = [
         version != "" ? format("%s:%s%s-php%s-%s", IMAGE_NAME, version, tgt == "builder" ? "-builder" : "", php-version, os) : "",
-        php-version == "8.2" && os == "bookworm"  && version != "" ? format("%s:%s%s", IMAGE_NAME, version, tgt == "builder" ? "-builder" : "") : "",
-        php-version == "8.2" && version != "" ? format("%s:%s%s-%s", IMAGE_NAME, version, tgt == "builder" ? "-builder" : "", os) : "",
-        php-version == "8.2" && version == "latest" ? format("%s:%s%s", IMAGE_NAME, os, tgt == "builder" ? "-builder" : "") : "",
+        php-version == "8.3" && os == "bookworm"  && version != "" ? format("%s:%s%s", IMAGE_NAME, version, tgt == "builder" ? "-builder" : "") : "",
+        php-version == "8.3" && version != "" ? format("%s:%s%s-%s", IMAGE_NAME, version, tgt == "builder" ? "-builder" : "", os) : "",
+        php-version == "8.3" && version == "latest" ? format("%s:%s%s", IMAGE_NAME, os, tgt == "builder" ? "-builder" : "") : "",
         os == "bookworm" && version != "" ? format("%s:%s%s-php%s", IMAGE_NAME, version, tgt == "builder" ? "-builder" : "", php-version) : "",
     ]
 }
@@ -59,7 +59,7 @@ target "default" {
     name = "${tgt}-php-${replace(php-version, ".", "-")}-${os}"
     matrix = {
         os = ["bookworm", "alpine"]
-        php-version = ["8.2", "8.3-rc"]
+        php-version = ["8.2", "8.3"]
         tgt = ["builder", "runner"]
     }
     contexts = {

--- a/static-builder.Dockerfile
+++ b/static-builder.Dockerfile
@@ -2,7 +2,7 @@
 FROM golang-base
 
 ARG FRANKENPHP_VERSION='dev'
-ARG PHP_VERSION='8.2'
+ARG PHP_VERSION='8.3'
 ARG PHP_EXTENSIONS='apcu,bcmath,bz2,calendar,ctype,curl,dba,dom,exif,fileinfo,filter,gd,iconv,intl,ldap,mbregex,mbstring,mysqli,mysqlnd,opcache,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sqlite3,sysvsem,tokenizer,xml,xmlreader,xmlwriter,zip,zlib'
 ARG PHP_EXTENSION_LIBS='freetype,libjpeg,libavif,libwebp,libzip,bzip2'
 
@@ -28,23 +28,26 @@ RUN apk update; \
         linux-headers \
         m4 \
         make \
-        php82 \
-        php82-common \
-        php82-curl \
-        php82-dom \
-        php82-mbstring \
-        php82-openssl \
-        php82-pcntl \
-        php82-phar \
-        php82-posix \
-        php82-sodium \
-        php82-tokenizer \
-        php82-xml \
-        php82-xmlwriter \
         pkgconfig \
         wget \
         xz ; \
-    ln -sf /usr/bin/php82 /usr/bin/php
+    apk add --no-cache \
+    	--repository=https://dl-cdn.alpinelinux.org/alpine/edge/main \
+    	--repository=https://dl-cdn.alpinelinux.org/alpine/edge/community \
+        php83 \
+        php83-common \
+        php83-curl \
+        php83-dom \
+        php83-mbstring \
+        php83-openssl \
+        php83-pcntl \
+        php83-phar \
+        php83-posix \
+        php83-sodium \
+        php83-tokenizer \
+        php83-xml \
+        php83-xmlwriter; \
+    ln -sf /usr/bin/php83 /usr/bin/php
 
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
 ENV COMPOSER_ALLOW_SUPERUSER=1


### PR DESCRIPTION
PHP 8.3 was released (https://www.php.net/downloads.php#v8.3.0) so we can now upgrade. This pull request upgrades PHP 8.3-rc to 8.3 stable, and sets 8.3 as the default (`dunglas/frankenphp:latest` now refer 8.3). Also upgrades to 8.3 in dev builds.

Note that this PR depends on the official base image updates (https://github.com/docker-library/php/pull/1464).