### PR TITLE
Fix Markdown styling of --http-redirect option in README

### DIFF
--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -67,7 +67,7 @@ The `octane:start` command can take the following options:
 * `--max-requests`: The number of requests to process before reloading the server (default: `500`)
 * `--caddyfile`: The path to the FrankenPHP `Caddyfile` file
 * `--https`: Enable HTTPS, HTTP/2, and HTTP/3, and automatically generate and renew certificates
-* --http-redirect : Enable HTTP to HTTPS redirection (only enabled if --https is passed)
+* `--http-redirect`: Enable HTTP to HTTPS redirection (only enabled if --https is passed)
 * `--watch`: Automatically reload the server when the application is modified
 * `--poll`: Use file system polling while watching in order to watch files over a network
 * `--log-level`: Log messages at or above the specified log level


### PR DESCRIPTION
Adds missing tick marks around the `--http-redirect` option in the Laravel Octane section of README.md.

<img width="1129" alt="Screenshot 2024-03-02 at 7 44 19 PM" src="https://github.com/dunglas/frankenphp/assets/145663/beb94a1b-d4c8-47bf-b5ce-dd46bd8fdf33">

<img width="1280" alt="Screenshot 2024-03-02 at 7 48 18 PM" src="https://github.com/dunglas/frankenphp/assets/145663/befe20d3-a9bc-459b-9d69-9edba1d7f048">

