### PR TITLE
Add ctype and session PHP extensions to static builder

### DIFF
--- a/static-builder.Dockerfile
+++ b/static-builder.Dockerfile
@@ -54,6 +54,7 @@ RUN apk update; \
     	--repository=https://dl-cdn.alpinelinux.org/alpine/edge/community \
         php83 \
         php83-common \
+        php83-ctype \
         php83-curl \
         php83-dom \
         php83-mbstring \
@@ -61,6 +62,7 @@ RUN apk update; \
         php83-pcntl \
         php83-phar \
         php83-posix \
+        php83-session \
         php83-sodium \
         php83-tokenizer \
         php83-xml \


### PR DESCRIPTION
Hi!

I just tried the Symfony demo here and it seems somewhat broken:

```
➜  workspace git clone git@github.com:dunglas/frankenphp-demo.git
Cloning into 'frankenphp-demo'...
...
➜  workspace cd frankenphp-demo 
➜  frankenphp-demo git:(main) docker run --rm -it -v $PWD:/app composer:latest install
...
Executing script cache:clear [OK]
Executing script assets:install public [OK]

➜  frankenphp-demo git:(main) docker build -t static-app -f static-build.Dockerfile .
[+] Building 4.3s (8/10)                                                                                                                                                                                                       docker:default
 => [internal] load .dockerignore                                                                                                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                                                                                                          0.0s
 => [internal] load build definition from static-build.Dockerfile                                                                                                                                                                        0.0s
 => => transferring dockerfile: 531B                                                                                                                                                                                                     0.0s
 => [internal] load metadata for docker.io/dunglas/frankenphp:static-builder                                                                                                                                                             0.0s
 => [1/6] FROM docker.io/dunglas/frankenphp:static-builder                                                                                                                                                                               0.0s
 => [internal] load build context                                                                                                                                                                                                        0.8s
 => => transferring context: 58.32MB                                                                                                                                                                                                     0.8s
 => CACHED [2/6] WORKDIR /go/src/app/dist/app                                                                                                                                                                                            0.0s
 => [3/6] COPY . .                                                                                                                                                                                                                       1.2s
 => ERROR [4/6] RUN echo APP_ENV=prod > .env.local ;     echo APP_DEBUG=0 >> .env.local ;     composer install --ignore-platform-reqs --no-dev -a ;     composer dump-env prod                                                           2.2s
------                                                                                                                                                                                                                                        
 > [4/6] RUN echo APP_ENV=prod > .env.local ;     echo APP_DEBUG=0 >> .env.local ;     composer install --ignore-platform-reqs --no-dev -a ;     composer dump-env prod:                                                                      
0.293 Installing dependencies from lock file                                                                                                                                                                                                  
0.295 Verifying lock file contents can be installed on current platform.                                                                                                                                                                      
0.401 Package operations: 0 installs, 0 updates, 5 removals                                                                                                                                                                                   
0.402   - Removing symfony/web-profiler-bundle (v6.3.6)                                                                                                                                                                                       
0.402   - Removing symfony/process (v6.3.4)
0.403   - Removing symfony/maker-bundle (v1.51.1)
0.403   - Removing symfony/debug-bundle (v6.3.2)
0.403   - Removing nikic/php-parser (v4.17.1)
0.411  0/5 [>---------------------------]   0%
0.452  5/5 [============================] 100%
0.461 Generating optimized autoload files
2.087 65 packages you are using are looking for funding.
2.087 Use the `composer fund` command to find out more!
2.089 
2.089 Run composer recipes at any time to see the status of your Symfony recipes.
2.089 
2.093 Executing script cache:clear [KO]
2.172  [KO]
2.172 Script cache:clear returned with error code 255
2.172 !!  PHP Fatal error:  Uncaught Error: Call to undefined function Symfony\Component\Yaml\ctype_digit() in /go/src/app/dist/app/vendor/symfony/yaml/Inline.php:694
2.172 !!  Stack trace:
2.172 !!  #0 /go/src/app/dist/app/vendor/symfony/yaml/Inline.php(312): Symfony\Component\Yaml\Inline::evaluateScalar()
2.172 !!  #1 /go/src/app/dist/app/vendor/symfony/yaml/Inline.php(80): Symfony\Component\Yaml\Inline::parseScalar()
2.172 !!  #2 /go/src/app/dist/app/vendor/symfony/yaml/Parser.php(791): Symfony\Component\Yaml\Inline::parse()
2.172 !!  #3 /go/src/app/dist/app/vendor/symfony/yaml/Parser.php(342): Symfony\Component\Yaml\Parser->parseValue()
2.172 !!  #4 /go/src/app/dist/app/vendor/symfony/yaml/Parser.php(525): Symfony\Component\Yaml\Parser->doParse()
2.172 !!  #5 /go/src/app/dist/app/vendor/symfony/yaml/Parser.php(320): Symfony\Component\Yaml\Parser->parseBlock()
2.172 !!  #6 /go/src/app/dist/app/vendor/symfony/yaml/Parser.php(86): Symfony\Component\Yaml\Parser->doParse()
2.172 !!  #7 /go/src/app/dist/app/vendor/symfony/yaml/Parser.php(63): Symfony\Component\Yaml\Parser->parse()
2.172 !!  #8 /go/src/app/dist/app/vendor/symfony/dependency-injection/Loader/YamlFileLoader.php(778): Symfony\Component\Yaml\Parser->parseFile()
2.172 !!  #9 /go/src/app/dist/app/vendor/symfony/dependency-injection/Loader/YamlFileLoader.php(124): Symfony\Component\DependencyInjection\Loader\YamlFileLoader->loadFile()
2.172 !!  #10 /go/src/app/dist/app/vendor/symfony/config/Loader/FileLoader.php(167): Symfony\Component\DependencyInjection\Loader\YamlFileLoader->load()
2.172 !!  #11 /go/src/app/dist/app/vendor/symfony/config/Loader/FileLoader.php(87): Symfony\Component\Config\Loader\FileLoader->doImport()
2.172 !!  #12 /go/src/app/dist/app/vendor/symfony/dependency-injection/Loader/FileLoader.php(70): Symfony\Component\Config\Loader\FileLoader->import()
2.172 !!  #13 /go/src/app/dist/app/vendor/symfony/dependency-injection/Loader/Configurator/ContainerConfigurator.php(64): Symfony\Component\DependencyInjection\Loader\FileLoader->import()
2.172 !!  #14 /go/src/app/dist/app/vendor/symfony/framework-bundle/Kernel/MicroKernelTrait.php(53): Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator->import()
2.172 !!  #15 /go/src/app/dist/app/vendor/symfony/framework-bundle/Kernel/MicroKernelTrait.php(180): App\Kernel->configureContainer()
2.172 !!  #16 /go/src/app/dist/app/vendor/symfony/dependency-injection/Loader/ClosureLoader.php(36): App\Kernel->Symfony\Bundle\FrameworkBundle\Kernel\{closure}()
2.172 !!  #17 /go/src/app/dist/app/vendor/symfony/config/Loader/DelegatingLoader.php(37): Symfony\Component\DependencyInjection\Loader\ClosureLoader->load()
2.172 !!  #18 /go/src/app/dist/app/vendor/symfony/framework-bundle/Kernel/MicroKernelTrait.php(136): Symfony\Component\Config\Loader\DelegatingLoader->load()
2.172 !!  #19 /go/src/app/dist/app/vendor/symfony/http-kernel/Kernel.php(604): App\Kernel->registerContainerConfiguration()
2.172 !!  #20 /go/src/app/dist/app/vendor/symfony/http-kernel/Kernel.php(505): Symfony\Component\HttpKernel\Kernel->buildContainer()
2.172 !!  #21 /go/src/app/dist/app/vendor/symfony/http-kernel/Kernel.php(757): Symfony\Component\HttpKernel\Kernel->initializeContainer()
2.172 !!  #22 /go/src/app/dist/app/vendor/symfony/http-kernel/Kernel.php(126): Symfony\Component\HttpKernel\Kernel->preBoot()
2.172 !!  #23 /go/src/app/dist/app/vendor/symfony/framework-bundle/Console/Application.php(154): Symfony\Component\HttpKernel\Kernel->boot()
2.172 !!  #24 /go/src/app/dist/app/vendor/symfony/framework-bundle/Console/Application.php(72): Symfony\Bundle\FrameworkBundle\Console\Application->registerCommands()
2.172 !!  #25 /go/src/app/dist/app/vendor/symfony/console/Application.php(174): Symfony\Bundle\FrameworkBundle\Console\Application->doRun()
2.172 !!  #26 /go/src/app/dist/app/vendor/symfony/runtime/Runner/Symfony/ConsoleApplicationRunner.php(54): Symfony\Component\Console\Application->run()
2.172 !!  #27 /go/src/app/dist/app/vendor/autoload_runtime.php(29): Symfony\Component\Runtime\Runner\Symfony\ConsoleApplicationRunner->run()
2.172 !!  #28 /go/src/app/dist/app/bin/console(11): require_once('...')
2.172 !!  #29 {main}
2.172 !!    thrown in /go/src/app/dist/app/vendor/symfony/yaml/Inline.php on line 694
2.172 !!  
2.172 Script @auto-scripts was called via post-install-cmd
------
static-build.Dockerfile:6
--------------------
   5 |     COPY . .
   6 | >>> RUN echo APP_ENV=prod > .env.local ; \
   7 | >>>     echo APP_DEBUG=0 >> .env.local ; \
   8 | >>>     composer install --ignore-platform-reqs --no-dev -a ; \
   9 | >>>     composer dump-env prod
  10 |     
--------------------
ERROR: failed to solve: process "/bin/ash -eo pipefail -c echo APP_ENV=prod > .env.local ;     echo APP_DEBUG=0 >> .env.local ;     composer install --ignore-platform-reqs --no-dev -a ;     composer dump-env prod" did not complete successfully: exit code: 255
➜  frankenphp-demo git:(main) 

```

I've added `RUN apk add --no-cache php83-ctype php83-session` to the demo's Dockerfile and it seems to fix the build, but I believe this is the right place for this fix.

PS: thank you for frankenphp! I have a few use-cases that weren't possible without this, I hope I have the time to make them work now :D

Thank you.