### PR TITLE
limit concurrency for static/docker builds

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,5 +1,8 @@
 ---
 name: Build Docker images
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
 on:
   pull_request:
     branches:

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -1,5 +1,8 @@
 ---
 name: Build binary releases
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
 on:
   pull_request:
     branches:


### PR DESCRIPTION
This limits the concurrency of the builds for docker/static images to one per branch/tag, and halts currently running builds. This applies even to the main branch to prevent a race condition where two build groups are running, and the first one finishes after the second one, thus committing a "latest" tag that isn't the latest tag.

See https://docs.github.com/en/actions/using-jobs/using-concurrency