### PR TITLE
Tideways now supports FrankenPHP in normal and worker mode

### DIFF
--- a/docs/fr/known-issues.md
+++ b/docs/fr/known-issues.md
@@ -44,7 +44,6 @@ Les extensions suivantes sont connues pour ne pas être compatibles avec Franken
 Les extensions suivantes ont des bugs connus ou des comportements inattendus lorsqu'elles sont utilisées avec FrankenPHP :
 
 Nom | Problème
-[Tideways](https://tideways.com/) | En mode worker, l'extension Tideways [empêche les scripts workers de se terminer correctement ou consomme 100% du CPU](https://github.com/dunglas/frankenphp/issues/578#issuecomment-1966620351). Ce problème a été signalé à Tideways.
 [ext-openssl](https://www.php.net/manual/fr/book.openssl.php) | Lors de l'utilisation d'une version statique de FrankenPHP (construite avec la libc musl), l'extension OpenSSL peut planter sous de fortes charges. Une solution consiste à utiliser une version liée dynamiquement (comme celle utilisée dans les images Docker). Ce bogue est [suivi par PHP](https://github.com/php/php-src/issues/13648).
 
 ## get_browser

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -45,7 +45,6 @@ The following extensions have known bugs and unexpected behaviors when used with
 
 | Name                                                          | Problem                                                                                                                                                                                                                                                                                         |
 |---------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [Tideways](https://tideways.com/)                             | In worker mode, the Tideways extension [prevents worker scripts from finishing properly](https://github.com/dunglas/frankenphp/issues/578#issuecomment-1966620351) or consumes 100% of the CPU. This has been reported to Tideways.                                                             |
 | [ext-openssl](https://www.php.net/manual/en/book.openssl.php) | When using a static build of FrankenPHP (built with the musl libc), the OpenSSL extension may crash under heavy loads. A workaround is to use a dynamically linked build (like the one used in Docker images). This bug is [being tracked by PHP](https://github.com/php/php-src/issues/13648). |
 
 ## get_browser

--- a/docs/tr/known-issues.md
+++ b/docs/tr/known-issues.md
@@ -44,7 +44,6 @@ Aşağıdaki eklentiler FrankenPHP ile kullanıldığında bilinen hatalara ve b
 
 | Adı                               | Problem                                                                                                                                                                                                                                                    |
 |-----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [Tideways](https://tideways.com/) | Worker modunda, Tideways eklentisi [worker komut dosyalarının düzgün şekilde sonlandırılmasını engelliyor](https://github.com/dunglas/frankenphp/issues/578#issuecomment-1966620351) veya CPU'nun %100'ünü tüketiyor. Bu durum Tideways'e bildirilmiştir. |
 
 ## get_browser
 


### PR DESCRIPTION
With the recent version 5.8.0 Tideways now supports FrankenPHP.

See for docs: https://support.tideways.com/documentation/setup/installation/frankenphp.html