### PR TITLE
ci: temporary fix for Buildx crash

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -231,7 +231,8 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          version: latest
+          # Temporary fix for https://github.com/docker/buildx/issues/2229
+          version: "https://github.com/jedevc/buildx.git#imagetools-resolver-copy-dupe"
       -
         name: Login to DockerHub
         uses: docker/login-action@v3


### PR DESCRIPTION
See https://github.com/docker/buildx/issues/2229.