### PR TITLE
docs: remove unnecessary parenthesis

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -109,7 +109,7 @@ docker run \
 
 ## Composer Scripts Referencing `@php`
 
-[Composer scripts](https://getcomposer.org/doc/articles/scripts.md) may want to execute a PHP binary for some tasks, e.g. in [a Laravel project](laravel.md) to run `@php artisan package:discover --ansi`. This [currently fails](https://github.com/dunglas/frankenphp/issues/483#issuecomment-1899890915)) for two reasons:
+[Composer scripts](https://getcomposer.org/doc/articles/scripts.md) may want to execute a PHP binary for some tasks, e.g. in [a Laravel project](laravel.md) to run `@php artisan package:discover --ansi`. This [currently fails](https://github.com/dunglas/frankenphp/issues/483#issuecomment-1899890915) for two reasons:
 
 * Composer does not know how to call the FrankenPHP binary;
 * Composer may add PHP settings using the `-d` flag in the command, which FrankenPHP does not yet support.


### PR DESCRIPTION
I'm sorry, there was still another unnecessary parenthesis in the link to the issue page.