### PR TITLE
fix: crash when a write error occurs

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -730,15 +730,11 @@ static void *manager_thread(void *arg) {
   // SIGPIPE must be masked in non-Go threads:
   // https://pkg.go.dev/os/signal#hdr-Go_programs_that_use_cgo_or_SWIG
   sigset_t set;
-  if (pthread_sigmask(SIG_SETMASK, NULL, &set) != 0) {
-    perror("failed to get sigmask");
-    exit(EXIT_FAILURE);
-  }
-
+  sigemptyset(&set);
   sigaddset(&set, SIGPIPE);
 
   if (pthread_sigmask(SIG_BLOCK, &set, NULL) != 0) {
-    perror("failed to set sigmask");
+    perror("failed to block SIGPIPE");
     exit(EXIT_FAILURE);
   }
 

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -12,6 +12,7 @@
 #include <php_output.h>
 #include <php_variables.h>
 #include <sapi/embed/php_embed.h>
+#include <signal.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -726,6 +727,20 @@ sapi_module_struct frankenphp_sapi_module = {
     STANDARD_SAPI_MODULE_PROPERTIES};
 
 static void *manager_thread(void *arg) {
+  // SIGPIPE must be masked in non-Go threads: https://pkg.go.dev/os/signal#hdr-Go_programs_that_use_cgo_or_SWIG
+  sigset_t set;
+  if (pthread_sigmask(SIG_SETMASK, NULL, &set) != 0) {
+    perror("failed to get sigmask");
+    exit(EXIT_FAILURE);
+  }
+
+  sigaddset(&set, SIGPIPE);
+  
+  if (pthread_sigmask(SIG_BLOCK, &set, NULL) != 0) {
+    perror("failed to set sigmask");
+    exit(EXIT_FAILURE);
+  }
+
 #ifdef ZTS
   // TODO: use tsrm_startup() directly as we know the number of expected threads
   php_tsrm_startup();

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -727,7 +727,8 @@ sapi_module_struct frankenphp_sapi_module = {
     STANDARD_SAPI_MODULE_PROPERTIES};
 
 static void *manager_thread(void *arg) {
-  // SIGPIPE must be masked in non-Go threads: https://pkg.go.dev/os/signal#hdr-Go_programs_that_use_cgo_or_SWIG
+  // SIGPIPE must be masked in non-Go threads:
+  // https://pkg.go.dev/os/signal#hdr-Go_programs_that_use_cgo_or_SWIG
   sigset_t set;
   if (pthread_sigmask(SIG_SETMASK, NULL, &set) != 0) {
     perror("failed to get sigmask");
@@ -735,7 +736,7 @@ static void *manager_thread(void *arg) {
   }
 
   sigaddset(&set, SIGPIPE);
-  
+
   if (pthread_sigmask(SIG_BLOCK, &set, NULL) != 0) {
     perror("failed to set sigmask");
     exit(EXIT_FAILURE);


### PR DESCRIPTION
`SIGPIPE` must be masked in the non-Go threads to prevent unexpected crashes: https://pkg.go.dev/os/signal#hdr-Go_programs_that_use_cgo_or_SWIG

Thanks @bukka for the bug report and the stack trace!

This is likely a cause (but maybe not the only one) of https://github.com/dunglas/frankenphp/issues/557