### PR TITLE
Update large file upload test

### DIFF
--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -540,7 +540,7 @@ func testLargeRequest(t *testing.T, opts *testOptions) {
 		req := httptest.NewRequest(
 			"POST",
 			fmt.Sprintf("http://example.com/large-request.php?i=%d", i),
-			strings.NewReader(strings.Repeat("f", 1_048_576)),
+			strings.NewReader(strings.Repeat("f", 6_048_576)),
 		)
 		w := httptest.NewRecorder()
 		handler(w, req)
@@ -548,7 +548,7 @@ func testLargeRequest(t *testing.T, opts *testOptions) {
 		resp := w.Result()
 		body, _ := io.ReadAll(resp.Body)
 
-		assert.Contains(t, string(body), fmt.Sprintf("Request body size: 1048576 (%d)", i))
+		assert.Contains(t, string(body), fmt.Sprintf("Request body size: 6048576 (%d)", i))
 	}, opts)
 }
 


### PR DESCRIPTION
This makes the file size 6mb-ish, more than the 2mb batching that PHP does. I verified this fails on 0e163a0a751ccbc8493e7bfeea2fb7301d01bbd8 (`main` prior to #686).