### PR TITLE
Enable full duplex for http1 connections

### DIFF
--- a/caddy/frankenphp/Caddyfile
+++ b/caddy/frankenphp/Caddyfile
@@ -5,6 +5,10 @@
 		#worker /path/to/your/worker.php
 		{$FRANKENPHP_CONFIG}
 	}
+	
+	servers {
+		enable_full_duplex
+	}
 
 	# https://caddyserver.com/docs/caddyfile/directives#sorting-algorithm
 	order mercure after encode

--- a/caddy/frankenphp/Caddyfile
+++ b/caddy/frankenphp/Caddyfile
@@ -5,10 +5,6 @@
 		#worker /path/to/your/worker.php
 		{$FRANKENPHP_CONFIG}
 	}
-	
-	servers {
-		enable_full_duplex
-	}
 
 	# https://caddyserver.com/docs/caddyfile/directives#sorting-algorithm
 	order mercure after encode

--- a/docs/config.md
+++ b/docs/config.md
@@ -132,7 +132,7 @@ php_server [<matcher>] {
 ### Full Duplex (HTTP/1)
 
 When using HTTP/1.x, it may be desirable to enable full-duplex mode to allow writing a response before the entire body
-has been read. (for example: websockets, SSE, etc.)
+has been read. (for example: WebSocket, Server-Sent Events, etc.)
 
 This is an opt-in configuration that needs to be added to the global options in the caddyfile:
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -129,7 +129,7 @@ php_server [<matcher>] {
 }
 ```
 
-### Full Duplex (h1)
+### Full Duplex (HTTP/1)
 
 When using http 1.x, it may be desirable to enable full-duplex mode to allow writing a response before the entire body
 has been read. (for example: websockets, SSE, etc.)

--- a/docs/config.md
+++ b/docs/config.md
@@ -144,6 +144,9 @@ This is an opt-in configuration that needs to be added to the global options in 
 }
 ```
 
+> ![CAUTION]
+>
+> Enabling this option may cause old HTTP/1.x clients that don't support full-duplex to deadlock.
 This can also be configured using the `CADDY_GLOBAL_OPTIONS` environment config:
 
 ```

--- a/docs/config.md
+++ b/docs/config.md
@@ -149,12 +149,11 @@ This is an opt-in configuration that needs to be added to the global options in 
 > Enabling this option may cause old HTTP/1.x clients that don't support full-duplex to deadlock.
 This can also be configured using the `CADDY_GLOBAL_OPTIONS` environment config:
 
-```
+```sh
 CADDY_GLOBAL_OPTIONS="servers { enable_full_duplex }"
 ```
 
-You can find more information about this setting in Caddy documentation: 
-https://caddyserver.com/docs/caddyfile/options#enable-full-duplex
+You can find more information about this setting in the [Caddy documentation](https://caddyserver.com/docs/caddyfile/options#enable-full-duplex).
 
 ## Environment Variables
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -131,7 +131,7 @@ php_server [<matcher>] {
 
 ### Full Duplex (HTTP/1)
 
-When using http 1.x, it may be desirable to enable full-duplex mode to allow writing a response before the entire body
+When using HTTP/1.x, it may be desirable to enable full-duplex mode to allow writing a response before the entire body
 has been read. (for example: websockets, SSE, etc.)
 
 This is an opt-in configuration that needs to be added to the global options in the caddyfile:

--- a/docs/config.md
+++ b/docs/config.md
@@ -150,7 +150,7 @@ This is an opt-in configuration that needs to be added to the global options in 
 This can also be configured using the `CADDY_GLOBAL_OPTIONS` environment config:
 
 ```
-ENV CADDY_GLOBAL_OPTIONS="servers { enable_full_duplex }"
+CADDY_GLOBAL_OPTIONS="servers { enable_full_duplex }"
 ```
 
 You can find more information about this setting in Caddy documentation: 

--- a/docs/config.md
+++ b/docs/config.md
@@ -134,7 +134,7 @@ php_server [<matcher>] {
 When using HTTP/1.x, it may be desirable to enable full-duplex mode to allow writing a response before the entire body
 has been read. (for example: WebSocket, Server-Sent Events, etc.)
 
-This is an opt-in configuration that needs to be added to the global options in the caddyfile:
+This is an opt-in configuration that needs to be added to the global options in the `Caddyfile`:
 
 ```caddyfile
 {

--- a/docs/config.md
+++ b/docs/config.md
@@ -129,6 +129,30 @@ php_server [<matcher>] {
 }
 ```
 
+### Full Duplex (h1)
+
+When using http 1.x, it may be desirable to enable full-duplex mode to allow writing a response before the entire body
+has been read. (for example: websockets, SSE, etc.)
+
+This is an opt-in configuration that needs to be added to the global options in the caddyfile:
+
+```caddyfile
+{
+  servers {
+    enable_full_duplex
+  }
+}
+```
+
+This can also be configured using the `CADDY_GLOBAL_OPTIONS` environment config:
+
+```
+ENV CADDY_GLOBAL_OPTIONS="servers { enable_full_duplex }"
+```
+
+You can find more information about this setting in Caddy documentation: 
+https://caddyserver.com/docs/caddyfile/options#enable-full-duplex
+
 ## Environment Variables
 
 The following environment variables can be used to inject Caddy directives in the `Caddyfile` without modifying it:

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -720,13 +720,6 @@ func go_sapi_flush(rh C.uintptr_t) bool {
 		return true
 	}
 
-	if r.ProtoMajor == 1 {
-		if _, err := r.Body.Read(nil); err != nil {
-			// Don't flush until the whole body has been read to prevent https://github.com/golang/go/issues/15527
-			return false
-		}
-	}
-
 	if err := http.NewResponseController(fc.responseWriter).Flush(); err != nil {
 		fc.logger.Error("the current responseWriter is not a flusher", zap.Error(err))
 	}


### PR DESCRIPTION
There are two things here:

1. Per https://github.com/dunglas/frankenphp/pull/686#issuecomment-2018378525, we can let caddy handle the duplexity of http1. So the Caddyfile is updated to include this by default.

- [x] check the documentation for caddyfile references and update if necessary

2. An empty body was actually impossible to "read" (`file_get_contents('php://input')` didn't even work), thus causing things like #690 to be unable to work for http1 connections.

- [x] triple check for other cases like this

kudos: @francislavoie 

fixes: #690 