### PR TITLE
fix: temporary directory name for embed apps

### DIFF
--- a/build-static.sh
+++ b/build-static.sh
@@ -225,7 +225,7 @@ cd ../
 # Embed PHP app, if any
 if [ -n "${EMBED}" ] && [ -d "${EMBED}" ]; then
     tar -cf app.tar -C "${EMBED}" .
-    ${md5binary} app.tar > app_checksum.txt
+    ${md5binary} app.tar | awk '{printf $1}' > app_checksum.txt
 fi
 
 cd caddy/frankenphp/

--- a/embed.go
+++ b/embed.go
@@ -32,7 +32,7 @@ func init() {
 		return
 	}
 
-	appPath := filepath.Join(os.TempDir(), "frankenphp_"+strings.TrimSuffix(string(embeddedAppChecksum[:]), "\n"))
+	appPath := filepath.Join(os.TempDir(), "frankenphp_"+string(embeddedAppChecksum))
 
 	if _, err := os.Stat(appPath); os.IsNotExist(err) {
 		if err := untar(appPath); err != nil {


### PR DESCRIPTION
On Linux, the output of `md5sum` is `<hash> <filename>`. This patch ensures that the generated directory name contains only the hash, not the filename (as on Mac).