### PR TITLE
Chore: pointer refactor

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -78,25 +78,12 @@ static uintptr_t frankenphp_clean_server_context() {
     return 0;
   }
 
-  free(SG(request_info).auth_password);
   SG(request_info).auth_password = NULL;
-
-  free(SG(request_info).auth_user);
   SG(request_info).auth_user = NULL;
-
-  free((char *)SG(request_info).request_method);
   SG(request_info).request_method = NULL;
-
-  free(SG(request_info).query_string);
   SG(request_info).query_string = NULL;
-
-  free((char *)SG(request_info).content_type);
   SG(request_info).content_type = NULL;
-
-  free(SG(request_info).path_translated);
   SG(request_info).path_translated = NULL;
-
-  free(SG(request_info).request_uri);
   SG(request_info).request_uri = NULL;
 
   return ctx->current_request;
@@ -352,7 +339,6 @@ static uintptr_t frankenphp_request_shutdown() {
 
   php_request_shutdown((void *)0);
 
-  free(ctx->cookie_data);
   ((frankenphp_server_context *)SG(server_context))->cookie_data = NULL;
   uintptr_t rh = frankenphp_clean_server_context();
 
@@ -508,11 +494,6 @@ static void frankenphp_register_known_variable(const char *key, char *value,
                                &new_val_len)) {
     php_register_variable_safe(key, value, new_val_len, track_vars_array);
   }
-
-  if (f) {
-    free(value);
-    value = NULL;
-  }
 }
 
 void frankenphp_register_bulk_variables(char *known_variables[27],
@@ -590,12 +571,7 @@ void frankenphp_register_bulk_variables(char *known_variables[27],
       php_register_variable_safe(dynamic_variables[i], dynamic_variables[i + 1],
                                  new_val_len, track_vars_array);
     }
-
-    free(dynamic_variables[i]);
-    free(dynamic_variables[i + 1]);
   }
-
-  free(dynamic_variables);
 }
 
 static void frankenphp_register_variables(zval *track_vars_array) {
@@ -729,8 +705,6 @@ int frankenphp_request_startup() {
 
 int frankenphp_execute_script(char *file_name) {
   if (frankenphp_request_startup() == FAILURE) {
-    free(file_name);
-
     return FAILURE;
   }
 
@@ -738,7 +712,6 @@ int frankenphp_execute_script(char *file_name) {
 
   zend_file_handle file_handle;
   zend_stream_init_filename(&file_handle, file_name);
-  free(file_name);
 
   file_handle.primary_script = 1;
 

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -616,8 +616,7 @@ sapi_module_struct frankenphp_sapi_module = {
     NULL,                          /* Get request time */
     NULL,                          /* Child terminate */
 
-    STANDARD_SAPI_MODULE_PROPERTIES
-};
+    STANDARD_SAPI_MODULE_PROPERTIES};
 
 static void *manager_thread(void *arg) {
 #ifdef ZTS

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -616,7 +616,8 @@ sapi_module_struct frankenphp_sapi_module = {
     NULL,                          /* Get request time */
     NULL,                          /* Child terminate */
 
-    STANDARD_SAPI_MODULE_PROPERTIES};
+    STANDARD_SAPI_MODULE_PROPERTIES
+};
 
 static void *manager_thread(void *arg) {
 #ifdef ZTS

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -380,14 +380,14 @@ func updateServerContext(request *http.Request, create bool, mrh C.uintptr_t) er
 	authUser, authPassword, ok := request.BasicAuth()
 	var cAuthUser, cAuthPassword *C.char
 	if ok && authPassword != "" {
-		cAuthPassword = pointers.WithString(authPassword)
+		cAuthPassword = pointers.ToCString(authPassword)
 	}
 	if ok && authUser != "" {
-		cAuthUser = pointers.WithString(authUser)
+		cAuthUser = pointers.ToCString(authUser)
 	}
 
-	cMethod := pointers.WithString(request.Method)
-	cQueryString := pointers.WithString(request.URL.RawQuery)
+	cMethod := pointers.ToCString(request.Method)
+	cQueryString := pointers.ToCString(request.URL.RawQuery)
 	contentLengthStr := request.Header.Get("Content-Length")
 	contentLength := 0
 	if contentLengthStr != "" {
@@ -401,7 +401,7 @@ func updateServerContext(request *http.Request, create bool, mrh C.uintptr_t) er
 	contentType := request.Header.Get("Content-Type")
 	var cContentType *C.char
 	if contentType != "" {
-		cContentType = pointers.WithString(contentType)
+		cContentType = pointers.ToCString(contentType)
 	}
 
 	// compliance with the CGI specification requires that
@@ -409,10 +409,10 @@ func updateServerContext(request *http.Request, create bool, mrh C.uintptr_t) er
 	// Info: https://www.ietf.org/rfc/rfc3875 Page 14
 	var cPathTranslated *C.char
 	if fc.pathInfo != "" {
-		cPathTranslated = pointers.WithString(sanitizedPathJoin(fc.documentRoot, fc.pathInfo)) // Info: http://www.oreilly.com/openbook/cgi/ch02_04.html
+		cPathTranslated = pointers.ToCString(sanitizedPathJoin(fc.documentRoot, fc.pathInfo)) // Info: http://www.oreilly.com/openbook/cgi/ch02_04.html
 	}
 
-	cRequestUri := pointers.WithString(request.URL.RequestURI())
+	cRequestUri := pointers.ToCString(request.URL.RequestURI())
 
 	var rh cgo.Handle
 	if fc.responseWriter == nil {
@@ -517,7 +517,7 @@ func go_execute_script(rh unsafe.Pointer) {
 		panic(err)
 	}
 
-	fc.exitStatus = C.frankenphp_execute_script(pointers.WithString(fc.scriptFilename))
+	fc.exitStatus = C.frankenphp_execute_script(pointers.ToCString(fc.scriptFilename))
 	if fc.exitStatus < 0 {
 		panic(ScriptExecutionError)
 	}
@@ -568,18 +568,18 @@ func go_register_variables(rh C.uintptr_t, trackVarsArray *C.zval) {
 			continue
 		}
 
-		dynamicVariables[i] = pointers.WithString(k)
+		dynamicVariables[i] = pointers.ToCString(k)
 		i++
 
-		dynamicVariables[i] = pointers.WithString(strings.Join(val, ", "))
+		dynamicVariables[i] = pointers.ToCString(strings.Join(val, ", "))
 		i++
 	}
 
 	for k, v := range fc.env {
-		dynamicVariables[i] = pointers.WithString(k)
+		dynamicVariables[i] = pointers.ToCString(k)
 		i++
 
-		dynamicVariables[i] = pointers.WithString(v)
+		dynamicVariables[i] = pointers.ToCString(v)
 		i++
 	}
 
@@ -688,7 +688,7 @@ func go_read_cookies(rh C.uintptr_t) *C.char {
 	}
 
 	// freed in frankenphp_request_shutdown()
-	return pointers.WithString(strings.Join(cookieString, "; "))
+	return pointers.ToCString(strings.Join(cookieString, "; "))
 }
 
 //export go_log

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -556,9 +556,8 @@ func go_register_variables(rh C.uintptr_t, trackVarsArray *C.zval) {
 	pointers := getPointersForRequest(r)
 
 	le := (len(fc.env) + len(r.Header)) * 2
-	dynamicVariablesArr := (**C.char)(C.malloc(C.size_t(le) * C.size_t(unsafe.Sizeof((*C.char)(nil)))))
-	dynamicVariables := unsafe.Slice(dynamicVariablesArr, le)
-	pointers.AddPointer(unsafe.Pointer(dynamicVariablesArr))
+	//dynamicVariablesArr := (**C.char)(C.malloc(C.size_t(le) * C.size_t(unsafe.Sizeof((*C.char)(nil)))))
+	dynamicVariables := make([]*C.char, le)
 
 	var i int
 	// Add all HTTP headers to env variables
@@ -583,8 +582,13 @@ func go_register_variables(rh C.uintptr_t, trackVarsArray *C.zval) {
 		i++
 	}
 
+	var pointer **C.char = nil
+	if le > 0 {
+		pointer = &dynamicVariables[0]
+	}
+
 	knownVariables := computeKnownVariables(r)
-	C.frankenphp_register_bulk_variables(&knownVariables[0], dynamicVariablesArr, C.size_t(le), trackVarsArray)
+	C.frankenphp_register_bulk_variables(&knownVariables[0], pointer, C.size_t(le), trackVarsArray)
 
 	fc.env = nil
 }

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -556,7 +556,6 @@ func go_register_variables(rh C.uintptr_t, trackVarsArray *C.zval) {
 	pointers := getPointersForRequest(r)
 
 	le := (len(fc.env) + len(r.Header)) * 2
-	//dynamicVariablesArr := (**C.char)(C.malloc(C.size_t(le) * C.size_t(unsafe.Sizeof((*C.char)(nil)))))
 	dynamicVariables := make([]*C.char, le)
 
 	var i int
@@ -582,13 +581,13 @@ func go_register_variables(rh C.uintptr_t, trackVarsArray *C.zval) {
 		i++
 	}
 
-	var pointer **C.char = nil
+	var dynamicVariablesPtr **C.char = nil
 	if le > 0 {
-		pointer = &dynamicVariables[0]
+		dynamicVariablesPtr = &dynamicVariables[0]
 	}
 
 	knownVariables := computeKnownVariables(r)
-	C.frankenphp_register_bulk_variables(&knownVariables[0], pointer, C.size_t(le), trackVarsArray)
+	C.frankenphp_register_bulk_variables(&knownVariables[0], dynamicVariablesPtr, C.size_t(le), trackVarsArray)
 
 	fc.env = nil
 }

--- a/smartpointer.go
+++ b/smartpointer.go
@@ -12,8 +12,6 @@ FrankenPHP is fairly complex because it shuffles handles/requests/contexts
 between C and Go. This simplifies the lifecycle management of per-request
 structures by allowing us to hold references until the end of the request
 and ensure they are always cleaned up.
-
-Note the non-inlined functions. Not inlining allows for slightly faster execution in this case due to
 */
 
 // PointerList A list of pointers that can be freed at a later time
@@ -32,8 +30,6 @@ func (h *handleList) AddHandle(handle cgo.Handle) {
 }
 
 // AddPointer Call when creating a request-level C pointer for the very first time
-//
-//go:noinline
 func (p *pointerList) AddPointer(ptr unsafe.Pointer) {
 	p.Pointers = append(p.Pointers, ptr)
 }
@@ -41,8 +37,6 @@ func (p *pointerList) AddPointer(ptr unsafe.Pointer) {
 // AddString adds a string to the pointer list by converting it to a C-char pointer and calling the AddPointer method.
 // The string is converted to a C-char pointer using the C.CString function.
 // It is recommended to use this method when you need to add a string to the pointer list.
-//
-//go:noinline
 func (p *pointerList) AddString(str *C.char) {
 	p.AddPointer(unsafe.Pointer(str))
 	//getLogger().Warn("Adding string", zap.Int("i", len(p.Pointers)), zap.String("str", C.GoString(str)), zap.Stack("trace"))
@@ -50,8 +44,6 @@ func (p *pointerList) AddString(str *C.char) {
 
 // ToCString takes a string and converts it to a C string using C.CString. Then it calls the AddString method of
 // pointerList to add the resulting C string as a pointer to the pointer
-//
-//go:noinline
 func (p *pointerList) ToCString(string string) *C.char {
 	str := C.CString(string)
 	p.AddString(str)

--- a/smartpointer.go
+++ b/smartpointer.go
@@ -34,9 +34,21 @@ func (p *pointerList) AddPointer(ptr unsafe.Pointer) {
 	p.Pointers = append(p.Pointers, ptr)
 }
 
+func (p *pointerList) AddString(str *C.char) {
+	p.AddPointer(unsafe.Pointer(str))
+	//getLogger().Warn("Adding string", zap.Int("i", len(p.Pointers)), zap.String("str", C.GoString(str)), zap.Stack("trace"))
+}
+
+func (p *pointerList) WithString(string string) *C.char {
+	str := C.CString(string)
+	p.AddString(str)
+	return str
+}
+
 // FreeAll frees all C pointers
 func (p *pointerList) FreeAll() {
 	for _, ptr := range p.Pointers {
+		//getLogger().Warn("About to delete", zap.Int("i", i))
 		C.free(ptr)
 	}
 	p.Pointers = nil // To avoid dangling pointers

--- a/worker.go
+++ b/worker.go
@@ -170,7 +170,7 @@ func go_frankenphp_finish_request(mrh, rh C.uintptr_t, deleteHandle bool) {
 	fc := r.Context().Value(contextKey).(*FrankenPHPContext)
 
 	if deleteHandle {
-		r.Context().Value(handleKey).(*handleList).FreeAll()
+		finalizeRequest(r)
 		cgo.Handle(mrh).Value().(*http.Request).Context().Value(contextKey).(*FrankenPHPContext).currentWorkerRequest = 0
 	}
 


### PR DESCRIPTION
This takes advantage of the smart-pointer stuff from #442 and a small optimization on `go_register_variables`. Through some benchmarks, this is just a tiny bit faster (but within a margin of error, so, at the very least, just as fast).

It introduces a (possibly contentious) idea that any C memory created in Go, must be released in Go -- which is new. 

I'm also opening a PR with _just_ the optimization in case we don't like this idea. 

Beyond this, FrankenPHP cannot be optimized further without improvements in stack switching by Go itself.

I did some benchmarks; there is a slight (but barely detectable) improvement over the other PR:

| branch | time per request (1.5 million requests - 95% quantile) | error |
| ------ | ------------------------------------------------------ | ----- |
| main   | 60.39ms | 1.2ms |
| chore/pointer-refactor | 59.20ms | 1.3ms |
| chore/optimize | 60.05ms | 1.2ms |

As you can see, for performance, this is a micro-optimization; however, I believe it can improve code maintenance since it delineates which language owns which bits of memory.