### PR TITLE
Ensure we don't modify a shared env

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -452,11 +452,10 @@ func ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) error 
 
 	rc := requestChan
 	// Detect if a worker is available to handle this request
-	if nil == fc.responseWriter {
-		fc.env["FRANKENPHP_WORKER"] = "1"
-	} else if v, ok := workersRequestChans.Load(fc.scriptFilename); ok {
-		fc.env["FRANKENPHP_WORKER"] = "1"
-		rc = v.(chan *http.Request)
+	if nil != fc.responseWriter {
+		if v, ok := workersRequestChans.Load(fc.scriptFilename); ok {
+			rc = v.(chan *http.Request)
+		}
 	}
 
 	select {

--- a/worker.go
+++ b/worker.go
@@ -50,7 +50,7 @@ func startWorkers(fileName string, nbWorkers int, env map[string]string) error {
 	)
 
 	if env == nil {
-		env = make(map[string]string, 0, 1)
+		env = make(map[string]string, 1)
 	}
 
 	env["FRANKENPHP_WORKER"] = "1"

--- a/worker.go
+++ b/worker.go
@@ -49,6 +49,12 @@ func startWorkers(fileName string, nbWorkers int, env map[string]string) error {
 		errs []error
 	)
 
+	if env == nil {
+		env = make(map[string]string)
+	}
+
+	env["FRANKENPHP_WORKER"] = "1"
+
 	l := getLogger()
 	for i := 0; i < nbWorkers; i++ {
 		go func() {

--- a/worker.go
+++ b/worker.go
@@ -50,7 +50,7 @@ func startWorkers(fileName string, nbWorkers int, env map[string]string) error {
 	)
 
 	if env == nil {
-		env = make(map[string]string)
+		env = make(map[string]string, 0, 1)
 	}
 
 	env["FRANKENPHP_WORKER"] = "1"


### PR DESCRIPTION
If `env` is passed into `startWorkers()`, then workers will try to both set `env["FRANKENPHP_WORKER"] = "1"` at the same time, which causes a data race.

This PR updates the `env` before any workers start, ensuring there isn't a data race.