### PR TITLE
fix: DOMdocument not found when building embedded apps

### DIFF
--- a/static-builder.Dockerfile
+++ b/static-builder.Dockerfile
@@ -33,7 +33,6 @@ RUN apk update; \
 		bison \
 		build-base \
 		cmake \
-		composer \
 		curl \
 		file \
 		flex \
@@ -70,6 +69,7 @@ RUN apk update; \
 
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
 ENV COMPOSER_ALLOW_SUPERUSER=1
+COPY --from=composer/composer:2-bin /composer /usr/bin/composer
 
 WORKDIR /go/src/app
 COPY go.mod go.sum ./


### PR DESCRIPTION
Installing Composer using the Alpine package manager forces the installation of PHP 8.2 in addition to PHP 8.3. This can create issues when Composer runs post-install scripts.

Closes https://github.com/dunglas/frankenphp/issues/693.