### PR TITLE
Override binary name in build-static.sh

### DIFF
--- a/build-static.sh
+++ b/build-static.sh
@@ -52,7 +52,11 @@ elif [ -d ".git/" ]; then
     fi
 fi
 
-bin="frankenphp-${os}-${arch}"
+if [ -z "${BIN_NAME}" ]; then
+  BIN_NAME="frankenphp-${os}-${arch}"
+fi
+
+bin="${BIN_NAME}"
 
 if [ -n "${CLEAN}" ]; then
     rm -Rf dist/


### PR DESCRIPTION
I found it useful to override output binary name.

```shell
EMBED=/path/to/your/app \
    BIN_NAME=example-app \
    ./build-static.sh 
```

This will create `example-app` binary file in `dist` directory instead of default generated `frankenphp-${os}-${arch}`.
