### PR TITLE
feat: autodetect extensions to build for embedded apps

### DIFF
--- a/build-static.sh
+++ b/build-static.sh
@@ -16,7 +16,14 @@ if [ "${os}" = "darwin" ]; then
 fi
 
 if [ -z "${PHP_EXTENSIONS}" ]; then
-    export PHP_EXTENSIONS="apcu,bcmath,bz2,calendar,ctype,curl,dba,dom,exif,fileinfo,filter,gd,iconv,igbinary,intl,ldap,mbregex,mbstring,mysqli,mysqlnd,opcache,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sodium,sqlite3,sysvsem,tokenizer,xml,xmlreader,xmlwriter,zip,zlib"
+    if [ -n "${EMBED}" ] && [ -f "${EMBED}/composer.json" ]; then
+        cd "${EMBED}"
+        PHP_EXTENSIONS="$(composer check-platform-reqs --no-dev 2>/dev/null | grep ^ext | sed -e 's/^ext-//' -e 's/ .*//' | xargs | tr ' ' ',')"
+        export PHP_EXTENSIONS
+        cd -
+    else
+        export PHP_EXTENSIONS="apcu,bcmath,bz2,calendar,ctype,curl,dba,dom,exif,fileinfo,filter,gd,iconv,igbinary,intl,ldap,mbregex,mbstring,mysqli,mysqlnd,opcache,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,readline,redis,session,simplexml,sockets,sodium,sqlite3,sysvsem,tokenizer,xml,xmlreader,xmlwriter,zip,zlib"
+    fi
 fi
 
 if [ -z "${PHP_EXTENSION_LIBS}" ]; then

--- a/build-static.sh
+++ b/build-static.sh
@@ -18,7 +18,8 @@ fi
 if [ -z "${PHP_EXTENSIONS}" ]; then
     if [ -n "${EMBED}" ] && [ -f "${EMBED}/composer.json" ]; then
         cd "${EMBED}"
-        PHP_EXTENSIONS="$(composer check-platform-reqs --no-dev 2>/dev/null | grep ^ext | sed -e 's/^ext-//' -e 's/ .*//' | xargs | tr ' ' ',')"
+        # Replace "libxml" by "xml" for compatibility with Static PHP CLI extension name
+        PHP_EXTENSIONS="$(composer check-platform-reqs --no-dev 2>/dev/null | grep ^ext | sed -e 's/^ext-//' -e 's/ .*//' -e 's/^libxml$/xml/' | xargs | tr ' ' ',')"
         export PHP_EXTENSIONS
         cd -
     else

--- a/docs/embed.md
+++ b/docs/embed.md
@@ -54,9 +54,7 @@ The easiest way to create a Linux binary is to use the Docker-based builder we p
 
     # Build the static binary, be sure to select only the PHP extensions you want
     WORKDIR /go/src/app/
-    RUN EMBED=dist/app/ \
-        PHP_EXTENSIONS=ctype,iconv,pdo_sqlite \
-        ./build-static.sh
+    RUN EMBED=dist/app/ ./build-static.sh
     ```
 
     > [!CAUTION]
@@ -85,9 +83,7 @@ If you don't want to use Docker, or want to build a macOS binary, use the shell 
 ```console
 git clone https://github.com/dunglas/frankenphp
 cd frankenphp
-EMBED=/path/to/your/app \
-    PHP_EXTENSIONS=ctype,iconv,pdo_sqlite \
-    ./build-static.sh
+EMBED=/path/to/your/app ./build-static.sh
 ```
 
 The resulting binary is the file named `frankenphp-<os>-<arch>` in the `dist/` directory.
@@ -119,6 +115,13 @@ You can also run the PHP CLI scripts embedded in your binary:
 ```console
 ./my-app php-cli bin/console
 ```
+
+## PHP Extensions
+
+By default, the script will build extensions required by the `composer.json` file of your project, if any.
+If the `composer.json` file doesn't exist, the default extensions are built, as documented in [the static builds entry](static.md).
+
+To customize the extensions, use the `PHP_EXTENSIONS` environment variable.
 
 ## Customizing The Build
 


### PR DESCRIPTION
This patch uses Composer to automatically detect the required extensions of an app embedded in a standalone binary, and build only these!