### PR TITLE
add an issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,44 @@
+<!-- Your issue may already be reported! Please search for open/closed issues before reporting and use GitHub Discussions for general support questions. -->
+
+## Use case
+
+<!--
+Describe what you are doing here to give us some context.
+-->
+
+## Expected Behavior
+
+<!--
+Descibe what you expected to happen
+-->
+
+## Actual Behavior
+
+<!--
+Describe what actually happens. Include any relevant logs wrapped in ```three backticks```
+-->
+
+## Steps to reproduce
+
+Build Type:
+
+- [ ] custom standalone build
+- [ ] native build
+- [ ] docker (alpine)
+- [ ] docker (bookworm)
+
+Run Type:
+
+- [ ] worker mode
+- [ ] cgi mode
+
+CPU architecture:
+
+- [ ] Arm (non-Apple)
+- [ ] Arm (Apple)
+- [ ] x64 (intel/amd)
+- [ ] other: <!-- fill in -->
+
+<!--
+Provide us with some step-by-step instructions to produce the issue
+-->


### PR DESCRIPTION
This adds a simplistic issue template to help cutdown the number of duplicate-ish issues hopefully and get some important information (CPU architecture, type of frankenphp build, whether worker mode is enabled, etc).