### PR TITLE
Revert "ci: upgrade upload-artifact action"

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -200,7 +200,7 @@ jobs:
     steps:
       -
         name: Download metadata
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: metadata-${{ matrix.target }}-${{ matrix.variant }}
           path: /tmp/metadata

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -160,7 +160,7 @@ jobs:
       -
         name: Upload builder metadata
         if: fromJson(needs.prepare.outputs.push)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: metadata-builder-${{ matrix.variant }}
           path: /tmp/metadata/builder/*
@@ -169,7 +169,7 @@ jobs:
       -
         name: Upload runner metadata
         if: fromJson(needs.prepare.outputs.push)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: metadata-runner-${{ matrix.variant }}
           path: /tmp/metadata/runner/*

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -96,9 +96,8 @@ jobs:
       -
         name: Upload artifact
         if: github.ref_type == 'branch'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
-          name: frankenphp-linux-x86_64
           path: frankenphp-linux-x86_64
   build-mac:
     name: Build macOS x86_64 binaries
@@ -150,7 +149,6 @@ jobs:
       -
         name: Upload artifact
         if: github.ref_type == 'branch'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
-          name: frankenphp-mac-x86_64
           path: dist/frankenphp-mac-x86_64

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -98,6 +98,7 @@ jobs:
         if: github.ref_type == 'branch'
         uses: actions/upload-artifact@v3
         with:
+          name: frankenphp-linux-x86_64
           path: frankenphp-linux-x86_64
   build-mac:
     name: Build macOS x86_64 binaries
@@ -151,4 +152,5 @@ jobs:
         if: github.ref_type == 'branch'
         uses: actions/upload-artifact@v3
         with:
+          name: frankenphp-mac-x86_64
           path: dist/frankenphp-mac-x86_64


### PR DESCRIPTION
Artifact V2 isn't compatible with how we use it:

> Due to how Artifacts are created in this new version, it is no longer possible to upload to the same named Artifact multiple times. You must either split the uploads into multiple Artifacts with different names, or only upload once.

https://github.com/actions/toolkit/tree/main/packages/artifact#breaking-changes