### PR TITLE
fix: crash when using apache_request_headers()

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -262,6 +262,7 @@ PHP_FUNCTION(frankenphp_request_headers) {
   }
 
   free(headers.r0);
+  go_apache_request_cleanup(headers.r2);
 }
 /* }}} */
 

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -261,7 +261,6 @@ PHP_FUNCTION(frankenphp_request_headers) {
     add_assoc_stringl_ex(return_value, key.data, key.len, val.data, val.len);
   }
 
-  free(headers.r0);
   go_apache_request_cleanup(headers.r2);
 }
 /* }}} */

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -585,36 +585,36 @@ func go_register_variables(rh C.uintptr_t, trackVarsArray *C.zval) {
 func go_apache_request_headers(rh C.uintptr_t) (*C.go_string, C.size_t, C.uintptr_t) {
 	r := cgo.Handle(rh).Value().(*http.Request)
 
-	pinner := runtime.Pinner{}
+	pinner := &runtime.Pinner{}
 	pinnerHandle := C.uintptr_t(cgo.NewHandle(pinner))
 
-	rl := len(r.Header)
-	scs := unsafe.Sizeof(C.go_string{})
+	headers := make([]C.go_string, 0, len(r.Header)*2)
 
-	headers := (*C.go_string)(unsafe.Pointer(C.malloc(C.size_t(rl*2) * (C.size_t)(scs))))
-	header := headers
 	for field, val := range r.Header {
 		fd := unsafe.StringData(field)
 		pinner.Pin(fd)
-
-		*header = C.go_string{C.size_t(len(field)), (*C.char)(unsafe.Pointer(fd))}
-		header = (*C.go_string)(unsafe.Add(unsafe.Pointer(header), scs))
 
 		cv := strings.Join(val, ", ")
 		vd := unsafe.StringData(cv)
 		pinner.Pin(vd)
 
-		*header = C.go_string{C.size_t(len(cv)), (*C.char)(unsafe.Pointer(vd))}
-		header = (*C.go_string)(unsafe.Add(unsafe.Pointer(header), scs))
+		headers = append(
+			headers,
+			C.go_string{C.size_t(len(field)), (*C.char)(unsafe.Pointer(fd))},
+			C.go_string{C.size_t(len(cv)), (*C.char)(unsafe.Pointer(vd))},
+		)
 	}
 
-	return headers, C.size_t(rl), pinnerHandle
+	sd := unsafe.SliceData(headers)
+	pinner.Pin(sd)
+
+	return sd, C.size_t(len(r.Header)), pinnerHandle
 }
 
 //export go_apache_request_cleanup
 func go_apache_request_cleanup(rh C.uintptr_t) {
 	h := cgo.Handle(rh)
-	p := h.Value().(runtime.Pinner)
+	p := h.Value().(*runtime.Pinner)
 	p.Unpin()
 	h.Delete()
 }

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -581,8 +581,8 @@ func TestRequestHeaders_worker(t *testing.T) {
 func testRequestHeaders(t *testing.T, opts *testOptions) {
 	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, i int) {
 		req := httptest.NewRequest("GET", fmt.Sprintf("http://example.com/request-headers.php?i=%d", i), nil)
-		req.Header.Add("Content-Type", "text/plain")
-		req.Header.Add("Frankenphp-I", strconv.Itoa(i))
+		req.Header.Add(strings.Clone("Content-Type"), strings.Clone("text/plain"))
+		req.Header.Add(strings.Clone("Frankenphp-I"), strings.Clone(strconv.Itoa(i)))
 
 		w := httptest.NewRecorder()
 		handler(w, req)


### PR DESCRIPTION
Fixes a crash when the headers are allocated on the heap.