### PR TITLE
Introduce debug symbols flag for static build

### DIFF
--- a/build-static.sh
+++ b/build-static.sh
@@ -86,6 +86,10 @@ else
         extraOpts="--disable-opcache-jit"
     fi
 
+    if [ -n "${DEBUG_SYMBOLS}" ]; then
+        extraOpts="${extraOpts} --no-strip"
+    fi
+
     ./bin/spc doctor
     ./bin/spc fetch --with-php="${PHP_VERSION}" --for-extensions="${PHP_EXTENSIONS}"
     # shellcheck disable=SC2086
@@ -116,9 +120,13 @@ if [ "${os}" = "linux" ]; then
     extraExtldflags="-Wl,-z,stack-size=0x80000"
 fi
 
+if [ -z "${DEBUG_SYMBOLS}" ]; then
+    extraLdflags="-w -s"
+fi
+
 cd caddy/frankenphp/
 go env
-go build -buildmode=pie -tags "cgo netgo osusergo static_build" -ldflags "-linkmode=external -extldflags '-static-pie ${extraExtldflags}' -w -s -X 'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP ${FRANKENPHP_VERSION} PHP ${LIBPHP_VERSION} Caddy'" -o "../../dist/${bin}"
+go build -buildmode=pie -tags "cgo netgo osusergo static_build" -ldflags "-linkmode=external -extldflags '-static-pie ${extraExtldflags}' ${extraLdflags} -X 'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP ${FRANKENPHP_VERSION} PHP ${LIBPHP_VERSION} Caddy'" -o "../../dist/${bin}"
 cd ../..
 
 if [ -d "${EMBED}" ]; then

--- a/docs/static.md
+++ b/docs/static.md
@@ -77,4 +77,5 @@ script to customize the static build:
 * `PHP_EXTENSION_LIBS`: extra libraries to build that add extra features to the extensions
 * `EMBED`: path of the PHP application to embed in the binary
 * `CLEAN`: when set, libphp and all its dependencies are built from scratch (no cache)
+* `DEBUG_SYMBOLS`: when set, debug-symbols will not be stripped and will be added within the binary
 * `RELEASE`: (maintainers only) when set, the resulting binary will be uploaded on GitHub


### PR DESCRIPTION
I had some isolated issue where PHP throwed a segmentation error when using pdo_pgsql on a few servers.
pgtls_close was the culprit, and i temporariliy fixed the issue by adding a sslmode=disable.

Before knowing this, i needed to have a build with debug symbols enabled to investigate the situation.

I think it's a nice feature to enable a "debug-build" with an environment variable like 'DEBUG_SYMBOLS'.