### PR TITLE
Add documentation for 404 default

### DIFF
--- a/docs/worker.md
+++ b/docs/worker.md
@@ -68,6 +68,9 @@ $myApp->boot();
 
 // Handler outside the loop for better performance (doing less work)
 $handler = static function () use ($myApp) {
+        // set the default to a 404 instead of caddy's 200
+        http_response_code(404); // remove this line if your code doesn't explicitly set a 200 response
+
         // Called when a request is received,
         // superglobals, php://input and the like are reset
         echo $myApp->handle($_GET, $_POST, $_COOKIE, $_FILES, $_SERVER);


### PR DESCRIPTION
When a route doesn't exist, caddy sets a 200 response code. However, PHP response emitters (such as Nyholm's) do NOT set a 404 when a route doesn't exist because that is the default for other web servers.

This hints that a default can be set prior to running the application if users see a 200 when they expect a 404.