### PR TITLE
chore: git clone `php-src` to 1 depth level in dev mode

### DIFF
--- a/dev-alpine.Dockerfile
+++ b/dev-alpine.Dockerfile
@@ -39,7 +39,7 @@ RUN apk add --no-cache \
 	echo 'set auto-load safe-path /' > /root/.gdbinit
 
 WORKDIR /usr/local/src/php
-RUN git clone --branch=PHP-8.3 https://github.com/php/php-src.git . && \
+RUN git clone --branch=PHP-8.3 --depth=1 https://github.com/php/php-src.git . && \
 	# --enable-embed is only necessary to generate libphp.so, we don't use this SAPI directly
 	./buildconf --force && \
 	./configure \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update && \
 	apt-get clean 
 
 WORKDIR /usr/local/src/php
-RUN git clone --branch=PHP-8.3 https://github.com/php/php-src.git . && \
+RUN git clone --branch=PHP-8.3 --depth=1 https://github.com/php/php-src.git . && \
 	# --enable-embed is only necessary to generate libphp.so, we don't use this SAPI directly
 	./buildconf --force && \
 	./configure \


### PR DESCRIPTION
The git clone command for `php-src` is updated to include the depth parameter for a shallow clone, reducing history and speeding up the process. The current size is ~760MiB while with the shallow clone it is reduced to ~225MiB.