### PR TITLE
optimize cookie handling in request

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -672,14 +672,13 @@ func go_read_cookies(rh C.uintptr_t) *C.char {
 	if len(cookies) == 0 {
 		return nil
 	}
-
-	cookieString := make([]string, len(cookies))
-	for _, cookie := range r.Cookies() {
-		cookieString = append(cookieString, cookie.String())
+	cookieStrings := make([]string, len(cookies))
+	for i, cookie := range cookies {
+		cookieStrings[i] = cookie.String()
 	}
 
 	// freed in frankenphp_request_shutdown()
-	return C.CString(strings.Join(cookieString, "; "))
+	return C.CString(strings.Join(cookieStrings, "; "))
 }
 
 //export go_log


### PR DESCRIPTION
This PR optimizes the way we handle cookies in the request. 

Previously, we were calling `r.Cookies()` twice and using `append` to add each cookie to a slice. This could potentially lead to unnecessary overhead due to the function calls and the automatic resizing of the slice when using `append`.

The new implementation only calls `r.Cookies()` once and uses indexing to set each element in the slice, which should be more efficient.

This change should not affect the functionality of the code, but it should improve its performance.
