### PR TITLE
fix: prevent crash when calling apache_request_headers() in non-HTTP context

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -250,7 +250,7 @@ PHP_FUNCTION(frankenphp_request_headers) {
 
   frankenphp_server_context *ctx = SG(server_context);
   struct go_apache_request_headers_return headers =
-      go_apache_request_headers(ctx->current_request);
+      go_apache_request_headers(ctx->current_request, ctx->main_request);
 
   array_init_size(return_value, headers.r1);
 

--- a/testdata/request-headers.php
+++ b/testdata/request-headers.php
@@ -1,5 +1,7 @@
 <?php
 
+apache_request_headers();
+
 require_once __DIR__.'/_executor.php';
 
 return function() {


### PR DESCRIPTION
Panic reported privately by @GregoireHebert.