### PR TITLE
fix(docs): Worker mode Docker example

### DIFF
--- a/docs/worker.md
+++ b/docs/worker.md
@@ -11,7 +11,7 @@ Set the value of the `FRANKENPHP_CONFIG` environment variable to `worker /path/t
 
 ```console
 docker run \
-    -e APP_RUNTIME=Runtime\\FrankenPhpSymfony\\Runtime \
+    -e FRANKENPHP_CONFIG="worker /app/path/to/your/worker/script.php" \
     -v $PWD:/app \
     -p 80:80 -p 443:443 -p 443:443/udp \
     dunglas/frankenphp


### PR DESCRIPTION
The Docker example at the Worker mode docs is using Symfony's `APP_RUNTIME` instead of the `FRANKENPHP_CONFIG` which is described above.