### PR TITLE
Do not extract embedded app on every execution

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,4 @@
 !testdata/*.txt
 !build-static.sh
 !app.tar
+!app_checksum.txt

--- a/build-static.sh
+++ b/build-static.sh
@@ -122,6 +122,7 @@ cd ../..
 # Embed PHP app, if any
 if [ -n "${EMBED}" ] && [ -d "${EMBED}" ]; then
     tar -cf app.tar -C "${EMBED}" .
+    md5 -q app.tar > app_checksum.txt
 fi
 
 if [ "${os}" = "linux" ]; then
@@ -139,6 +140,7 @@ cd ../..
 
 if [ -d "${EMBED}" ]; then
     truncate -s 0 app.tar
+    truncate -s 0 app_checksum.txt
 fi
 
 "dist/${bin}" version

--- a/embed.go
+++ b/embed.go
@@ -24,7 +24,7 @@ var EmbeddedAppPath string
 var embeddedApp []byte
 
 //go:embed app_checksum.txt
-var embeddedAppHash []byte
+var embeddedAppChecksum []byte
 
 func init() {
 	if len(embeddedApp) == 0 {
@@ -32,7 +32,7 @@ func init() {
 		return
 	}
 
-	appPath := filepath.Join(os.TempDir(), "frankenphp_"+strings.TrimSuffix(string(embeddedAppHash[:]), "\n"))
+	appPath := filepath.Join(os.TempDir(), "frankenphp_"+strings.TrimSuffix(string(embeddedAppChecksum[:]), "\n"))
 
 	if _, err := os.Stat(appPath); os.IsNotExist(err) {
 		mustUntar(appPath)

--- a/embed.go
+++ b/embed.go
@@ -35,30 +35,13 @@ func init() {
 	appPath := filepath.Join(os.TempDir(), "frankenphp_"+strings.TrimSuffix(string(embeddedAppChecksum[:]), "\n"))
 
 	if _, err := os.Stat(appPath); os.IsNotExist(err) {
-		mustUntar(appPath)
-	} else {
-		f, err := os.Open(appPath)
-		if err != nil {
+		if err := untar(appPath); err != nil {
+			os.RemoveAll(appPath)
 			panic(err)
-		}
-		defer f.Close()
-
-		_, err = f.Readdir(1)
-		if err == io.EOF {
-			mustUntar(appPath)
 		}
 	}
 
 	EmbeddedAppPath = appPath
-}
-
-func mustUntar(dir string) {
-	err := untar(dir)
-
-	if err != nil {
-		os.RemoveAll(dir)
-		panic(err)
-	}
 }
 
 // untar reads the tar file from r and writes it into dir.


### PR DESCRIPTION
When embedding a large app (in my case around ~700mb), the app checksum is calculated and the tar is extracted on every execution of the binary.

This slows down the execution (running `php-cli` takes around ~8 seconds) since this process needs to run every time. Instead, we can extract the app only once and re-use the same files for every execution.

Another drawback of the current process, is that when the web-server is running (using `php-server`), and you want to run a cli command, then it would remove and re-extract the tar while the webserver is still running.

The PR adds the following changes:
* Calculate the checksum at build-time instead of runtime, and embed the checksum in the binary
* Only untar the archive if it doesn't exist already on the filesystem