### PR TITLE
docs: fix Chinese docs to make it more readable

### DIFF
--- a/docs/cn/README.md
+++ b/docs/cn/README.md
@@ -26,7 +26,7 @@ docker run -v $PWD:/app/public \
 
 访问 `https://localhost`, 并享受吧!
 
-> [!提示]
+> [!TIP]
 >
 > 不要尝试使用 `https://127.0.0.1`。使用 `localhost` 并接受自签名证书。
 > 使用 [`SERVER_NAME` 环境变量](config.md#环境变量) 更改要使用的域。
@@ -34,7 +34,7 @@ docker run -v $PWD:/app/public \
 ### 独立二进制
 
 如果您不想使用 Docker，我们为 Linux 和 macOS 提供独立的 FrankenPHP 二进制文件
-包含 [PHP 8.3](https://www.php.net/releases/8.3/en.php) 和最流行的 PHP 扩展：[下载 FrankenPHP](https://github.com/dunglas/frankenphp/releases)
+，其中包含 [PHP 8.3](https://www.php.net/releases/8.3/en.php) 和最流行的 PHP 扩展：[下载 FrankenPHP](https://github.com/dunglas/frankenphp/releases)。
 
 若要启动当前目录的内容，请运行：
 
@@ -61,7 +61,7 @@ docker run -v $PWD:/app/public \
 * [从源代码编译](compile.md)
 * [Laravel 集成](laravel.md)
 * [已知问题](known-issues.md)
-* [演示应用程序 (Symfony) 和基准测试](https://github.com/dunglas/frankenphp-demo)
+* [演示应用程序 (Symfony) 和性能测试](https://github.com/dunglas/frankenphp-demo)
 * [Go 库文档](https://pkg.go.dev/github.com/dunglas/frankenphp)
 * [贡献和调试](https://frankenphp.dev/docs/contributing/)
 

--- a/docs/cn/compile.md
+++ b/docs/cn/compile.md
@@ -3,13 +3,13 @@
 本文档解释了如何创建一个 FrankenPHP 构建，它将 PHP 加载为一个动态库。
 这是推荐的方法。
 
-或者，[创建静态构建](static.md)也是可能的。
+或者，你也可以 [编译静态版本](static.md)。
 
 ## 安装 PHP
 
-FrankenPHP 与 PHP 8.2 及更高版本兼容。
+FrankenPHP 支持 PHP 8.2 及更高版本。
 
-首先，[获取PHP的源代码](https://www.php.net/downloads.php)并提取它们：
+首先，[获取 PHP 源代码](https://www.php.net/downloads.php) 并提取它们：
 
 ```console
 tar xf php-*
@@ -37,15 +37,14 @@ sudo make install
 
 ### Mac
 
-使用 [Homebrew](https://brew.sh/) 包管理器安装
-`libiconv`, `bison`, `re2c` 和 `pkg-config`：
+使用 [Homebrew](https://brew.sh/) 包管理器安装 `libiconv`、`bison`、`re2c` 和 `pkg-config`：
 
 ```console
 brew install libiconv bison re2c pkg-config
 echo 'export PATH="/opt/homebrew/opt/bison/bin:$PATH"' >> ~/.zshrc
 ```
 
-然后运行配置脚本：
+然后运行 `./configure` 脚本：
 
 ```console
 ./configure \
@@ -58,8 +57,7 @@ echo 'export PATH="/opt/homebrew/opt/bison/bin:$PATH"' >> ~/.zshrc
     --with-iconv=/opt/homebrew/opt/libiconv/
 ```
 
-这些标志是必需的，但您可以添加其他标志(例如额外的扩展)
-如果需要。
+这些参数是必需的，但你也可以添加其他编译参数（例如额外的扩展）。
 
 最后，编译并安装 PHP：
 
@@ -80,7 +78,7 @@ CGO_CFLAGS=$(php-config --includes) CGO_LDFLAGS="$(php-config --ldflags) $(php-c
 
 ### 使用 xcaddy
 
-或者，使用 [xcaddy](https://github.com/caddyserver/xcaddy) 用 [自定义 Caddy 模块](https://caddyserver.com/docs/modules/) 编译 FrankenPHP：
+你可以使用 [xcaddy](https://github.com/caddyserver/xcaddy) 来编译 [自定义 Caddy 模块](https://caddyserver.com/docs/modules/) 的 FrankenPHP：
 
 ```console
 CGO_ENABLED=1 \
@@ -93,12 +91,12 @@ xcaddy build \
     # Add extra Caddy modules here
 ```
 
-> [!提示]
+> [!TIP]
 >
-> 如果您使用的是 musl libc(Alpine Linux 上的默认值)和 Symfony，
+> 如果你的系统基于 musl libc（Alpine Linux 上默认使用）并搭配 Symfony 使用，
 > 您可能需要增加默认堆栈大小。
 > 否则，您可能会收到如下错误 `PHP Fatal error: Maximum call stack size of 83360 bytes reached during compilation. Try splitting expression`
 >
-> 为此，请将 `XCADDY_GO_BUILD_FLAGS` 环境变量更改为类似
+> 请将 `XCADDY_GO_BUILD_FLAGS` 环境变量更改为如下类似的值
 > `XCADDY_GO_BUILD_FLAGS=$'-ldflags "-w -s -extldflags \'-Wl,-z,stack-size=0x80000\'"'`
-> (根据您的应用需求更改堆栈大小的值)。
+> （根据您的应用需求更改堆栈大小）。

--- a/docs/cn/config.md
+++ b/docs/cn/config.md
@@ -6,7 +6,7 @@ FrankenPHP，Caddy 以及 Mercure 和 Vulcain 模块可以使用 [Caddy 支持�
 
 您也可以像往常一样使用 `php.ini` 配置 PHP。
 
-在 Docker 镜像中，`php.ini` 文件不存在，您可以手动创建它或 `复制`。
+在 Docker 镜像中，默认不存在 `php.ini`，您可以手动创建它或从官方模板中复制。
 
 ```dockerfile
 FROM dunglas/frankenphp
@@ -14,15 +14,15 @@ FROM dunglas/frankenphp
 # 开发:
 RUN cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini
 
-# 还是生产:
+# 生产:
 RUN cp $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
 ```
 
 ## Caddyfile 配置
 
-要注册 FrankenPHP 执行器，必须设置 `frankenphp` [全局选项](https://caddyserver.com/docs/caddyfile/concepts#global-options)，然后可以在站点块中使用 `php_server` 或 `php` [HTTP 指令](https://caddyserver.com/docs/caddyfile/concepts#directives)来为您的 PHP 应用程序提供服务。
+要注册 FrankenPHP 执行器，必须设置 `frankenphp` [全局选项](https://caddyserver.com/docs/caddyfile/concepts#global-options)，然后可以在站点块中使用 `php_server` 或 `php` [HTTP 指令](https://caddyserver.com/docs/caddyfile/concepts#directives) 来为您的 PHP 应用程序提供服务。
 
-极小示例：
+最小示例：
 
 ```caddyfile
 {
@@ -33,14 +33,14 @@ RUN cp $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
 }
 
 localhost {
-	# 启用压缩(可选)
+	# 启用压缩（可选）
 	encode zstd br gzip
 	# 执行当前目录中的 PHP 文件并提供资产
 	php_server
 }
 ```
 
-或者，可以在全局选项下指定要创建的线程数和要从服务器启动的 [worker scripts](worker.md)。
+或者，可以在全局选项下指定要创建的线程数和要从服务器启动的 [worker 脚本](worker.md)。
 
 ```caddyfile
 {
@@ -69,7 +69,7 @@ localhost {
 # ...
 ```
 
-如果在同一服务器上提供多个应用，还可以定义多个 worker：
+如果在同一服务器上运行多个应用，还可以定义多个 worker：
 
 ```caddyfile
 {
@@ -88,11 +88,11 @@ other.example.com {
 	root * /path/to/other/public
 	php_server
 }
-...
+# ...
 ```
 
-使用 `php_server` 指令通常是您需要的，
-但是，如果您需要完全控制，则可以使用较低级别的 `php` 指令：
+通常你只需要 `php_server` 指令，
+但如果要完全控制，则可以使用较低级别的 `php` 指令：
 
 使用 `php_server` 指令等效于以下配置：
 
@@ -104,7 +104,7 @@ route {
 		not path */
 	}
 	redir @canonicalPath {path}/ 308
-	# 如果请求的文件不存在，请尝试 index 文件
+	# 如果请求的文件不存在，则尝试 index 文件
 	@indexFiles file {
 		try_files {path} {path}/index.php index.php
 		split_path .php
@@ -121,10 +121,10 @@ route {
 
 ```caddyfile
 php_server [<matcher>] {
-	root <directory> # 设置站点的根文件夹。默认值：`root` 指令。
-	split_path <delim...> # 设置用于将 URI 拆分为两部分的子字符串。第一个匹配的子字符串将用于从路径中拆分“路径信息”。第一个部分以匹配的子字符串为后缀，并将假定为实际资源(CGI 脚本)名称。第二部分将设置为PATH_INFO，供 脚本使用。默认值：`.php`
-	resolve_root_symlink # 允许通过计算符号链接(如果存在)将 `根` 目录解析为其实际值。
-	env <key> <value> # 将额外的环境变量设置为给定值。可以为多个环境变量多次指定。
+	root <directory> # 设置站点的根目录。默认值：`root` 指令。
+	split_path <delim...> # 设置用于将 URI 拆分为两部分的子字符串。第一个匹配的子字符串将用于从路径中拆分“路径信息”。第一个部分以匹配的子字符串为后缀，并将假定为实际资源(CGI 脚本)名称。第二部分将设置为PATH_INFO，供脚本使用。默认值：`.php`
+	resolve_root_symlink false # 禁用将 `root` 目录在符号链接时将其解析为实际值（默认启用）。
+	env <key> <value> # 设置额外的环境变量，可以设置多个环境变量。
 }
 ```
 
@@ -138,7 +138,7 @@ php_server [<matcher>] {
 
 ## PHP 配置
 
-要加载[其他PHP配置文件](https://www.php.net/manual/en/configuration.file.php#configuration.file.scan)，
+要加载 [其他 PHP INI 配置文件](https://www.php.net/manual/en/configuration.file.php#configuration.file.scan)，
 可以使用 `PHP_INI_SCAN_DIR` 环境变量。
 设置后，PHP 将加载给定目录中存在 `.ini` 扩展名的所有文件。
 

--- a/docs/cn/docker.md
+++ b/docs/cn/docker.md
@@ -1,6 +1,7 @@
 # 构建自定义 Docker 镜像
 
-[FrankenPHP Docker 镜像](https://hub.docker.com/r/dunglas/frankenphp)基于[官方PHP镜像](https://hub.docker.com/_/php/)。Alpine Linux 和 Debian 变体适用于流行的架构。提供了 PHP 8.2 和 PHP 8.3 的变体。[浏览标签](https://hub.docker.com/r/dunglas/frankenphp/tags)。
+[FrankenPHP Docker 镜像](https://hub.docker.com/r/dunglas/frankenphp) 基于 [官方 PHP 镜像](https://hub.docker.com/_/php/)。
+Alpine Linux 和 Debian 衍生版适用于常见的处理器架构，且支持 PHP 8.2 和 PHP 8.3。[查看 Tags](https://hub.docker.com/r/dunglas/frankenphp/tags)。
 
 ## 如何使用镜像
 
@@ -12,17 +13,17 @@ FROM dunglas/frankenphp
 COPY . /app/public
 ```
 
-然后，运行以下命令以构建并运行 Docker 镜像：
+然后运行以下命令以构建并运行 Docker 镜像：
 
 ```console
 docker build -t my-php-app .
 docker run -it --rm --name my-running-app my-php-app
 ```
 
-## 如何安装更多PHP扩展
+## 如何安装更多 PHP 扩展
 
-[`docker-php-extension-installer`](https://github.com/mlocati/docker-php-extension-installer)脚本在基础镜像中提供。
-添加额外的PHP扩展很简单：
+[`docker-php-extension-installer`](https://github.com/mlocati/docker-php-extension-installer) 脚本在基础镜像中提供。
+添加额外的 PHP 扩展很简单：
 
 ```dockerfile
 FROM dunglas/frankenphp
@@ -54,7 +55,7 @@ RUN xcaddy build \
   --output /usr/local/bin/frankenphp \
   --with github.com/dunglas/frankenphp=./ \
   --with github.com/dunglas/frankenphp/caddy=./caddy/ \
-  # Mercure 和 Vulcain 包含在官方版本中，但请随意删除它们
+  # Mercure 和 Vulcain 包含在官方版本中，如果不需要你可以删除它们
   --with github.com/dunglas/mercure/caddy \
   --with github.com/dunglas/vulcain/caddy
   # 在此处添加额外的 Caddy 模块
@@ -66,11 +67,11 @@ COPY --from=builder /usr/local/bin/frankenphp /usr/local/bin/frankenphp
 ```
 
 FrankenPHP 提供的 `builder` 镜像包含 libphp 的编译版本。
-[构建器图像](https://hub.docker.com/r/dunglas/frankenphp/tags?name=builder) 适用于所有版本的 FrankenPHP 和 PHP，包括 Alpine 和 Debian。
+[用于构建的镜像](https://hub.docker.com/r/dunglas/frankenphp/tags?name=builder) 适用于所有版本的 FrankenPHP 和 PHP，包括 Alpine 和 Debian。
 
-> [!提示]
+> [!TIP]
 >
-> 如果您使用的是 Alpine Linux 和 Symfony，
+> 如果你的系统基于 musl libc（Alpine Linux 上默认使用）并搭配 Symfony 使用，
 > 您可能需要 [增加默认堆栈大小](compile.md#使用-xcaddy)。
 
 ## 默认启用 worker 模式
@@ -85,7 +86,7 @@ FROM dunglas/frankenphp
 ENV FRANKENPHP_CONFIG="worker ./public/index.php"
 ```
 
-## 在开发中使用 Volume
+## 开发挂载宿主机目录
 
 要使用 FrankenPHP 轻松开发，请从包含应用程序源代码的主机挂载目录作为 Docker 容器中的 volume：
 
@@ -93,7 +94,7 @@ ENV FRANKENPHP_CONFIG="worker ./public/index.php"
 docker run -v $PWD:/app/public -p 80:80 -p 443:443 -p 443:443/udp --tty my-php-app
 ```
 
-> [!提示]
+> [!TIP]
 >
 > `--tty` 选项允许使用清晰可读的日志，而不是 JSON 日志。
 
@@ -120,7 +121,7 @@ services:
     # 在生产环境中注释以下行，它允许在 dev 中使用清晰可读日志
     tty: true
 
-# Caddy 证书和配置所需的 volumes
+# Caddy 证书和配置所需的挂载目录
 volumes:
   caddy_data:
   caddy_config:
@@ -153,12 +154,11 @@ USER ${USER}
 Docker 镜像会按照以下条件更新：
 
 * 发布新的版本后
-* 每天的 4am UTC 检查如果有新的PHP镜像可用
+* 每日 4:00（UTC 时间）检查新的 PHP 镜像
 
 ## 开发版本
 
-可在此docker[`dunglas/frankenphp-dev`](https://hub.docker.com/repository/docker/dunglas/frankenphp-dev)仓库路径获取开发版本。
-每次在GitHub仓库的主分支有了新的commit都会触发一个新的build。
+可在此 [`dunglas/frankenphp-dev`](https://hub.docker.com/repository/docker/dunglas/frankenphp-dev) 仓库获取开发版本。
+每次在 GitHub 仓库的主分支有新的 commit 都会触发一次新的 build。
 
-'latest*' tag 指向最新的`main`分支。
-也支持 'sha-<git-commit-hash>' 的tag格式。
+`latest*` tag 指向最新的 `main` 分支，且同样支持 `sha-<git-commit-hash>` 的 tag。

--- a/docs/cn/early-hints.md
+++ b/docs/cn/early-hints.md
@@ -1,6 +1,6 @@
 # 早期提示
 
-FrankenPHP 原生支持 [103 Early Hints 状态代码](https://developer.chrome.com/blog/early-hints/)。
+FrankenPHP 原生支持 [103 Early Hints 状态码](https://developer.chrome.com/blog/early-hints/)。
 使用早期提示可以将网页的加载时间缩短 30%。
 
 ```php

--- a/docs/cn/embed.md
+++ b/docs/cn/embed.md
@@ -1,26 +1,26 @@
 # PHP 应用程序作为独立二进制文件
 
-FrankenPHP 能够将 PHP 应用程序的源代码和资产嵌入到静态的、独立的二进制文件中。
+FrankenPHP 能够将 PHP 应用程序的源代码和资源文件嵌入到静态的、独立的二进制文件中。
 
-由于这个特性，PHP应用程序可以作为独立的二进制文件分发，包括应用程序本身、PHP解释器和生产级Web服务器Caddy。
+由于这个特性，PHP 应用程序可以作为独立的二进制文件分发，包括应用程序本身、PHP 解释器和生产级 Web 服务器 Caddy。
 
-了解有关此功能的更多信息 [Kévin 在 SymfonyCon 上的演讲中](https://dunglas.dev/2023/12/php-and-symfony-apps-as-standalone-binaries/)。
+了解有关此功能的更多信息 [Kévin 在 SymfonyCon 上的演讲](https://dunglas.dev/2023/12/php-and-symfony-apps-as-standalone-binaries/)。
 
-## 准备应用
+## 准备你的应用
 
-在创建独立二进制文件之前，请确保您的应用已准备好进行嵌入。
+在创建独立二进制文件之前，请确保应用已准备好进行打包。
 
 例如，您可能希望：
 
-* 安装应用的生产依赖项
-* 转储自动加载机
-* 启用应用程序的生产模式(如果有)
-* 剥离不需要的文件，例如 `.git` 或测试，以减小最终二进制文件的大小
+* 给应用安装生产环境的依赖
+* 导出 autoloader
+* 如果可能，为应用启用生产模式
+* 丢弃不需要的文件，例如 `.git` 或测试文件，以减小最终二进制文件的大小
 
 例如，对于 Symfony 应用程序，您可以使用以下命令：
 
 ```console
-# 导出项目以摆脱 .git/ 等
+# 导出项目以避免 .git/ 等目录
 mkdir $TMPDIR/my-prepared-app
 git archive HEAD | tar -x -C $TMPDIR/my-prepared-app
 cd $TMPDIR/my-prepared-app
@@ -29,7 +29,7 @@ cd $TMPDIR/my-prepared-app
 echo APP_ENV=prod > .env.local
 echo APP_DEBUG=0 >> .env.local
 
-# 删除测试
+# 删除测试文件
 rm -Rf tests/
 
 # 安装依赖项
@@ -48,11 +48,11 @@ composer dump-env prod
     ```dockerfile
     FROM --platform=linux/amd64 dunglas/frankenphp:static-builder
 
-    # 复制应用
+    # 复制应用代码
     WORKDIR /go/src/app/dist/app
     COPY . .
 
-    # 构建静态二进制文件，确保只选择你想要的PHP扩展
+    # 构建静态二进制文件，只选择你需要的 PHP 扩展
     WORKDIR /go/src/app/
     RUN EMBED=dist/app/ \
         PHP_EXTENSIONS=ctype,iconv,pdo_sqlite \
@@ -75,7 +75,7 @@ composer dump-env prod
 
 ## 为其他操作系统创建二进制文件
 
-如果您不想使用 Docker，或者想要构建 macOS 二进制文件，请使用我们提供的 shell 脚本：
+如果您不想使用 Docker，或者想要构建 macOS 二进制文件，你可以使用我们提供的 shell 脚本：
 
 ```console
 git clone https://github.com/dunglas/frankenphp
@@ -85,25 +85,25 @@ EMBED=/path/to/your/app \
     ./build-static.sh
 ```
 
-在 `dist/` 目录中生成的二进制文件名为 `frankenphp-<os>-<arch>`。
+在 `dist/` 目录中生成的二进制文件名称为 `frankenphp-<os>-<arch>`。
 
 ## 使用二进制文件
 
-就是这样！`my-app` 文件(或其他操作系统上的 `dist/frankenphp-<os>-<arch>`)包含您的独立应用程序！
+就是这样！`my-app` 文件（或其他操作系统上的 `dist/frankenphp-<os>-<arch>`）包含您的独立应用程序！
 
-若要启动 Web 应用，请运行：
+若要启动 Web 应用，请执行：
 
 ```console
 ./my-app php-server
 ```
 
-如果您的应用包含 [worker 脚本](worker.md)，请使用如下内容启动 worker：
+如果您的应用包含 [worker 脚本](worker.md)，请使用如下命令启动 worker：
 
 ```console
 ./my-app php-server --worker public/index.php
 ```
 
-要启用 HTTPS(自动创建 Let's Encrypt 证书)、HTTP/2 和 HTTP/3，请指定要使用的域名：
+要启用 HTTPS（自动创建 Let's Encrypt 证书）、HTTP/2 和 HTTP/3，请指定要使用的域名：
 
 ```console
 ./my-app php-server --domain localhost
@@ -117,7 +117,7 @@ EMBED=/path/to/your/app \
 
 ## 自定义构建
 
-[阅读静态构建文档](static.md) 查看如何自定义二进制文件(扩展、PHP 版本......)。
+[阅读静态构建文档](static.md) 查看如何自定义二进制文件（扩展、PHP 版本等）。
 
 ## 分发二进制文件
 

--- a/docs/cn/github-actions.md
+++ b/docs/cn/github-actions.md
@@ -5,27 +5,27 @@
 
 ## 设置 GitHub Actions
 
-在存储库设置中的机密下，添加以下机密：
+在存储库设置中的 `secrets` 下，添加以下字段：
 
-- `REGISTRY_LOGIN_SERVER`: 要使用的 docker 注册表 (例如 `docker.io`).
-- `REGISTRY_USERNAME`: 用于登录注册表的用户名 (例如 `dunglas`).
-- `REGISTRY_PASSWORD`: 用于登录注册表的密码 (例如 访问密钥).
-- `IMAGE_NAME`: 镜像的名称 (例如 `dunglas/frankenphp`).
+- `REGISTRY_LOGIN_SERVER`: 要使用的 docker registry（如 `docker.io`）。
+- `REGISTRY_USERNAME`: 用于登录 registry 的用户名（如 `dunglas`）。
+- `REGISTRY_PASSWORD`: 用于登录 registry 的密码（如 `access key`）。
+- `IMAGE_NAME`: 镜像的名称（如 `dunglas/frankenphp`）。
 
 ## 构建和推送镜像
 
-1. 创建拉取请求或推送到分支。
-2. GitHub Actions 将生成镜像并运行任何测试。
-3. 如果生成成功，则将使用 `pr-x`，其中 `x` 是 PR 编号，作为标记将镜像推送到注册表。
+1. 创建 Pull Request 或推送到你的 Fork 分支。
+2. GitHub Actions 将生成镜像并运行每项测试。
+3. 如果生成成功，则将使用 `pr-x` 推送 registry，其中 `x` 是 PR 编号，作为标记将镜像推送到注册表。
 
 ## 部署镜像
 
-1. 合并拉取请求后，GitHub Actions 将再次运行测试并生成新镜像。
-2. 如果构建成功，则 Docker 注册表中的 `main` 标记将更新。
+1. 合并 Pull Request 后，GitHub Actions 将再次运行测试并生成新镜像。
+2. 如果构建成功，则 Docker 注册表中的 `main` tag 将更新。
 
-## 释放
+## 发布
 
-1. 在存储库中创建新标签。
-2. GitHub Actions 将生成镜像并运行任何测试。
-3. 如果构建成功，镜像将使用标记名称作为标记推送到注册表(例如，将创建 `v1.2.3` 和 `v1.2`)。
+1. 在项目仓库中创建新 Tag。
+2. GitHub Actions 将生成镜像并运行每项测试。
+3. 如果构建成功，镜像将使用标记名称作为标记推送到 registry（例如，将创建 `v1.2.3` 和 `v1.2`）。
 4. `latest` 标签也将更新。

--- a/docs/cn/laravel.md
+++ b/docs/cn/laravel.md
@@ -17,7 +17,7 @@ docker run -p 80:80 -p 443:443 -p 443:443/udp -v $PWD:/app dunglas/frankenphp
 或者，你可以从本地机器上使用 FrankenPHP 运行 Laravel 项目：
 
 1. [下载与您的系统相对应的二进制文件](https://github.com/dunglas/frankenphp/releases)
-2. 将以下配置添加到Laravel项目根目录中名为 `Caddyfile` 的文件中：
+2. 将以下配置添加到 Laravel 项目根目录中名为 `Caddyfile` 的文件中：
 
     ```caddyfile
     {
@@ -36,7 +36,7 @@ docker run -p 80:80 -p 443:443 -p 443:443/udp -v $PWD:/app dunglas/frankenphp
     }
     ```
 
-3. 从 Laravel 项目的根目录启动 FrankenPHP： `./frankenphp run`
+3. 从 Laravel 项目的根目录启动 FrankenPHP：`./frankenphp run`
 
 ## Laravel Octane
 
@@ -60,16 +60,16 @@ php artisan octane:start
 
 `octane:start` 命令可以采用以下选项：
 
-* `--host`: 服务器应绑定到的 IP 地址 (默认值: `127.0.0.1`)
-* `--port`: 服务器应可用的端口 (默认值: `8000`)
-* `--admin-port`: 管理服务器应可用的端口 (默认值: `2019`)
-* `--workers`: 应可用于处理请求的 worker 数 (默认值: `auto`)
-* `--max-requests`: 在重新加载服务之前要处理的请求数 (默认值: `500`)
+* `--host`: 服务器应绑定到的 IP 地址（默认值: `127.0.0.1`）
+* `--port`: 服务器应可用的端口（默认值: `8000`）
+* `--admin-port`: 管理服务器应可用的端口（默认值: `2019`）
+* `--workers`: 应可用于处理请求的 worker 数（默认值: `auto`）
+* `--max-requests`: 在 worker 重启之前要处理的请求数（默认值: `500`）
 * `--caddyfile`: FrankenPHP `Caddyfile` 文件的路径
-* `--https`: 开启 HTTPS、HTTP/2 和 HTTP/3，自动生成和续订证书
-* `--http-redirect`: 启用 HTTP 到 HTTPS 重定向(仅在通过 --https 时启用)
+* `--https`: 开启 HTTPS、HTTP/2 和 HTTP/3，自动生成和延长证书
+* `--http-redirect`: 启用 HTTP 到 HTTPS 重定向（仅在使用 `--https` 时启用）
 * `--watch`: 修改应用程序时自动重新加载服务器
 * `--poll`: 在监视时使用文件系统轮询，以便通过网络监视文件
 * `--log-level`: 在指定日志级别或高于指定日志级别的日志消息
 
-了解更多关于 [Laravel Octane 在其官方文档](https://laravel.com/docs/octane)。
+你可以了解更多关于 [Laravel Octane 官方文档](https://laravel.com/docs/octane)。

--- a/docs/cn/mercure.md
+++ b/docs/cn/mercure.md
@@ -1,12 +1,12 @@
 # 实时
 
-FrankenPHP 带有一个内置的 Mercure 集线器！
+FrankenPHP 带有一个内置的 Mercure Hub！
 Mercure 允许将事件实时推送到所有连接的设备：它们将立即收到 JavaScript 事件。
 
-无需JS库或SDK！
+无需 JS 库或 SDK！
 
 ![Mercure](https://mercure.rocks/static/main.png)
 
-要启用 Mercure 中心，请按照 [Mercure 网站](https://mercure.rocks/docs/hub/config)中的说明更新`Caddyfile`。
+要启用 Mercure Hub，请按照 [Mercure 网站](https://mercure.rocks/docs/hub/config) 中的说明更新 `Caddyfile`。
 
-要从您的代码中推送 Mercure 更新，我们推荐 [Symfony Mercure Component](https://symfony.com/components/Mercure)(您不需要 Symfony 全栈框架来使用它)。
+要从您的代码中推送 Mercure 更新，我们推荐 [Symfony Mercure Component](https://symfony.com/components/Mercure)（不需要 Symfony 框架来使用）。

--- a/docs/cn/production.md
+++ b/docs/cn/production.md
@@ -2,9 +2,9 @@
 
 在本教程中，我们将学习如何使用 Docker Compose 在单个服务器上部署 PHP 应用程序。
 
-如果您使用的是 Symfony，请阅读 Symfony Docker 项目(使用 FrankenPHP)的“[在生产环境中部署](https://github.com/dunglas/symfony-docker/blob/main/docs/production.md)”文档条目。
+如果您使用的是 Symfony，请阅读 Symfony Docker 项目（使用 FrankenPHP）的 [在生产环境中部署](https://github.com/dunglas/symfony-docker/blob/main/docs/production.md) 文档条目。
 
-如果您使用的是 API Platform(也使用 FrankenPHP)，请参阅 [框架的部署文档](https://api-platform.com/docs/deployment/)。
+如果您使用的是 API Platform（同样使用 FrankenPHP），请参阅 [框架的部署文档](https://api-platform.com/docs/deployment/)。
 
 ## 准备应用
 
@@ -13,12 +13,12 @@
 ```dockerfile
 FROM dunglas/frankenphp
 
-# 请务必将 "your-domain-name.example.com" 替换为您的域名
+# 请将 "your-domain-name.example.com" 替换为您的域名
 ENV SERVER_NAME=your-domain-name.example.com
 # 如果要禁用 HTTPS，请改用以下值：
 #ENV SERVER_NAME=:80
 
-# 启用 PHP 生产设置
+# 启用 PHP 生产配置
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
 # 将项目的 PHP 文件复制到 public 目录中
@@ -27,7 +27,7 @@ COPY . /app/public
 #COPY . /app
 ```
 
-有关更多详细信息和选项，请参阅“[构建自定义 Docker 镜像](docker.md)”，
+有关更多详细信息和选项，请参阅 [构建自定义 Docker 镜像](docker.md)。
 要了解如何自定义配置，请安装 PHP 扩展和 Caddy 模块。
 
 如果您的项目使用 Composer，
@@ -48,18 +48,18 @@ services:
       - caddy_data:/data
       - caddy_config:/config
 
-# Caddy 证书和配置所需的 volumes
+# Caddy 证书和配置所需的挂载目录
 volumes:
   caddy_data:
   caddy_config:
 ```
 
-> [!注意]
+> [!NOTE]
 > 前面的示例适用于生产用途。
-> 在开发中，您可能希望使用 volume，不同的 PHP 配置和不同的 `SERVER_NAME` 环境变量值。
+> 在开发中，你可能希望使用挂载目录，不同的 PHP 配置和不同的 `SERVER_NAME` 环境变量值。
 >
-> 看看 [Symfony Docker](https://github.com/dunglas/symfony-docker) 项目
-> (使用 FrankenPHP)作为使用多阶段镜像的更高级示例，
+> 见 [Symfony Docker](https://github.com/dunglas/symfony-docker) 项目
+> （使用 FrankenPHP）作为使用多阶段镜像的更高级示例，
 > Composer、额外的 PHP 扩展等。
 
 最后，如果您使用 Git，请提交这些文件并推送。
@@ -70,17 +70,17 @@ volumes:
 在本教程中，我们将使用 DigitalOcean 提供的虚拟机，但任何 Linux 服务器都可以工作。
 如果您已经有安装了 Docker 的 Linux 服务器，您可以直接跳到 [下一节](#配置域名)。
 
-否则，请使用 [此会员链接](https://m.do.co/c/5d8aabe3ab80) 获得 200 美元的免费信用额度，创建一个帐户，然后单击“创建 Droplet”。
-然后，单击“选择镜像”部分下的“市场”选项卡，然后搜索名为“Docker”的应用程序。
+否则，请使用 [此会员链接](https://m.do.co/c/5d8aabe3ab80) 获得 200 美元的免费信用额度，创建一个帐户，然后单击“Create a Droplet”。
+然后，单击“Choose an image”部分下的“Marketplace”选项卡，然后搜索名为“Docker”的应用程序。
 这将配置已安装最新版本的 Docker 和 Docker Compose 的 Ubuntu 服务器！
 
-出于测试目的，最便宜的计划就足够了。
-对于实际的生产用途，您可能需要在“常规用途”部分中选择一个计划来满足您的需求。
+出于测试目的，最便宜的就足够了。
+对于实际的生产用途，您可能需要在“general purpose”部分中选择一个计划来满足您的需求。
 
 ![使用 Docker 在 DigitalOcean 上部署 FrankenPHP](../digitalocean-droplet.png)
 
 您可以保留其他设置的默认值，也可以根据需要进行调整。
-不要忘记添加您的SSH密钥或创建密码，然后按“完成并创建”按钮。
+不要忘记添加您的 SSH 密钥或创建密码，然后点击“完成并创建”按钮。
 
 然后，在 Droplet 预配时等待几秒钟。
 Droplet 准备就绪后，使用 SSH 进行连接：
@@ -100,18 +100,18 @@ ssh root@<droplet-ip>
 your-domain-name.example.com.  IN  A     207.154.233.113
 ```
 
-DigitalOcean 域服务示例（“网络” > “域”）：
+DigitalOcean 域服务示例（“Networking” > “Domains”）：
 
 ![在 DigitalOcean 上配置 DNS](../digitalocean-dns.png)
 
-> [!注意]
+> [!NOTE]  
 > Let's Encrypt 是 FrankenPHP 默认用于自动生成 TLS 证书的服务，不支持使用裸 IP 地址。使用域名是使用 Let's Encrypt 的必要条件。
 
 ## 部署
 
 使用 `git clone`、`scp` 或任何其他可能适合您需要的工具在服务器上复制您的项目。
 如果使用 GitHub，则可能需要使用 [部署密钥](https://docs.github.com/en/free-pro-team@latest/developers/overview/managing-deploy-keys#deploy-keys)。
-部署密钥也[由 GitLab 支持](https://docs.gitlab.com/ee/user/project/deploy_keys/)。
+部署密钥也 [由 GitLab 支持](https://docs.gitlab.com/ee/user/project/deploy_keys/)。
 
 Git 示例：
 
@@ -128,11 +128,11 @@ docker compose up -d --wait
 您的服务器已启动并运行，并且已自动为您生成 HTTPS 证书。
 去 `https://your-domain-name.example.com` 享受吧！
 
-> [!谨慎]
+> [!CAUTION]
 > Docker 有一个缓存层，请确保每个部署都有正确的构建，或者使用 --no-cache 选项重新构建项目以避免缓存问题。
 
 ## 在多个节点上部署
 
 如果要在计算机集群上部署应用程序，可以使用 [Docker Swarm](https://docs.docker.com/engine/swarm/stack-deploy/)，
 它与提供的 Compose 文件兼容。
-要在 Kubernetes 上部署，请查看 [API 平台提供的 Helm 图表](https://api-platform.com/docs/deployment/kubernetes/)，它可以很容易地适应 Symfony Docker 的使用。
+要在 Kubernetes 上部署，请查看 [API 平台提供的 Helm 图表](https://api-platform.com/docs/deployment/kubernetes/)，同样也使用 FrankenPHP。

--- a/docs/cn/static.md
+++ b/docs/cn/static.md
@@ -1,9 +1,9 @@
 # 创建静态构建
 
-由于伟大的 [static-php-cli 项目](https://github.com/crazywhalecc/static-php-cli)，创建 FrankenPHP 的静态构建是可能的(尽管它的名字，这个项目支持所有 SAPI，而不仅仅是 CLI)，
-而不是使用 PHP 库的本地安装。
+基于 [static-php-cli](https://github.com/crazywhalecc/static-php-cli) 项目（这个项目支持所有 SAPI，不仅仅是 `cli`），
+FrankenPHP 已支持创建静态二进制，无需安装本地 PHP。
 
-使用这种方法，一个可移植的二进制文件将包含 PHP 解释器、Caddy Web 服务器和 FrankenPHP！
+使用这种方法，我们可构建一个包含 PHP 解释器、Caddy Web 服务器和 FrankenPHP 的可移植二进制文件！
 
 FrankenPHP 还支持 [将 PHP 应用程序嵌入到静态二进制文件中](embed.md)。
 
@@ -16,7 +16,7 @@ docker buildx bake --load static-builder
 docker cp $(docker create --name static-builder dunglas/frankenphp:static-builder):/go/src/app/dist/frankenphp-linux-$(uname -m) frankenphp ; docker rm static-builder
 ```
 
-生成的静态二进制文件名为 `frankenphp` ，可在当前目录中找到。
+生成的静态二进制文件名为 `frankenphp`，可在当前目录中找到。
 
 如果您想在没有 Docker 的情况下构建静态二进制文件，请查看 macOS 说明，它也适用于 Linux。
 
@@ -24,16 +24,16 @@ docker cp $(docker create --name static-builder dunglas/frankenphp:static-builde
 
 默认情况下，大多数流行的 PHP 扩展都会被编译。
 
-若要减小二进制文件的大小并减少攻击面，可以选择使用 `PHP_EXTENSIONS` Docker ARG 构建的扩展列表。
+若要减小二进制文件的大小并减少攻击面，可以选择使用 `PHP_EXTENSIONS` Docker 参数来自定义构建的扩展。
 
-例如，运行以下命令以仅生成 `opcache` 扩展：
+例如，运行以下命令以生成仅包含 `opcache,pdo_sqlite` 扩展的二进制：
 
 ```console
 docker buildx bake --load --set static-builder.args.PHP_EXTENSIONS=opcache,pdo_sqlite static-builder
 # ...
 ```
 
-若要将启用其他功能的库添加到已启用的扩展中，可以使用 `PHP_EXTENSION_LIBS` Docker ARG：
+若要将启用其他功能的库添加到已启用的扩展中，可以使用 `PHP_EXTENSION_LIBS` Docker 参数：
 
 ```console
 docker buildx bake \
@@ -47,7 +47,7 @@ docker buildx bake \
 
 ### GitHub Token
 
-如果达到 GitHub API 速率限制，请在名为 `GITHUB_TOKEN` 的环境变量中设置 GitHub Personal Access Token：
+如果遇到了 GitHub API 速率限制，请在 `GITHUB_TOKEN` 的环境变量中设置 GitHub Personal Access Token：
 
 ```console
 GITHUB_TOKEN="xxx" docker --load buildx bake static-builder
@@ -56,7 +56,7 @@ GITHUB_TOKEN="xxx" docker --load buildx bake static-builder
 
 ## macOS
 
-运行以下脚本以创建适用于 macOS 的静态二进制文件(必须安装 [Homebrew](https://brew.sh/))：
+运行以下脚本以创建适用于 macOS 的静态二进制文件（需要先安装 [Homebrew](https://brew.sh/)）：
 
 ```console
 git clone https://github.com/dunglas/frankenphp
@@ -64,7 +64,7 @@ cd frankenphp
 ./build-static.sh
 ```
 
-注意：此脚本也适用于 Linux(可能也适用于其他 Unix)，并由我们提供的基于 Docker 的静态构建器在内部使用。
+注意：此脚本也适用于 Linux（可能也适用于其他 Unix 系统），我们提供的用于构建静态二进制的 Docker 镜像也在内部使用这个脚本。
 
 ## 自定义构建
 
@@ -73,9 +73,9 @@ cd frankenphp
 
 * `FRANKENPHP_VERSION`: 要使用的 FrankenPHP 版本
 * `PHP_VERSION`: 要使用的 PHP 版本
-* `PHP_EXTENSIONS`: 要构建的 PHP 扩展 ([支持的扩展列表](https://static-php.dev/en/guide/extensions.html))
+* `PHP_EXTENSIONS`: 要构建的 PHP 扩展（[支持的扩展列表](https://static-php.dev/zh/guide/extensions.html)）
 * `PHP_EXTENSION_LIBS`: 要构建的额外库，为扩展添加额外的功能
 * `EMBED`: 要嵌入二进制文件的 PHP 应用程序的路径
-* `CLEAN`: 设置后，libphp 及其所有依赖项都是从头开始构建的(无缓存)
-* `DEBUG_SYMBOLS`: 设置后，调试符号不会被剥离，而是将添加到二进制文件中
-* `RELEASE`: (仅限维护者)设置后，生成的二进制文件将上传到 GitHub 上
+* `CLEAN`: 设置后，libphp 及其所有依赖项都是重新构建的（不使用缓存）
+* `DEBUG_SYMBOLS`: 设置后，调试符号将被保留在二进制文件内
+* `RELEASE`: （仅限维护者）设置后，生成的二进制文件将上传到 GitHub 上

--- a/docs/cn/worker.md
+++ b/docs/cn/worker.md
@@ -28,7 +28,7 @@ docker run \
 ## Symfony Runtime
 
 FrankenPHP 的 worker 模式由 [Symfony Runtime 组件](https://symfony.com/doc/current/components/runtime.html) 支持。
-要在 worker 中启动任何 Symfony 应用程序，请安装[PHP Runtime](https://github.com/php-runtime/runtime)的 FrankenPHP 软件包：
+要在 worker 中启动任何 Symfony 应用程序，请安装 [PHP Runtime](https://github.com/php-runtime/runtime) 的 FrankenPHP 软件包：
 
 ```console
 composer require runtime/frankenphp-symfony
@@ -47,7 +47,7 @@ docker run \
 
 ## Laravel Octane
 
-请参阅 [专用文档](laravel.md#laravel-octane)。
+请参阅 [文档](laravel.md#laravel-octane)。
 
 ## 自定义应用程序
 
@@ -66,10 +66,10 @@ require __DIR__.'/vendor/autoload.php';
 $myApp = new \App\Kernel();
 $myApp->boot();
 
-// 循环外的处理程序以获得更好的性能(减少工作量)
+// 循环外的处理程序以获得更好的性能（减少工作量）
 $handler = static function () use ($myApp) {
-        // 收到请求时调用,
-        // 超全局变量, php://input
+        // 收到请求时调用
+        // 超全局变量 php://input
         echo $myApp->handle($_GET, $_POST, $_COOKIE, $_FILES, $_SERVER);
 };
 for($nbRequests = 0, $running = true; isset($_SERVER['MAX_REQUESTS']) && ($nbRequests < ((int)$_SERVER['MAX_REQUESTS'])) && $running; ++$nbRequests) {
@@ -81,7 +81,7 @@ for($nbRequests = 0, $running = true; isset($_SERVER['MAX_REQUESTS']) && ($nbReq
     // 调用垃圾回收器以减少在页面生成过程中触发垃圾回收器的几率
     gc_collect_cycles();
 }
-// 清理
+// 结束清理
 $myApp->shutdown();
 ```
 
@@ -95,8 +95,8 @@ docker run \
     dunglas/frankenphp
 ```
 
-默认情况下，每个 CPU 启动一个 worker 线程。
-您还可以配置要启动的 worker 线程数：
+默认情况下，每个 CPU 启动一个 worker。
+您还可以配置要启动的 worker 数：
 
 ```console
 docker run \
@@ -106,9 +106,9 @@ docker run \
     dunglas/frankenphp
 ```
 
-### 在一定数量的请求后重新启动 Worker 线程
+### 在一定数量的请求后重新启动 Worker
 
-由于 PHP 最初不是为长时间运行的进程而设计的，因此仍然有许多库和遗留代码会泄漏内存。
+由于 PHP 最初不是为长时间运行的进程而设计的，因此仍然有许多库和遗留代码会发生内存泄露。
 在 worker 模式下使用此类代码的解决方法是在处理一定数量的请求后重新启动 worker 程序脚本：
 
-前面的 worker 线程代码段允许通过设置名为 `MAX_REQUESTS` 的环境变量来配置要处理的最大请求数。
+前面的 worker 代码段允许通过设置名为 `MAX_REQUESTS` 的环境变量来配置要处理的最大请求数。


### PR DESCRIPTION
I also started using FrankenPHP as a test server, but I find that a lot of improvements are needed in the documentation. My improvements do not involve modifications to the document content, just updates to more localized expressions and section formats.

- The Chinese Markdown format is based on [Chinese Markdown Writing Standard](https://github.com/fex-team/styleguide/blob/master/markdown.md) and [another extended guide](https://stdrc.cc/style-guides/chinese).
- Fix some format (e.g. special markdown block cannot be translated: `[!提示]` -> `[!TIP]`).
- Some linked sites offer Chinese versions.
- Some English expressions cannot be translated directly into Chinese, so English is retained (this is consistent with the context).