### PR TITLE
docs: embedding Laravel apps

### DIFF
--- a/docs/embed.md
+++ b/docs/embed.md
@@ -6,6 +6,8 @@ Thanks to this feature, PHP applications can be distributed as standalone binari
 
 Learn more about this feature [in the presentation made by Kévin at SymfonyCon 2023](https://dunglas.dev/2023/12/php-and-symfony-apps-as-standalone-binaries/).
 
+For embedding Laravel applications, [read this specific documentation entry](laravel.md#laravel-apps-as-standalone-binaries).
+
 ## Preparing Your App
 
 Before creating the self-contained binary be sure that your app is ready for embedding.
@@ -29,7 +31,8 @@ cd $TMPDIR/my-prepared-app
 echo APP_ENV=prod > .env.local
 echo APP_DEBUG=0 >> .env.local
 
-# Remove the tests
+# Remove the tests and other unneeded files to save space
+# Alternatively, add these files with the export-ignore attribute in your .gitattributes file
 rm -Rf tests/
 
 # Install the dependencies
@@ -43,7 +46,7 @@ composer dump-env prod
 
 The easiest way to create a Linux binary is to use the Docker-based builder we provide.
 
-1. Create a file named `static-build.Dockerfile` in the repository of your prepared app:
+1. Create a file named `static-build.Dockerfile` in the repository of your app:
 
     ```dockerfile
     FROM --platform=linux/amd64 dunglas/frankenphp:static-builder
@@ -52,7 +55,7 @@ The easiest way to create a Linux binary is to use the Docker-based builder we p
     WORKDIR /go/src/app/dist/app
     COPY . .
 
-    # Build the static binary, be sure to select only the PHP extensions you want
+    # Build the static binary
     WORKDIR /go/src/app/
     RUN EMBED=dist/app/ ./build-static.sh
     ```
@@ -62,6 +65,7 @@ The easiest way to create a Linux binary is to use the Docker-based builder we p
     > Some `.dockerignore` files (e.g. default [Symfony Docker `.dockerignore`](https://github.com/dunglas/symfony-docker/blob/main/.dockerignore))
     > will ignore the `vendor/` directory and `.env` files. Be sure to adjust or remove the `.dockerignore` file before the build.
 
+2. Follow the steps to prepare your app for embedding
 2. Build:
 
     ```console

--- a/docs/embed.md
+++ b/docs/embed.md
@@ -65,7 +65,6 @@ The easiest way to create a Linux binary is to use the Docker-based builder we p
     > Some `.dockerignore` files (e.g. default [Symfony Docker `.dockerignore`](https://github.com/dunglas/symfony-docker/blob/main/.dockerignore))
     > will ignore the `vendor/` directory and `.env` files. Be sure to adjust or remove the `.dockerignore` file before the build.
 
-2. Follow the steps to prepare your app for embedding
 2. Build:
 
     ```console

--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -154,3 +154,18 @@ Your app is now ready!
 
 Learn more about the options available and how to build binaries for other OSes in the [applications embedding](embed.md)
 documentation.
+
+### Running Octane With Standalone Binaries
+
+It's even possible to package Laravel Octane apps as standalone binaries!
+
+To do so, [install Octane properly](#laravel-octane) and follow the steps described in [the previous section](#laravel-apps-as-standalone-binaries).
+
+Then, to start FrankenPHP in worker mode through Octane, run:
+
+```console
+PATH="$PWD:$PATH" ./frankenphp php-cli artisan octane:frankephp
+```
+
+> ![WARNING]
+> For the command to work, the standalone binary **must** be named `frankenphp`.

--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -164,8 +164,8 @@ To do so, [install Octane properly](#laravel-octane) and follow the steps descri
 Then, to start FrankenPHP in worker mode through Octane, run:
 
 ```console
-PATH="$PWD:$PATH" ./frankenphp php-cli artisan octane:frankephp
+PATH="$PWD:$PATH" ./frankenphp php-cli artisan octane:frankenphp
 ```
 
-> ![WARNING]
+> ![CAUTION]
 > For the command to work, the standalone binary **must** be named `frankenphp`.

--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -155,6 +155,13 @@ Your app is now ready!
 Learn more about the options available and how to build binaries for other OSes in the [applications embedding](embed.md)
 documentation.
 
+### Changing The Storage Path
+
+By default, Laravel stores uploaded files, caches, logs, etc. in the application's `storage/` directory.
+This is not suitable for embedded applications, as each new version will be extracted into a different temporary directory.
+
+Set the `LARAVEL_STORAGE_PATH` environment variable (for example, in your `.env` file) or call the `Illuminate\Foundation\Application::useStoragePath()` method to use a directory outside the temporary directory.
+
 ### Running Octane With Standalone Binaries
 
 It's even possible to package Laravel Octane apps as standalone binaries!

--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -144,7 +144,7 @@ Follow these steps to package your Laravel app as a standalone binary for Linux:
     ./frankenphp php-cli artisan key:generate
     ```
 
-5. Start the server:
+7. Start the server:
 
     ```console
     ./frankenphp php-server

--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -111,7 +111,7 @@ Follow these steps to package your Laravel app as a standalone binary for Linux:
 
     > [!CAUTION]
     >
-    > Some `.dockerignore` files 
+    > Some `.dockerignore` files
     > will ignore the `vendor/` directory and `.env` files. Be sure to adjust or remove the `.dockerignore` file before the build.
 
 2. Build:
@@ -128,27 +128,27 @@ Follow these steps to package your Laravel app as a standalone binary for Linux:
 
 4. Populate caches:
 
-	```console
-	./frankenphp php-cli artisan optimize
-	```
+    ```console
+    ./frankenphp php-cli artisan optimize
+    ```
 
 5. Run database migrations (if any):
 
-	```console
-	./frankenphp php-cli artisan migrate
-	````
+    ```console
+    ./frankenphp php-cli artisan migrate
+    ````
 
-6. Generate app's secret key
+6. Generate app's secret key:
 
-	```console
-	./frankenphp php-cli artisan key:generate
-	```
+    ```console
+    ./frankenphp php-cli artisan key:generate
+    ```
 
 5. Start the server:
 
-	```console
-	./frankenphp php-server
-	```
+    ```console
+    ./frankenphp php-server
+    ```
 
 Your app is now ready!
 

--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -123,31 +123,31 @@ Follow these steps to package your Laravel app as a standalone binary for Linux:
 3. Extract the binary:
 
     ```console
-    docker cp $(docker create --name static-laravel-app-tmp static-laravel-app):/go/src/app/dist/frankenphp-linux-x86_64 my-laravel-app ; docker rm static-laravel-app-tmp
+    docker cp $(docker create --name static-laravel-app-tmp static-laravel-app):/go/src/app/dist/frankenphp-linux-x86_64 frankenphp ; docker rm static-laravel-app-tmp
     ```
 
 4. Populate caches:
 
 	```console
-	./my-laravel-app php-cli artisan optimize
+	./frankenphp php-cli artisan optimize
 	```
 
 5. Run database migrations (if any):
 
 	```console
-	./my-laravel-app php-cli artisan migrate
+	./frankenphp php-cli artisan migrate
 	````
 
 6. Generate app's secret key
 
 	```console
-	./my-laravel-app php-cli artisan key:generate
+	./frankenphp php-cli artisan key:generate
 	```
 
 5. Start the server:
 
 	```console
-	./app/my-laravel-app php-server
+	./frankenphp php-server
 	```
 
 Your app is now ready!

--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -168,4 +168,5 @@ PATH="$PWD:$PATH" ./frankenphp php-cli artisan octane:frankenphp
 ```
 
 > ![CAUTION]
+>
 > For the command to work, the standalone binary **must** be named `frankenphp`.

--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -169,4 +169,5 @@ PATH="$PWD:$PATH" ./frankenphp php-cli artisan octane:frankenphp
 
 > ![CAUTION]
 >
-> For the command to work, the standalone binary **must** be named `frankenphp`.
+> For the command to work, the standalone binary **must** be named `frankenphp`
+> because Octane needs a program named `frankenphp` available in the path.


### PR DESCRIPTION
Closes https://github.com/dunglas/frankenphp/issues/605.

Needs https://github.com/laravel/framework/pull/51243 if `LARAVEL_STORAGE_PATH` is set without using the `.env` file.