### PR TITLE
PIE mode tests with fibers

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -92,7 +92,6 @@ jobs:
             qemu: true
           - platform: linux/amd64
             qemu: false
-            race: "-race" # The Go race detector is only supported on amd64
           - platform: linux/386
             qemu: false
     steps:
@@ -182,7 +181,7 @@ jobs:
         run: |
           docker run --platform=${{ matrix.platform }} --rm \
             "$(jq -r '."builder-${{ matrix.variant }}"."containerimage.config.digest"' <<< "${METADATA}")" \
-            sh -c 'go test ${{ matrix.race }} -v ./... && cd caddy && go test ${{ matrix.race }} -v ./...'
+            sh -c ' go test -buildmode=pie -v ./... && cd caddy && go test -buildmode=pie -v ./...'
         env:
           METADATA: ${{ steps.build.outputs.metadata }}
   # Adapted from https://docs.docker.com/build/ci/github-actions/multi-platform/

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -181,7 +181,7 @@ jobs:
         run: |
           docker run --platform=${{ matrix.platform }} --rm \
             "$(jq -r '."builder-${{ matrix.variant }}"."containerimage.config.digest"' <<< "${METADATA}")" \
-            sh -c ' go test -buildmode=pie -v ./... && cd caddy && go test -buildmode=pie -v ./...'
+            sh -c 'CGO_CXXFLAGS=-fPIE CGO_CFLAGS=-fPIE CGO_LDFLAGS=-pie go test -buildmode=pie -v ./... && cd caddy && go test -buildmode=pie -v ./...'
         env:
           METADATA: ${{ steps.build.outputs.metadata }}
   # Adapted from https://docs.docker.com/build/ci/github-actions/multi-platform/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,11 +48,11 @@ jobs:
         run: go build
       -
         name: Run library tests
-        run: go test -race -v ./...
+        run: CGO_CXXFLAGS=-fPIE CGO_CFLAGS=-fPIE CGO_LDFLAGS=-pie go test -buildmode=pie -v ./...
       -
         name: Run Caddy module tests
         working-directory: caddy/
-        run: go test -race -v ./...
+        run: CGO_CXXFLAGS=-fPIE CGO_CFLAGS=-fPIE CGO_LDFLAGS=-pie go test -buildmode=pie -v ./...
       -
         name: Lint Go code
         uses: golangci/golangci-lint-action@v3

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -503,6 +503,23 @@ func testFlush(t *testing.T, opts *testOptions) {
 	}, opts)
 }
 
+func TestFiberBasic_module(t *testing.T) { testFiberBasic(t, &testOptions{}) }
+func TestFiberBasic_worker(t *testing.T) {
+	testFiberBasic(t, &testOptions{workerScript: "fiber-basic.php"})
+}
+func testFiberBasic(t *testing.T, opts *testOptions) {
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, i int) {
+		req := httptest.NewRequest("GET", fmt.Sprintf("http://example.com/fiber-basic.php?i=%d", i), nil)
+		w := httptest.NewRecorder()
+		handler(w, req)
+
+		resp := w.Result()
+		body, _ := io.ReadAll(resp.Body)
+
+		assert.Equal(t, string(body), fmt.Sprintf("Fiber %d", i))
+	}, opts)
+}
+
 func TestLargeRequest_module(t *testing.T) {
 	testLargeRequest(t, &testOptions{})
 }

--- a/testdata/fiber-basic.php
+++ b/testdata/fiber-basic.php
@@ -1,0 +1,9 @@
+<?php
+require_once __DIR__.'/_executor.php';
+
+return function() {
+    $fiber = new Fiber(function() {
+        echo 'Fiber '.($_GET['i'] ?? '');
+    });
+    $fiber->start();
+};


### PR DESCRIPTION
Running `CGO_CXXFLAGS=-fPIE CGO_CFLAGS=-fPIE CGO_LDFLAGS=-pie go test -buildmode=pie -v ./...` (`-race` is not compatible with `pie`) appears to be passing tests on x64 (local). Opening this PR to have it test all other architectures as well.

I have no idea why this works and it might be an excellent question for [golang/go/#62130](https://github.com/golang/go/issues/62130) to see if it is actually working or just pretending to work by somehow making a larger stack that just so happens to pass the test.

Continuation of #99, #171. Closes #46, closes #99, closes #171.