### PR TITLE
Fix memory leak

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -709,12 +709,23 @@ func ExecuteScriptCLI(script string, args []string) int {
 	cScript := C.CString(script)
 	defer C.free(unsafe.Pointer(cScript))
 
+	argc, argv := convertArgs(args)
+	defer freeArgs(argv)
+
+	return int(C.frankenphp_execute_script_cli(cScript, argc, (**C.char)(unsafe.Pointer(&argv[0]))))
+}
+
+func convertArgs(args []string) (C.int, []*C.char) {
 	argc := C.int(len(args))
 	argv := make([]*C.char, argc)
 	for i, arg := range args {
 		argv[i] = C.CString(arg)
-		defer C.free(unsafe.Pointer(argv[i]))
 	}
+	return argc, argv
+}
 
-	return int(C.frankenphp_execute_script_cli(cScript, argc, (**C.char)(unsafe.Pointer(&argv[0]))))
+func freeArgs(argv []*C.char) {
+	for _, arg := range argv {
+		C.free(unsafe.Pointer(arg))
+	}
 }

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -465,6 +465,8 @@ func ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) error 
 		<-fc.done
 	}
 
+	request.Context().Value(handleKey).(*handleList).FreeAll()
+
 	return nil
 }
 

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -191,7 +191,7 @@ func NewRequestWithContext(r *http.Request, opts ...RequestOption) (*http.Reques
 	// SCRIPT_FILENAME is the absolute path of SCRIPT_NAME
 	fc.scriptFilename = sanitizedPathJoin(fc.documentRoot, fc.scriptName)
 
-	return r.WithContext(context.WithValue(r.Context(), contextKey, fc)), nil
+	return r.WithContext(context.WithValue(context.Background(), contextKey, fc)), nil
 }
 
 // FromContext extracts the FrankenPHPContext from a context.

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -408,11 +408,11 @@ func updateServerContext(request *http.Request, create bool, mrh C.uintptr_t) er
 	var rh cgo.Handle
 	if fc.responseWriter == nil {
 		h := cgo.NewHandle(request)
-		request.Context().Value(handleKey).(*HandleList).AddHandle(h)
+		request.Context().Value(handleKey).(*handleList).AddHandle(h)
 		mrh = C.uintptr_t(h)
 	} else {
 		rh = cgo.NewHandle(request)
-		request.Context().Value(handleKey).(*HandleList).AddHandle(rh)
+		request.Context().Value(handleKey).(*handleList).AddHandle(rh)
 	}
 
 	ret := C.frankenphp_update_server_context(
@@ -476,7 +476,7 @@ func go_fetch_request() C.uintptr_t {
 
 	case r := <-requestChan:
 		h := cgo.NewHandle(r)
-		r.Context().Value(handleKey).(*HandleList).AddHandle(h)
+		r.Context().Value(handleKey).(*handleList).AddHandle(h)
 		return C.uintptr_t(h)
 	}
 }

--- a/smartpointer.go
+++ b/smartpointer.go
@@ -59,6 +59,6 @@ func Pointers() *pointerList {
 // Handles Get a new list of handles
 func Handles() *handleList {
 	return &handleList{
-		Handles: make([]cgo.Handle, 0),
+		Handles: make([]cgo.Handle, 6),
 	}
 }

--- a/smartpointer.go
+++ b/smartpointer.go
@@ -15,27 +15,27 @@ and ensure they are always cleaned up.
 */
 
 // PointerList A list of pointers that can be freed at a later time
-type PointerList struct {
+type pointerList struct {
 	Pointers []unsafe.Pointer
 }
 
 // HandleList A list of pointers that can be freed at a later time
-type HandleList struct {
+type handleList struct {
 	Handles []cgo.Handle
 }
 
 // AddHandle Call when registering a handle for the very first time
-func (h *HandleList) AddHandle(handle cgo.Handle) {
+func (h *handleList) AddHandle(handle cgo.Handle) {
 	h.Handles = append(h.Handles, handle)
 }
 
 // AddPointer Call when creating a request-level C pointer for the very first time
-func (p *PointerList) AddPointer(ptr unsafe.Pointer) {
+func (p *pointerList) AddPointer(ptr unsafe.Pointer) {
 	p.Pointers = append(p.Pointers, ptr)
 }
 
 // FreeAll frees all C pointers
-func (p *PointerList) FreeAll() {
+func (p *pointerList) FreeAll() {
 	for _, ptr := range p.Pointers {
 		C.free(ptr)
 	}
@@ -43,7 +43,7 @@ func (p *PointerList) FreeAll() {
 }
 
 // FreeAll frees all handles
-func (h *HandleList) FreeAll() {
+func (h *handleList) FreeAll() {
 	defer func() {
 		if err := recover(); err != nil {
 			getLogger().Warn("A handle was already deleted manually, indeterminate state")
@@ -55,15 +55,15 @@ func (h *HandleList) FreeAll() {
 }
 
 // Pointers Get a new list of pointers
-func Pointers() *PointerList {
-	return &PointerList{
+func Pointers() *pointerList {
+	return &pointerList{
 		Pointers: make([]unsafe.Pointer, 0),
 	}
 }
 
 // Handles Get a new list of handles
-func Handles() *HandleList {
-	return &HandleList{
+func Handles() *handleList {
+	return &handleList{
 		Handles: make([]cgo.Handle, 0),
 	}
 }

--- a/smartpointer.go
+++ b/smartpointer.go
@@ -1,0 +1,69 @@
+package frankenphp
+
+// #include <stdlib.h>
+import "C"
+import (
+	"runtime/cgo"
+	"unsafe"
+)
+
+/*
+FrankenPHP is fairly complex because it shuffles handles/requests/contexts
+between C and Go. This simplifies the lifecycle management of per-request
+structures by allowing us to hold references until the end of the request
+and ensure they are always cleaned up.
+*/
+
+// PointerList A list of pointers that can be freed at a later time
+type PointerList struct {
+	Pointers []unsafe.Pointer
+}
+
+// HandleList A list of pointers that can be freed at a later time
+type HandleList struct {
+	Handles []cgo.Handle
+}
+
+// AddHandle Call when registering a handle for the very first time
+func (h *HandleList) AddHandle(handle cgo.Handle) {
+	h.Handles = append(h.Handles, handle)
+}
+
+// AddPointer Call when creating a request-level C pointer for the very first time
+func (p *PointerList) AddPointer(ptr unsafe.Pointer) {
+	p.Pointers = append(p.Pointers, ptr)
+}
+
+// FreeAll frees all C pointers
+func (p *PointerList) FreeAll() {
+	for _, ptr := range p.Pointers {
+		C.free(ptr)
+	}
+	p.Pointers = nil // To avoid dangling pointers
+}
+
+// FreeAll frees all handles
+func (h *HandleList) FreeAll() {
+	defer func() {
+		if err := recover(); err != nil {
+			getLogger().Warn("A handle was already deleted manually, indeterminate state")
+		}
+	}()
+	for _, p := range h.Handles {
+		p.Delete()
+	}
+}
+
+// Pointers Get a new list of pointers
+func Pointers() *PointerList {
+	return &PointerList{
+		Pointers: make([]unsafe.Pointer, 0),
+	}
+}
+
+// Handles Get a new list of handles
+func Handles() *HandleList {
+	return &HandleList{
+		Handles: make([]cgo.Handle, 0),
+	}
+}

--- a/smartpointer.go
+++ b/smartpointer.go
@@ -59,6 +59,6 @@ func Pointers() *pointerList {
 // Handles Get a new list of handles
 func Handles() *handleList {
 	return &handleList{
-		Handles: make([]cgo.Handle, 0),
+		Handles: make([]cgo.Handle, 0, 8),
 	}
 }

--- a/smartpointer.go
+++ b/smartpointer.go
@@ -44,11 +44,6 @@ func (p *pointerList) FreeAll() {
 
 // FreeAll frees all handles
 func (h *handleList) FreeAll() {
-	defer func() {
-		if err := recover(); err != nil {
-			getLogger().Warn("A handle was already deleted manually, indeterminate state")
-		}
-	}()
 	for _, p := range h.Handles {
 		p.Delete()
 	}

--- a/smartpointer.go
+++ b/smartpointer.go
@@ -59,6 +59,6 @@ func Pointers() *pointerList {
 // Handles Get a new list of handles
 func Handles() *handleList {
 	return &handleList{
-		Handles: make([]cgo.Handle, 6),
+		Handles: make([]cgo.Handle, 0),
 	}
 }

--- a/worker.go
+++ b/worker.go
@@ -91,7 +91,7 @@ func startWorkers(fileName string, nbWorkers int, env map[string]string) error {
 					}
 				} else {
 					// clean up the dummy request
-					r.Context().Value(handleKey).(*HandleList).FreeAll()
+					r.Context().Value(handleKey).(*handleList).FreeAll()
 					r = nil
 					break
 				}
@@ -153,7 +153,7 @@ func go_frankenphp_worker_handle_request_start(mrh C.uintptr_t) C.uintptr_t {
 	}
 
 	fc.currentWorkerRequest = cgo.NewHandle(r)
-	r.Context().Value(handleKey).(*HandleList).AddHandle(fc.currentWorkerRequest)
+	r.Context().Value(handleKey).(*handleList).AddHandle(fc.currentWorkerRequest)
 
 	l.Debug("request handling started", zap.String("worker", fc.scriptFilename), zap.String("url", r.RequestURI))
 	if err := updateServerContext(r, false, mrh); err != nil {
@@ -173,7 +173,7 @@ func go_frankenphp_finish_request(mrh, rh C.uintptr_t, deleteHandle bool) {
 	fc := r.Context().Value(contextKey).(*FrankenPHPContext)
 
 	if deleteHandle {
-		r.Context().Value(handleKey).(*HandleList).FreeAll()
+		r.Context().Value(handleKey).(*handleList).FreeAll()
 		cgo.Handle(mrh).Value().(*http.Request).Context().Value(contextKey).(*FrankenPHPContext).currentWorkerRequest = 0
 	}
 

--- a/worker.go
+++ b/worker.go
@@ -90,9 +90,6 @@ func startWorkers(fileName string, nbWorkers int, env map[string]string) error {
 						l.Error("unexpected termination, restarting", zap.String("worker", absFileName), zap.Int("exit_status", int(fc.exitStatus)))
 					}
 				} else {
-					// clean up the dummy request
-					r.Context().Value(handleKey).(*handleList).FreeAll()
-					r = nil
 					break
 				}
 			}
@@ -173,7 +170,6 @@ func go_frankenphp_finish_request(mrh, rh C.uintptr_t, deleteHandle bool) {
 	fc := r.Context().Value(contextKey).(*FrankenPHPContext)
 
 	if deleteHandle {
-		r.Context().Value(handleKey).(*handleList).FreeAll()
 		cgo.Handle(mrh).Value().(*http.Request).Context().Value(contextKey).(*FrankenPHPContext).currentWorkerRequest = 0
 	}
 

--- a/worker.go
+++ b/worker.go
@@ -90,6 +90,9 @@ func startWorkers(fileName string, nbWorkers int, env map[string]string) error {
 						l.Error("unexpected termination, restarting", zap.String("worker", absFileName), zap.Int("exit_status", int(fc.exitStatus)))
 					}
 				} else {
+					// clean up the dummy request
+					r.Context().Value(handleKey).(*HandleList).FreeAll()
+					r = nil
 					break
 				}
 			}
@@ -150,6 +153,7 @@ func go_frankenphp_worker_handle_request_start(mrh C.uintptr_t) C.uintptr_t {
 	}
 
 	fc.currentWorkerRequest = cgo.NewHandle(r)
+	r.Context().Value(handleKey).(*HandleList).AddHandle(fc.currentWorkerRequest)
 
 	l.Debug("request handling started", zap.String("worker", fc.scriptFilename), zap.String("url", r.RequestURI))
 	if err := updateServerContext(r, false, mrh); err != nil {
@@ -169,8 +173,7 @@ func go_frankenphp_finish_request(mrh, rh C.uintptr_t, deleteHandle bool) {
 	fc := r.Context().Value(contextKey).(*FrankenPHPContext)
 
 	if deleteHandle {
-		rHandle.Delete()
-
+		r.Context().Value(handleKey).(*HandleList).FreeAll()
 		cgo.Handle(mrh).Value().(*http.Request).Context().Value(contextKey).(*FrankenPHPContext).currentWorkerRequest = 0
 	}
 

--- a/worker.go
+++ b/worker.go
@@ -170,6 +170,7 @@ func go_frankenphp_finish_request(mrh, rh C.uintptr_t, deleteHandle bool) {
 	fc := r.Context().Value(contextKey).(*FrankenPHPContext)
 
 	if deleteHandle {
+		r.Context().Value(handleKey).(*handleList).FreeAll()
 		cgo.Handle(mrh).Value().(*http.Request).Context().Value(contextKey).(*FrankenPHPContext).currentWorkerRequest = 0
 	}
 


### PR DESCRIPTION
It appears we aren't deleting ALL the created handles. This PR introduces a "smartpointer.go" file which can manage handles (and pointers, though it isn't used in this PR -- can remove the pointer code) without having to keep track of them manually. I like it because it frees up the cognitive load when trying to ensure everything is actually freed, without having to trace through the entire program's execution to figure out whether or not it is freed. 

To illustrate the difference, here are screen shots after 1:15 of running a load-test on a 2gb container (pay attention to memory usage).

fixes #366 

<img width="1280" alt="image" src="https://github.com/dunglas/frankenphp/assets/1883296/2819bf4b-16a4-41d3-b8bc-f39c21267d3e">

^ before this change

<img width="1280" alt="image" src="https://github.com/dunglas/frankenphp/assets/1883296/581cadb8-78d1-4de6-98a2-1111e69b4f60">

^ after this change (~7k RPS!)