### PR TITLE
feature: include php.ini from current dir when available

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,4 @@
 !testdata/*.txt
 !build-static.sh
 !app.tar
+!custom-ini.php

--- a/build-static.sh
+++ b/build-static.sh
@@ -18,7 +18,7 @@ if [ -z "${PHP_EXTENSIONS}" ]; then
         # Temporary fix for https://github.com/crazywhalecc/static-php-cli/issues/280 (remove ldap)
         export PHP_EXTENSIONS="apcu,bcmath,bz2,calendar,ctype,curl,dba,dom,exif,fileinfo,filter,gd,iconv,igbinary,intl,mbregex,mbstring,mysqli,mysqlnd,opcache,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sodium,sqlite3,sysvsem,tokenizer,xml,xmlreader,xmlwriter,zip,zlib"
     else
-        export PHP_EXTENSIONS="apcu,bcmath,bz2,calendar,ctype,curl,dba,dom,exif,fileinfo,filter,gd,iconv,igbinary,intl,ldap,mbregex,mbstring,mysqli,mysqlnd,opcache,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sodium,sqlite3,sysvsem,tokenizer,xml,xmlreader,xmlwriter,zip,zlib" 
+        export PHP_EXTENSIONS="apcu,bcmath,bz2,calendar,ctype,curl,dba,dom,exif,fileinfo,filter,gd,iconv,igbinary,intl,ldap,mbregex,mbstring,mysqli,mysqlnd,opcache,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sodium,sqlite3,sysvsem,tokenizer,xml,xmlreader,xmlwriter,zip,zlib"
     fi
 fi
 
@@ -59,7 +59,7 @@ fi
 
 # Build libphp if ncessary
 if [ -f "dist/static-php-cli/buildroot/lib/libphp.a" ]; then
-    cd dist/static-php-cli    
+    cd dist/static-php-cli
 else
     mkdir -p dist/
     cd dist/
@@ -98,7 +98,7 @@ else
     ./bin/spc doctor
     ./bin/spc fetch --with-php="${PHP_VERSION}" --for-extensions="${PHP_EXTENSIONS}"
     # shellcheck disable=SC2086
-    ./bin/spc build --enable-zts --build-embed ${extraOpts} "${PHP_EXTENSIONS}" --with-libs="${PHP_EXTENSION_LIBS}"
+    ./bin/spc build --enable-zts --build-embed ${extraOpts} "${PHP_EXTENSIONS}" --with-libs="${PHP_EXTENSION_LIBS}" -P "../../custom-ini.php"
 fi
 
 CGO_CFLAGS="-DFRANKENPHP_VERSION=${FRANKENPHP_VERSION} $(./buildroot/bin/php-config --includes | sed s#-I/#-I"${PWD}"/buildroot/#g)"

--- a/custom-ini.php
+++ b/custom-ini.php
@@ -1,0 +1,9 @@
+<?php
+// patch it before `./buildconf` executed
+if (patch_point() === 'before-php-buildconf') {
+    \SPC\store\FileSystem::replaceFileStr(
+        SOURCE_PATH . '/php-src/sapi/cli/php_cli.c',
+        'sapi_module->php_ini_ignore_cwd = 1;',
+        'sapi_module->php_ini_ignore_cwd = 0;'
+    );
+}


### PR DESCRIPTION
Currently, the php.ini file of the current working directory is not included.

This has been changed to include the php.ini file of the current working directory by setting "sapi_module->php_ini_ignore_cwd = 0" before buildconf.