### PR TITLE
fix reading post bodies

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -746,12 +746,6 @@ func go_read_post(rh C.uintptr_t, cBuf *C.char, countBytes C.size_t) (readBytes 
 		readBytes += C.size_t(n)
 	}
 
-	if err != nil && err != io.EOF {
-		// invalid Read on closed Body may happen because of https://github.com/golang/go/issues/15527
-		fc, _ := FromContext(r.Context())
-		fc.logger.Error("error while reading the request body", zap.Error(err))
-	}
-
 	return
 }
 


### PR DESCRIPTION
Now that https://github.com/golang/go/issues/15527 is supposedly fixed, this condition should be no-longer needed. Further, if php didn't request enough bytes, this condition would be hit. It appears PHP requests chunks ~2mb in size at a time.

Fixes #122 