### PR TITLE
ci: add Docker tags containing the minor and major PHP version

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -33,18 +33,18 @@ jobs:
         id: matrix
         run: |
           # Fetch latest versions of PHP
-          skopeo inspect docker://docker.io/library/php:8.2 --override-os linux --override-arch amd64 | jq -r '.Env.[] | select(test("^PHP_VERSION=")) | sub("^PHP_VERSION="; "")'
-        #PHP_82_LATEST=$(skopeo inspect docker://docker.io/library/php:8.2 --override-os linux --override-arch amd64 | jq -r '.Env.[] | select(test("^PHP_VERSION=")) | sub("^PHP_VERSION="; "")')
-        #PHP_83_LATEST=$(skopeo inspect docker://docker.io/library/php:8.3 --override-os linux --override-arch amd64 | jq -r '.Env.[] | select(test("^PHP_VERSION=")) | sub("^PHP_VERSION="; "")')
-        #export PHP_VERSION="${PHP_83_LATEST},${PHP_82_LATEST}"
-#
-        #METADATA="$(docker buildx bake --print | jq -c)"
-#
-        #{
-        #  echo metadata="$METADATA"
-        #  echo variants="$(jq -c '.group.default.targets|map(sub("runner-|builder-"; ""))|unique' <<< "$METADATA")"
-        #  echo platforms="$(jq -c 'first(.target[]) | .platforms' <<< "$METADATA")"
-        #} >> "$GITHUB_OUTPUT"
+          skopeo inspect docker://docker.io/library/php:8.2 --override-os linux --override-arch amd64 | jq -r '.Env[] | select(test("^PHP_VERSION=")) | sub("^PHP_VERSION="; "")'
+          PHP_82_LATEST=$(skopeo inspect docker://docker.io/library/php:8.2 --override-os linux --override-arch amd64 | jq -r '.Env[] | select(test("^PHP_VERSION=")) | sub("^PHP_VERSION="; "")')
+          PHP_83_LATEST=$(skopeo inspect docker://docker.io/library/php:8.3 --override-os linux --override-arch amd64 | jq -r '.Env[] | select(test("^PHP_VERSION=")) | sub("^PHP_VERSION="; "")')
+          export PHP_VERSION="${PHP_83_LATEST},${PHP_82_LATEST}"
+
+          METADATA="$(docker buildx bake --print | jq -c)"
+
+          {
+            echo metadata="$METADATA"
+            echo variants="$(jq -c '.group.default.targets|map(sub("runner-|builder-"; ""))|unique' <<< "$METADATA")"
+            echo platforms="$(jq -c 'first(.target[]) | .platforms' <<< "$METADATA")"
+          } >> "$GITHUB_OUTPUT"
         env:
           SHA: ${{github.sha}}
           VERSION: ${{github.ref_type == 'tag' && github.ref_name || github.sha}}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -32,7 +32,13 @@ jobs:
         name: Create variants matrix
         id: matrix
         run: |
+          # Fetch latest versions of PHP
+          PHP_82_LATEST=$(skopeo inspect docker://docker.io/library/php:8.2 --override-os linux --override-arch amd64 | jq -r '.Env.[] | select(test("^PHP_VERSION=")) | sub("^PHP_VERSION="; "")')
+          PHP_83_LATEST=$(skopeo inspect docker://docker.io/library/php:8.3 --override-os linux --override-arch amd64 | jq -r '.Env.[] | select(test("^PHP_VERSION=")) | sub("^PHP_VERSION="; "")')
+
+          PHP_VERSION="$PHP_82_LATEST,$PHP_83_LATEST" >> "$GITHUB_OUTPUT"
           METADATA="$(docker buildx bake --print | jq -c)"
+
           {
             echo metadata="$METADATA"
             echo variants="$(jq -c '.group.default.targets|map(sub("runner-|builder-"; ""))|unique' <<< "$METADATA")"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -127,7 +127,7 @@ jobs:
         env:
           METADATA: ${{ steps.build.outputs.metadata }}
       -
-        name: Upload runner metadata
+        name: Upload builder metadata
         if: fromJson(needs.prepare.outputs.push)
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -33,6 +33,8 @@ jobs:
         id: matrix
         run: |
           # Fetch latest versions of PHP
+          skopeo inspect docker://docker.io/library/php:8.2 --override-os linux --override-arch amd64
+          skopeo inspect docker://docker.io/library/php:8.3 --override-os linux --override-arch amd64
           PHP_82_LATEST=$(skopeo inspect docker://docker.io/library/php:8.2 --override-os linux --override-arch amd64 | jq -r '.Env.[] | select(test("^PHP_VERSION=")) | sub("^PHP_VERSION="; "")')
           PHP_83_LATEST=$(skopeo inspect docker://docker.io/library/php:8.3 --override-os linux --override-arch amd64 | jq -r '.Env.[] | select(test("^PHP_VERSION=")) | sub("^PHP_VERSION="; "")')
           export PHP_VERSION="${PHP_83_LATEST},${PHP_82_LATEST}"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -33,8 +33,7 @@ jobs:
         id: matrix
         run: |
           # Fetch latest versions of PHP
-          skopeo inspect docker://docker.io/library/php:8.2 --override-os linux --override-arch amd64
-          skopeo inspect docker://docker.io/library/php:8.3 --override-os linux --override-arch amd64
+          skopeo inspect docker://docker.io/library/php:8.2 --override-os linux --override-arch amd64 | jq -r '.Env.[]'
           PHP_82_LATEST=$(skopeo inspect docker://docker.io/library/php:8.2 --override-os linux --override-arch amd64 | jq -r '.Env.[] | select(test("^PHP_VERSION=")) | sub("^PHP_VERSION="; "")')
           PHP_83_LATEST=$(skopeo inspect docker://docker.io/library/php:8.3 --override-os linux --override-arch amd64 | jq -r '.Env.[] | select(test("^PHP_VERSION=")) | sub("^PHP_VERSION="; "")')
           export PHP_VERSION="${PHP_83_LATEST},${PHP_82_LATEST}"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -16,10 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       # Push only if it's a tag or if we're committing in the main branch
-      push: ${{toJson(startsWith(github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main' && github.event_name != 'pull_request'))}}
+      push: ${{ toJson(startsWith(github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main' && github.event_name != 'pull_request')) }}
       variants: ${{ steps.matrix.outputs.variants }}
       platforms: ${{ steps.matrix.outputs.platforms }}
       metadata: ${{ steps.matrix.outputs.metadata }}
+      php_version: ${{ steps.matrix.outputs.php_version }}
     steps:
       -
         uses: actions/checkout@v4
@@ -33,7 +34,6 @@ jobs:
         id: matrix
         run: |
           # Fetch latest versions of PHP
-          skopeo inspect docker://docker.io/library/php:8.2 --override-os linux --override-arch amd64 | jq -r '.Env[] | select(test("^PHP_VERSION=")) | sub("^PHP_VERSION="; "")'
           PHP_82_LATEST=$(skopeo inspect docker://docker.io/library/php:8.2 --override-os linux --override-arch amd64 | jq -r '.Env[] | select(test("^PHP_VERSION=")) | sub("^PHP_VERSION="; "")')
           PHP_83_LATEST=$(skopeo inspect docker://docker.io/library/php:8.3 --override-os linux --override-arch amd64 | jq -r '.Env[] | select(test("^PHP_VERSION=")) | sub("^PHP_VERSION="; "")')
           export PHP_VERSION="${PHP_83_LATEST},${PHP_82_LATEST}"
@@ -47,8 +47,8 @@ jobs:
             echo platforms="$(jq -c 'first(.target[]) | .platforms' <<< "$METADATA")"
           } >> "$GITHUB_OUTPUT"
         env:
-          SHA: ${{github.sha}}
-          VERSION: ${{github.ref_type == 'tag' && github.ref_name || github.sha}}
+          SHA: ${{ github.sha }}
+          VERSION: ${{ github.ref_type == 'tag' && github.ref_name || github.sha }}
   build:
     runs-on: ubuntu-latest
     needs:
@@ -74,42 +74,42 @@ jobs:
         if: matrix.qemu
         uses: docker/setup-qemu-action@v3
         with:
-          platforms: ${{matrix.platform}}
+          platforms: ${{ matrix.platform }}
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          platforms: ${{matrix.platform}}
+          platforms: ${{ matrix.platform }}
           version: latest
       -
         name: Login to DockerHub
         if: fromJson(needs.prepare.outputs.push)
         uses: docker/login-action@v3
         with:
-          username: ${{secrets.REGISTRY_USERNAME}}
-          password: ${{secrets.REGISTRY_PASSWORD}}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
       -
         name: Build
         id: build
         uses: docker/bake-action@v4
         with:
           pull: true
-          load: ${{!fromJson(needs.prepare.outputs.push)}}
+          load: ${{ !fromJson(needs.prepare.outputs.push) }}
           targets: |
-            builder-${{matrix.variant}}
-            runner-${{matrix.variant}}
+            builder-${{ matrix.variant }}
+            runner-${{ matrix.variant }}
           # Remove tags to prevent "can't push tagged ref [...] by digest" error
           set: |
             *.tags=
-            *.platform=${{matrix.platform}}
-            *.cache-from=type=gha,scope=${{github.ref}}-${{matrix.platform}}
-            *.cache-from=type=gha,scope=refs/heads/main-${{matrix.platform}}
-            *.cache-to=type=gha,scope=${{github.ref}}-${{matrix.platform}}
-            ${{fromJson(needs.prepare.outputs.push) && '*.output=type=image,name=dunglas/frankenphp,push-by-digest=true,name-canonical=true,push=true' || ''}}
+            *.platform=${{ matrix.platform }}
+            *.cache-from=type=gha,scope=${{ github.ref }}-${{ matrix.platform }}
+            *.cache-from=type=gha,scope=refs/heads/main-${{ matrix.platform }}
+            *.cache-to=type=gha,scope=${{ github.ref }}-${{ matrix.platform }}
+            ${{ fromJson(needs.prepare.outputs.push) && '*.output=type=image,name=dunglas/frankenphp,push-by-digest=true,name-canonical=true,push=true' || '' }}
         env:
-          SHA: ${{github.sha}}
-          VERSION: ${{github.ref_type == 'tag' && github.ref_name || github.sha}}
-          PHP_VERSION: ${{needs.prepare.outputs.php_version}}
+          SHA: ${{ github.sha }}
+          VERSION: ${{ github.ref_type == 'tag' && github.ref_name || github.sha }}
+          PHP_VERSION: ${{ needs.prepare.outputs.php_version }}
       -
         # Workaround for https://github.com/actions/runner/pull/2477#issuecomment-1501003600
         name: Export metadata
@@ -118,20 +118,20 @@ jobs:
           mkdir -p /tmp/metadata/builder /tmp/metadata/runner
 
           # shellcheck disable=SC2086
-          builderDigest=$(jq -r '."builder-${{matrix.variant}}"."containerimage.digest"' <<< $METADATA)
+          builderDigest=$(jq -r '."builder-${{ matrix.variant }}"."containerimage.digest"' <<< $METADATA)
           touch "/tmp/metadata/builder/${builderDigest#sha256:}"
 
           # shellcheck disable=SC2086
-          runnerDigest=$(jq -r '."runner-${{matrix.variant}}"."containerimage.digest"' <<< $METADATA)
+          runnerDigest=$(jq -r '."runner-${{ matrix.variant }}"."containerimage.digest"' <<< $METADATA)
           touch "/tmp/metadata/runner/${runnerDigest#sha256:}"
         env:
-          METADATA: ${{steps.build.outputs.metadata}}
+          METADATA: ${{ steps.build.outputs.metadata }}
       -
         name: Upload runner metadata
         if: fromJson(needs.prepare.outputs.push)
         uses: actions/upload-artifact@v3
         with:
-          name: metadata-builder-${{matrix.variant}}
+          name: metadata-builder-${{ matrix.variant }}
           path: /tmp/metadata/builder/*
           if-no-files-found: error
           retention-days: 1
@@ -140,20 +140,20 @@ jobs:
         if: fromJson(needs.prepare.outputs.push)
         uses: actions/upload-artifact@v3
         with:
-          name: metadata-runner-${{matrix.variant}}
+          name: metadata-runner-${{ matrix.variant }}
           path: /tmp/metadata/runner/*
           if-no-files-found: error
           retention-days: 1
       -
         name: Run tests
         if: '!matrix.qemu'
-        continue-on-error: ${{fromJson(needs.prepare.outputs.push)}}
+        continue-on-error: ${{ fromJson(needs.prepare.outputs.push) }}
         run: |
-          docker run --platform=${{matrix.platform}} --rm \
-            "$(jq -r '."builder-${{matrix.variant}}"."containerimage.config.digest"' <<< "$METADATA")" \
-            sh -c 'go test ${{matrix.race}} -v ./... && cd caddy && go test ${{matrix.race}} -v ./...'
+          docker run --platform=${{ matrix.platform }} --rm \
+            "$(jq -r '."builder-${{ matrix.variant }}"."containerimage.config.digest"' <<< "$METADATA")" \
+            sh -c 'go test ${{ matrix.race }} -v ./... && cd caddy && go test ${{ matrix.race }} -v ./...'
         env:
-          METADATA: ${{steps.build.outputs.metadata}}
+          METADATA: ${{ steps.build.outputs.metadata }}
   # Adapted from https://docs.docker.com/build/ci/github-actions/multi-platform/
   push:
     runs-on: ubuntu-latest    
@@ -171,7 +171,7 @@ jobs:
         name: Download metadata
         uses: actions/download-artifact@v3
         with:
-          name: metadata-${{matrix.target}}-${{matrix.variant}}
+          name: metadata-${{ matrix.target }}-${{ matrix.variant }}
           path: /tmp/metadata
       -
         name: Set up Docker Buildx
@@ -182,21 +182,21 @@ jobs:
         name: Login to DockerHub
         uses: docker/login-action@v3
         with:
-          username: ${{secrets.REGISTRY_USERNAME}}
-          password: ${{secrets.REGISTRY_PASSWORD}}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
       -
         name: Create manifest list and push
         working-directory: /tmp/metadata
         run: |
           # shellcheck disable=SC2046,SC2086
-          docker buildx imagetools create $(jq -cr '.target."${{matrix.target}}-${{matrix.variant}}".tags | map("-t " + .) | join(" ")' <<< $METADATA) \
+          docker buildx imagetools create $(jq -cr '.target."${{ matrix.target }}-${{ matrix.variant }}".tags | map("-t " + .) | join(" ")' <<< $METADATA) \
             $(printf 'dunglas/frankenphp@sha256:%s ' *)
         env:
-          METADATA: ${{needs.prepare.outputs.metadata}}
+          METADATA: ${{ needs.prepare.outputs.metadata }}
       -
         name: Inspect image
         run: |
           # shellcheck disable=SC2046,SC2086
-          docker buildx imagetools inspect $(jq -cr '.target."${{matrix.target}}-${{matrix.variant}}".tags | first' <<< $METADATA) 
+          docker buildx imagetools inspect $(jq -cr '.target."${{ matrix.target }}-${{ matrix.variant }}".tags | first' <<< $METADATA) 
         env:
-          METADATA: ${{needs.prepare.outputs.metadata}}
+          METADATA: ${{ needs.prepare.outputs.metadata }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -22,9 +22,6 @@ jobs:
       metadata: ${{ steps.matrix.outputs.metadata }}
     steps:
       -
-        name: 'Setup jq'
-        uses: dcarbone/install-jq-action@v2.1.0
-      -
         uses: actions/checkout@v4
       -
         name: Set up Docker Buildx
@@ -36,18 +33,18 @@ jobs:
         id: matrix
         run: |
           # Fetch latest versions of PHP
-          skopeo inspect docker://docker.io/library/php:8.2 --override-os linux --override-arch amd64 | jq -r '.Env.[]'
-          PHP_82_LATEST=$(skopeo inspect docker://docker.io/library/php:8.2 --override-os linux --override-arch amd64 | jq -r '.Env.[] | select(test("^PHP_VERSION=")) | sub("^PHP_VERSION="; "")')
-          PHP_83_LATEST=$(skopeo inspect docker://docker.io/library/php:8.3 --override-os linux --override-arch amd64 | jq -r '.Env.[] | select(test("^PHP_VERSION=")) | sub("^PHP_VERSION="; "")')
-          export PHP_VERSION="${PHP_83_LATEST},${PHP_82_LATEST}"
-
-          METADATA="$(docker buildx bake --print | jq -c)"
-
-          {
-            echo metadata="$METADATA"
-            echo variants="$(jq -c '.group.default.targets|map(sub("runner-|builder-"; ""))|unique' <<< "$METADATA")"
-            echo platforms="$(jq -c 'first(.target[]) | .platforms' <<< "$METADATA")"
-          } >> "$GITHUB_OUTPUT"
+          skopeo inspect docker://docker.io/library/php:8.2 --override-os linux --override-arch amd64 | jq -r '.Env.[] | select(test("^PHP_VERSION=")) | sub("^PHP_VERSION="; "")'
+        #PHP_82_LATEST=$(skopeo inspect docker://docker.io/library/php:8.2 --override-os linux --override-arch amd64 | jq -r '.Env.[] | select(test("^PHP_VERSION=")) | sub("^PHP_VERSION="; "")')
+        #PHP_83_LATEST=$(skopeo inspect docker://docker.io/library/php:8.3 --override-os linux --override-arch amd64 | jq -r '.Env.[] | select(test("^PHP_VERSION=")) | sub("^PHP_VERSION="; "")')
+        #export PHP_VERSION="${PHP_83_LATEST},${PHP_82_LATEST}"
+#
+        #METADATA="$(docker buildx bake --print | jq -c)"
+#
+        #{
+        #  echo metadata="$METADATA"
+        #  echo variants="$(jq -c '.group.default.targets|map(sub("runner-|builder-"; ""))|unique' <<< "$METADATA")"
+        #  echo platforms="$(jq -c 'first(.target[]) | .platforms' <<< "$METADATA")"
+        #} >> "$GITHUB_OUTPUT"
         env:
           SHA: ${{github.sha}}
           VERSION: ${{github.ref_type == 'tag' && github.ref_name || github.sha}}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -35,9 +35,9 @@ jobs:
           # Fetch latest versions of PHP
           PHP_82_LATEST=$(skopeo inspect docker://docker.io/library/php:8.2 --override-os linux --override-arch amd64 | jq -r '.Env.[] | select(test("^PHP_VERSION=")) | sub("^PHP_VERSION="; "")')
           PHP_83_LATEST=$(skopeo inspect docker://docker.io/library/php:8.3 --override-os linux --override-arch amd64 | jq -r '.Env.[] | select(test("^PHP_VERSION=")) | sub("^PHP_VERSION="; "")')
+          export PHP_VERSION="${PHP_83_LATEST},${PHP_82_LATEST}"
 
-          
-          METADATA="$(PHP_VERSION=$PHP_VERSION docker buildx bake --print | jq -c)"
+          METADATA="$(docker buildx bake --print | jq -c)"
 
           {
             echo metadata="$METADATA"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -36,8 +36,8 @@ jobs:
           PHP_82_LATEST=$(skopeo inspect docker://docker.io/library/php:8.2 --override-os linux --override-arch amd64 | jq -r '.Env.[] | select(test("^PHP_VERSION=")) | sub("^PHP_VERSION="; "")')
           PHP_83_LATEST=$(skopeo inspect docker://docker.io/library/php:8.3 --override-os linux --override-arch amd64 | jq -r '.Env.[] | select(test("^PHP_VERSION=")) | sub("^PHP_VERSION="; "")')
 
-          PHP_VERSION="$PHP_82_LATEST,$PHP_83_LATEST" >> "$GITHUB_OUTPUT"
-          METADATA="$(docker buildx bake --print | jq -c)"
+          
+          METADATA="$(PHP_VERSION=$PHP_VERSION docker buildx bake --print | jq -c)"
 
           {
             echo metadata="$METADATA"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       -
         name: 'Setup jq'
-        uses: dcarbone/install-jq-action@v2
+        uses: dcarbone/install-jq-action@v2.1.0
       -
         uses: actions/checkout@v4
       -

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -22,6 +22,9 @@ jobs:
       metadata: ${{ steps.matrix.outputs.metadata }}
     steps:
       -
+        name: 'Setup jq'
+        uses: dcarbone/install-jq-action@v2
+      -
         uses: actions/checkout@v4
       -
         name: Set up Docker Buildx

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -41,6 +41,7 @@ jobs:
           METADATA="$(docker buildx bake --print | jq -c)"
 
           {
+            echo php_version="$PHP_VERSION"
             echo metadata="$METADATA"
             echo variants="$(jq -c '.group.default.targets|map(sub("runner-|builder-"; ""))|unique' <<< "$METADATA")"
             echo platforms="$(jq -c 'first(.target[]) | .platforms' <<< "$METADATA")"
@@ -108,6 +109,7 @@ jobs:
         env:
           SHA: ${{github.sha}}
           VERSION: ${{github.ref_type == 'tag' && github.ref_name || github.sha}}
+          PHP_VERSION: ${{needs.prepare.outputs.php_version}}
       -
         # Workaround for https://github.com/actions/runner/pull/2477#issuecomment-1501003600
         name: Export metadata


### PR DESCRIPTION
This patch improves Docker tags.
It allows using specific FrankenPHP versions with specific PHP versions, such as `dunglas/frankenphp:1.0.0-php8.3.1-bookworm`