### PR TITLE
feat: compress binary in Alpine with UPX

### DIFF
--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -63,7 +63,8 @@ RUN apk add --no-cache --virtual .build-deps \
 	oniguruma-dev \
 	openssl-dev \
 	readline-dev \
-	sqlite-dev
+	sqlite-dev \
+	upx
 
 WORKDIR /go/src/app
 
@@ -88,6 +89,7 @@ ENV CGO_LDFLAGS="-lssl -lcrypto -lreadline -largon2 -lcurl -lonig -lz $PHP_LDFLA
 WORKDIR /go/src/app/caddy/frankenphp
 RUN GOBIN=/usr/local/bin go install -ldflags "-w -s -extldflags '-Wl,-z,stack-size=0x80000' -X 'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP $FRANKENPHP_VERSION PHP $PHP_VERSION Caddy'" && \
 	setcap cap_net_bind_service=+ep /usr/local/bin/frankenphp && \
+	upx --best /usr/local/bin/frankenphp && \
 	frankenphp version
 
 WORKDIR /go/src/app


### PR DESCRIPTION
Follows https://github.com/dunglas/frankenphp/pull/572.

This will not be possible with Debian yet, because UPX isn't available in Bookworm.