### PR TITLE
Check for custom php.ini before checking Caddyfile

### DIFF
--- a/caddy/php-server.go
+++ b/caddy/php-server.go
@@ -93,6 +93,14 @@ func cmdPHPServer(fs caddycmd.Flags) (int, error) {
 	}
 
 	if frankenphp.EmbeddedAppPath != "" {
+		if _, err := os.Stat(filepath.Join(frankenphp.EmbeddedAppPath, "php.ini")); err == nil {
+			iniScanDir := os.Getenv("PHP_INI_SCAN_DIR")
+
+			if err := os.Setenv("PHP_INI_SCAN_DIR", iniScanDir+":"+frankenphp.EmbeddedAppPath); err != nil {
+				return caddy.ExitCodeFailedStartup, err
+			}
+		}
+
 		if _, err := os.Stat(filepath.Join(frankenphp.EmbeddedAppPath, "Caddyfile")); err == nil {
 			config, _, err := caddycmd.LoadConfig(filepath.Join(frankenphp.EmbeddedAppPath, "Caddyfile"), "")
 			if err != nil {
@@ -111,15 +119,6 @@ func cmdPHPServer(fs caddycmd.Flags) (int, error) {
 		} else if filepath.IsLocal(root) {
 			root = filepath.Join(frankenphp.EmbeddedAppPath, root)
 		}
-
-		if _, err := os.Stat(filepath.Join(frankenphp.EmbeddedAppPath, "php.ini")); err == nil {
-			iniScanDir := os.Getenv("PHP_INI_SCAN_DIR")
-
-			if err := os.Setenv("PHP_INI_SCAN_DIR", iniScanDir+":"+frankenphp.EmbeddedAppPath); err != nil {
-				return caddy.ExitCodeFailedStartup, err
-			}
-		}
-
 	}
 
 	const indexFile = "index.php"


### PR DESCRIPTION
Move the block to check a php.ini before checking for the Caddyfile in embedded apps, so that custom php.ini files can still be loaded when using a custom Caddyfile