### PR TITLE
feat: add go_apache_request_headers()

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,6 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ['8.2', '8.3']
+    env:
+      GOEXPERIMENT: cgocheck2
     steps:
       -
         uses: actions/checkout@v4
@@ -39,9 +41,7 @@ jobs:
           echo "CGO_CFLAGS=$(php-config --includes)" >> "$GITHUB_ENV"
       -
         name: Build
-        run: go build
-        env:
-          GOEXPERIMENT: cgocheck2
+        run: go build          
       -
         name: Build testcli binary
         working-directory: internal/testcli/

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -242,6 +242,29 @@ PHP_FUNCTION(frankenphp_finish_request) { /* {{{ */
   RETURN_TRUE;
 } /* }}} */
 
+/* {{{ Fetch all HTTP request headers */
+PHP_FUNCTION(apache_request_headers) {
+  if (zend_parse_parameters_none() == FAILURE) {
+    RETURN_THROWS();
+  }
+
+  frankenphp_server_context *ctx = SG(server_context);
+  struct go_apache_request_headers_return headers =
+      go_apache_request_headers(ctx->current_request);
+
+  array_init_size(return_value, headers.r1);
+
+  for (size_t i = 0; i < headers.r1; i++) {
+    go_string key = headers.r0[i * 2];
+    go_string val = headers.r0[i * 2 + 1];
+
+    add_assoc_stringl_ex(return_value, key.data, key.len, val.data, val.len);
+  }
+
+  free(headers.r0);
+}
+/* }}} */
+
 PHP_FUNCTION(frankenphp_handle_request) {
   zend_fcall_info fci;
   zend_fcall_info_cache fcc;

--- a/frankenphp.h
+++ b/frankenphp.h
@@ -11,6 +11,11 @@
 #define STRINGIFY(x) #x
 #define TOSTRING(x) STRINGIFY(x)
 
+typedef struct go_string {
+  size_t len;
+  const char *data;
+} go_string;
+
 typedef struct frankenphp_version {
   unsigned char major_version;
   unsigned char minor_version;

--- a/frankenphp.stub.php
+++ b/frankenphp.stub.php
@@ -12,3 +12,10 @@ function frankenphp_finish_request(): bool {}
  * @alias frankenphp_finish_request
  */
 function fastcgi_finish_request(): bool {}
+
+function apache_request_headers(): array {}
+
+/**
+ * @alias apache_request_headers
+*/
+function getallheaders(): array {}

--- a/frankenphp_arginfo.h
+++ b/frankenphp_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: de4dc4063fafd8c933e3068c8349889a7ece5f03 */
+ * Stub hash: f925a1c280fb955eb32d0823cbd4f360b0cbabed */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_frankenphp_handle_request, 0, 1,
                                         _IS_BOOL, 0)
@@ -16,13 +16,23 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_fastcgi_finish_request arginfo_frankenphp_finish_request
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_apache_request_headers, 0, 0,
+                                        IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_getallheaders arginfo_apache_request_headers
+
 ZEND_FUNCTION(frankenphp_handle_request);
 ZEND_FUNCTION(headers_send);
 ZEND_FUNCTION(frankenphp_finish_request);
+ZEND_FUNCTION(apache_request_headers);
 
 static const zend_function_entry ext_functions[] = {
     ZEND_FE(frankenphp_handle_request, arginfo_frankenphp_handle_request)
         ZEND_FE(headers_send, arginfo_headers_send) ZEND_FE(
             frankenphp_finish_request, arginfo_frankenphp_finish_request)
             ZEND_FALIAS(fastcgi_finish_request, frankenphp_finish_request,
-                        arginfo_fastcgi_finish_request) ZEND_FE_END};
+                        arginfo_fastcgi_finish_request)
+                ZEND_FE(apache_request_headers, arginfo_apache_request_headers)
+                    ZEND_FALIAS(getallheaders, apache_request_headers,
+                                arginfo_getallheaders) ZEND_FE_END};

--- a/testdata/apache-request-headers.php
+++ b/testdata/apache-request-headers.php
@@ -1,0 +1,7 @@
+<?php
+
+require_once __DIR__.'/_executor.php';
+
+return function() {
+    print_r(apache_request_headers());
+};


### PR DESCRIPTION
Adds support for `apache_request_headers()`/`getallheaders()`.
Closes #296.

The unsafe magic needs to be double-checked.
Using a similar gymnastic in `go_register_variables()` will allow me to remove a lot of allocations (I'm on it).