### PR TITLE
docs: Added missing slash in multiline command.

### DIFF
--- a/docs/cn/known-issues.md
+++ b/docs/cn/known-issues.md
@@ -91,7 +91,7 @@ docker run \
 
 ```console
 docker run \
-    -e CADDY_GLOBAL_OPTIONS="debug"
+    -e CADDY_GLOBAL_OPTIONS="debug" \
     -e SERVER_NAME="127.0.0.1" \
     -v $PWD:/app/public \
     -p 80:80 -p 443:443 -p 443:443/udp \

--- a/docs/fr/known-issues.md
+++ b/docs/fr/known-issues.md
@@ -101,7 +101,7 @@ Si ce n'est pas le cas, lancez FrankenPHP en mode debug pour essayer de comprend
 
 ```console
 docker run \
-    -e CADDY_GLOBAL_OPTIONS="debug"
+    -e CADDY_GLOBAL_OPTIONS="debug" \
     -e SERVER_NAME="127.0.0.1" \
     -v $PWD:/app/public \
     -p 80:80 -p 443:443 -p 443:443/udp \

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -101,7 +101,7 @@ If that's not the case, start FrankenPHP in debug mode to try to figure out the 
 
 ```console
 docker run \
-    -e CADDY_GLOBAL_OPTIONS="debug"
+    -e CADDY_GLOBAL_OPTIONS="debug" \
     -e SERVER_NAME="127.0.0.1" \
     -v $PWD:/app/public \
     -p 80:80 -p 443:443 -p 443:443/udp \

--- a/docs/tr/known-issues.md
+++ b/docs/tr/known-issues.md
@@ -99,7 +99,7 @@ Eğer durum böyle değilse, sorunu anlamaya çalışmak için FrankenPHP'yi hat
 
 ```console
 docker run \
-    -e CADDY_GLOBAL_OPTIONS="debug"
+    -e CADDY_GLOBAL_OPTIONS="debug" \
     -e SERVER_NAME="127.0.0.1" \
     -v $PWD:/app/public \
     -p 80:80 -p 443:443 -p 443:443/udp \


### PR DESCRIPTION
The slash to indicate that the command is multiline was missing and produced an error in the command after copying and pasting.