### PR TITLE
docs: Caddyfile config adjustments

### DIFF
--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -27,6 +27,8 @@ Alternatively, you can run your Laravel projects with FrankenPHP from your local
 
     # The domain name of your server
     localhost {
+        # Set the webroot to the public/ dir
+        root * public/
         # Enable compression (optional)
         encode zstd gzip
         # Execute PHP files in the current directory and serve assets


### PR DESCRIPTION
Some wording adjustments and correctness fixes:

- "directives" are specifically things within site blocks. Global options are not directives.
- `*` is still needed for the `root` directive for now
- the worker script example was missing `php_server` which was misleading because it wouldn't do anything without it.
- technically, the `php_server` long-form includes a `route` wrapper which guarantees the directive order stays as written.