### PR TITLE
Feature: Add one line install script and instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Go to `https://localhost`, and enjoy!
 
 ### Standalone Binary
 
-If you prefer not to use Docker, we provide standalone FrankenPHP binaries for `Linux` and macOS
+If you prefer not to use Docker, we provide standalone FrankenPHP binaries for Linux and macOS
 containing [PHP 8.3](https://www.php.net/releases/8.3/en.php) and most popular PHP extensions.
 
 [Download FrankenPHP](https://github.com/dunglas/frankenphp/releases) or copy this line into your

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Go to `https://localhost`, and enjoy!
 If you prefer not to use Docker, we provide standalone FrankenPHP binaries for Linux and macOS
 containing [PHP 8.3](https://www.php.net/releases/8.3/en.php) and most popular PHP extensions.
 
+On Windows, use [WSL](https://learn.microsoft.com/windows/wsl/) to run FrankenPHP.
+
 [Download FrankenPHP](https://github.com/dunglas/frankenphp/releases) or copy this line into your
 terminal to automatically install the version appropriate for your platform:
 

--- a/README.md
+++ b/README.md
@@ -33,26 +33,27 @@ Go to `https://localhost`, and enjoy!
 
 ### Standalone Binary
 
-If you prefer not to use Docker, we provide standalone FrankenPHP binaries for `Linux` or Mac - Intel, or Apple Chip M1+.
-containing [PHP 8.3](https://www.php.net/releases/8.3/en.php) and most popular PHP extensions:
+If you prefer not to use Docker, we provide standalone FrankenPHP binaries for `Linux` and macOS
+containing [PHP 8.3](https://www.php.net/releases/8.3/en.php) and most popular PHP extensions.
 
-```sh
+[Download FrankenPHP](https://github.com/dunglas/frankenphp/releases) or copy this line into your
+terminal to automatically install the version appropriate for your platform:
+
+```console
 curl -sLK https://raw.githubusercontent.com/dunglas/frankenphp/main/install.sh | sh
 mv frankenphp /usr/local/bin/
 ```
 
-Or [Download FrankenPHP manually](https://github.com/dunglas/frankenphp/releases)
-
 To serve the content of the current directory, run:
 
 ```console
-./frankenphp php-server
+frankenphp php-server
 ```
 
 You can also run command-line scripts with:
 
 ```console
-./frankenphp php-cli /path/to/your/script.php
+frankenphp php-cli /path/to/your/script.php
 ```
 
 ## Docs

--- a/README.md
+++ b/README.md
@@ -33,8 +33,15 @@ Go to `https://localhost`, and enjoy!
 
 ### Standalone Binary
 
-If you prefer not to use Docker, we provide standalone FrankenPHP binaries for Linux and macOS
-containing [PHP 8.3](https://www.php.net/releases/8.3/en.php) and most popular PHP extensions: [Download FrankenPHP](https://github.com/dunglas/frankenphp/releases)
+If you prefer not to use Docker, we provide standalone FrankenPHP binaries for `Linux` or Mac - Intel, or Apple Chip M1+.
+containing [PHP 8.3](https://www.php.net/releases/8.3/en.php) and most popular PHP extensions:
+
+```sh
+curl -sLK https://raw.githubusercontent.com/dunglas/frankenphp/main/install.sh | sh
+mv frankenphp /usr/local/bin/
+```
+
+Or [Download FrankenPHP manually](https://github.com/dunglas/frankenphp/releases)
 
 To serve the content of the current directory, run:
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+set -e
+
+if [ -z "$BIN_DIR" ]; then
+  BIN_DIR=$(pwd)
+fi
+
+THE_ARCH_BIN=""
+THIS_PROJECT_OWNER="dunglas"
+DEST=$BIN_DIR/frankenphp
+
+THISOS=$(uname -s)
+ARCH=$(uname -m)
+
+case $THISOS in
+   Linux*)
+      case $ARCH in
+        arm64)
+          THE_ARCH_BIN=""
+          ;;
+        aarch64)
+          THE_ARCH_BIN="$THIS_PROJECT_NAME-linux-aarch64"
+          ;;
+        armv6l)
+          THE_ARCH_BIN=""
+          ;;
+        armv7l)
+          THE_ARCH_BIN=""
+          ;;
+        *)
+          THE_ARCH_BIN="$THIS_PROJECT_NAME-linux-x86_64"
+          ;;
+      esac
+      ;;
+   Darwin*)
+      case $ARCH in
+        arm64)
+          THE_ARCH_BIN="$THIS_PROJECT_NAME-mac-arm64"
+          ;;
+        *)
+          THE_ARCH_BIN="$THIS_PROJECT_NAME-mac-x86_64"
+          ;;
+      esac
+      ;;
+   Windows|MINGW64_NT*)
+        THE_ARCH_BIN=""
+      ;;
+esac
+
+if [ -z "$THE_ARCH_BIN" ]; then
+   echo "This script is not supported on $THISOS and $ARCH"
+   exit 1
+fi
+
+curl -kL --progress-bar https://github.com/$THIS_PROJECT_OWNER/$THIS_PROJECT_NAME/releases/latest/download/$THE_ARCH_BIN -o "$DEST"
+
+chmod +x "$DEST"
+
+echo "Installed successfully to: $DEST"
+

--- a/install.sh
+++ b/install.sh
@@ -53,7 +53,7 @@ if [ -z "$THE_ARCH_BIN" ]; then
    exit 1
 fi
 
-curl -kL --progress-bar https://github.com/$THIS_PROJECT_OWNER/$THIS_PROJECT_NAME/releases/latest/download/$THE_ARCH_BIN -o "$DEST"
+curl -kL --progress-bar "https://github.com/$THIS_PROJECT_OWNER/$THIS_PROJECT_NAME/releases/latest/download/$THE_ARCH_BIN" -o "$DEST"
 
 chmod +x "$DEST"
 

--- a/install.sh
+++ b/install.sh
@@ -2,54 +2,51 @@
 
 set -e
 
-if [ -z "$BIN_DIR" ]; then
+if [ -z "${BIN_DIR}" ]; then
   BIN_DIR=$(pwd)
 fi
 
 THE_ARCH_BIN=""
-THIS_PROJECT_OWNER="dunglas"
-DEST=$BIN_DIR/frankenphp
+DEST=${BIN_DIR}/frankenphp
 
 OS=$(uname -s)
 ARCH=$(uname -m)
 
-case $OS in
+case ${OS} in
    Linux*)
-      case $ARCH in
-        arm64)
-          THE_ARCH_BIN=""
+      case ${ARCH} in
+         aarch64)
+          THE_ARCH_BIN="frankenphp-linux-aarch64"
           ;;
-        aarch64)
-          THE_ARCH_BIN="$THIS_PROJECT_NAME-linux-aarch64"
-          ;;
-        armv6l)
-          THE_ARCH_BIN=""
-          ;;
-        armv7l)
-          THE_ARCH_BIN=""
+         x86_64)
+          THE_ARCH_BIN="frankenphp-linux-x86_64"
           ;;
         *)
-          THE_ARCH_BIN="$THIS_PROJECT_NAME-linux-x86_64"
+          THE_ARCH_BIN=""
           ;;
       esac
       ;;
    Darwin*)
-      case $ARCH in
+      case ${ARCH} in
         arm64)
-          THE_ARCH_BIN="$THIS_PROJECT_NAME-mac-arm64"
+          THE_ARCH_BIN="frankenphp-mac-arm64"
           ;;
         *)
-          THE_ARCH_BIN="$THIS_PROJECT_NAME-mac-x86_64"
+          THE_ARCH_BIN="frankenphp-mac-x86_64"
           ;;
       esac
       ;;
    Windows|MINGW64_NT*)
+        echo "Install and use WSL to use FrankenPHP on Windows: https://learn.microsoft.com/windows/wsl/"
+        exit 1
+      ;;
+   *)
         THE_ARCH_BIN=""
       ;;
 esac
 
-if [ -z "$THE_ARCH_BIN" ]; then
-   echo "This script is not supported on $OS and $ARCH"
+if [ -z "${THE_ARCH_BIN}" ]; then
+   echo "FrankenPHP is not supported on ${OS} and ${ARCH}"
    exit 1
 fi
 
@@ -57,18 +54,18 @@ fi
 SUDO=""
 
 # check if $DEST is writable and suppress an error message
-touch $DEST 2>/dev/null
+touch "${DEST}" 2>/dev/null
 
 # we need sudo powers to write to DEST
 if [ $? -eq 1 ]; then
-    echo "You do not have permission to write to $DEST, enter your password to grant sudo powers"
+    echo "You do not have permission to write to ${DEST}, enter your password to grant sudo powers"
     SUDO="sudo"
 fi
 
-$SUDO curl -L --progress-bar "https://github.com/$THIS_PROJECT_OWNER/$THIS_PROJECT_NAME/releases/latest/download/$THE_ARCH_BIN" -o "$DEST"
+${SUDO} curl -L --progress-bar "https://github.com/dunglas/frankenphp/releases/latest/download/${THE_ARCH_BIN}" -o "${DEST}"
 
-$SUDO chmod +x "$DEST"
+${SUDO} chmod +x "${DEST}"
 
 
-echo "Installed successfully to: $DEST"
-
+echo "FrankenPHP downloaded successfully to ${DEST}"
+echo "Move the binary to /usr/local/bin/ or another directory in your PATH to use it globally: sudo mv ${DEST} /usr/local/bin/"

--- a/install.sh
+++ b/install.sh
@@ -53,7 +53,7 @@ if [ -z "$THE_ARCH_BIN" ]; then
    exit 1
 fi
 
-curl -kL --progress-bar "https://github.com/$THIS_PROJECT_OWNER/$THIS_PROJECT_NAME/releases/latest/download/$THE_ARCH_BIN" -o "$DEST"
+curl -L --progress-bar "https://github.com/$THIS_PROJECT_OWNER/$THIS_PROJECT_NAME/releases/latest/download/$THE_ARCH_BIN" -o "$DEST"
 
 chmod +x "$DEST"
 

--- a/install.sh
+++ b/install.sh
@@ -53,9 +53,22 @@ if [ -z "$THE_ARCH_BIN" ]; then
    exit 1
 fi
 
-curl -L --progress-bar "https://github.com/$THIS_PROJECT_OWNER/$THIS_PROJECT_NAME/releases/latest/download/$THE_ARCH_BIN" -o "$DEST"
 
-chmod +x "$DEST"
+SUDO=""
+
+# check if $DEST is writable and suppress an error message
+touch $DEST 2>/dev/null
+
+# we need sudo powers to write to DEST
+if [ $? -eq 1 ]; then
+    echo "You do not have permission to write to $DEST, enter your password to grant sudo powers"
+    SUDO="sudo"
+fi
+
+$SUDO curl -L --progress-bar "https://github.com/$THIS_PROJECT_OWNER/$THIS_PROJECT_NAME/releases/latest/download/$THE_ARCH_BIN" -o "$DEST"
+
+$SUDO chmod +x "$DEST"
+
 
 echo "Installed successfully to: $DEST"
 

--- a/install.sh
+++ b/install.sh
@@ -10,10 +10,10 @@ THE_ARCH_BIN=""
 THIS_PROJECT_OWNER="dunglas"
 DEST=$BIN_DIR/frankenphp
 
-THISOS=$(uname -s)
+OS=$(uname -s)
 ARCH=$(uname -m)
 
-case $THISOS in
+case $OS in
    Linux*)
       case $ARCH in
         arm64)
@@ -49,7 +49,7 @@ case $THISOS in
 esac
 
 if [ -z "$THE_ARCH_BIN" ]; then
-   echo "This script is not supported on $THISOS and $ARCH"
+   echo "This script is not supported on $OS and $ARCH"
    exit 1
 fi
 


### PR DESCRIPTION
Install cli could be more convinient for for users to not guess b/w `arm`, `x86_64` and `aarch` etc..
Plus it will provide better installation for dev-ops team as one interface.

Verify

```
╰─$ cat install.sh| sh -
######################################################################## 100.0%
Installed successfully to: /Users/pulkit.kathuria/git/action-coveritup/app/frankenphp

╰─$ ls -lh frankenphp
-rwxr-xr-x  1 user.name  679754705   105M Feb 25 20:15 frankenphp
```
