### PR TITLE
Allow custom php.ini in embedded app

### DIFF
--- a/caddy/php-server.go
+++ b/caddy/php-server.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -92,6 +93,10 @@ func cmdPHPServer(fs caddycmd.Flags) (int, error) {
 			root = filepath.Join(frankenphp.EmbeddedAppPath, defaultDocumentRoot)
 		} else if filepath.IsLocal(root) {
 			root = filepath.Join(frankenphp.EmbeddedAppPath, root)
+		}
+
+		if err := os.Setenv("PHP_INI_SCAN_DIR", ":"+frankenphp.EmbeddedAppPath); err != nil {
+			return caddy.ExitCodeFailedStartup, err
 		}
 	}
 

--- a/caddy/php-server.go
+++ b/caddy/php-server.go
@@ -95,9 +95,14 @@ func cmdPHPServer(fs caddycmd.Flags) (int, error) {
 			root = filepath.Join(frankenphp.EmbeddedAppPath, root)
 		}
 
-		if err := os.Setenv("PHP_INI_SCAN_DIR", ":"+frankenphp.EmbeddedAppPath); err != nil {
-			return caddy.ExitCodeFailedStartup, err
+		if _, err := os.Stat(filepath.Join(frankenphp.EmbeddedAppPath, "php.ini")); err == nil {
+			iniScanDir := os.Getenv("PHP_INI_SCAN_DIR")
+
+			if err := os.Setenv("PHP_INI_SCAN_DIR", iniScanDir+":"+frankenphp.EmbeddedAppPath); err != nil {
+				return caddy.ExitCodeFailedStartup, err
+			}
 		}
+
 	}
 
 	const indexFile = "index.php"


### PR DESCRIPTION
This adds the embedded path to the `PHP_INI_SCAN_DIR` env variable, so that a custom php.ini can be added to the root of a project.

Fixes #472 and #496

![Screenshot 2024-01-22 at 13 55 21](https://github.com/dunglas/frankenphp/assets/144858/073a702d-0e6c-47f4-9ccf-8fb846f3b34f)
