### PR TITLE
Updating WordPress references to managed FrankenWP repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 FrankenPHP is a modern application server for PHP built on top of the [Caddy](https://caddyserver.com/) web server.
 
-FrankenPHP gives superpowers to your PHP apps thanks to its stunning features: [_Early Hints_](https://frankenphp.dev/docs/early-hints/), [worker mode](https://frankenphp.dev/docs/worker/), [real-time capabilities](https://frankenphp.dev/docs/mercure/), automatic HTTPS, HTTP/2, and HTTP/3 support...
+FrankenPHP gives superpowers to your PHP apps thanks to its stunning features: [*Early Hints*](https://frankenphp.dev/docs/early-hints/), [worker mode](https://frankenphp.dev/docs/worker/), [real-time capabilities](https://frankenphp.dev/docs/mercure/), automatic HTTPS, HTTP/2, and HTTP/3 support...
 
 FrankenPHP works with any PHP app and makes your Laravel and Symfony projects faster than ever thanks to their official integrations with the worker mode.
 
 FrankenPHP can also be used as a standalone Go library to embed PHP in any app using `net/http`.
 
-[**Learn more** on _frankenphp.dev_](https://frankenphp.dev) and in this slide deck:
+[**Learn more** on *frankenphp.dev*](https://frankenphp.dev) and in this slide deck:
 
 <a href="https://dunglas.dev/2022/10/frankenphp-the-modern-php-app-server-written-in-go/"><img src="https://dunglas.dev/wp-content/uploads/2022/10/frankenphp.png" alt="Slides" width="600"></a>
 
@@ -50,28 +50,28 @@ You can also run command-line scripts with:
 
 ## Docs
 
-- [The worker mode](https://frankenphp.dev/docs/worker/)
-- [Early Hints support (103 HTTP status code)](https://frankenphp.dev/docs/early-hints/)
-- [Real-time](https://frankenphp.dev/docs/mercure/)
-- [Configuration](https://frankenphp.dev/docs/config/)
-- [Docker images](https://frankenphp.dev/docs/docker/)
-- [Deploy in production](docs/production.md)
-- [Create **standalone**, self-executable PHP apps](https://frankenphp.dev/docs/embed/)
-- [Create static binaries](https://frankenphp.dev/docs/static/)
-- [Compile from sources](https://frankenphp.dev/docs/compile/)
-- [Laravel integration](https://frankenphp.dev/docs/laravel/)
-- [Known issues](https://frankenphp.dev/docs/known-issues/)
-- [Demo app (Symfony) and benchmarks](https://github.com/dunglas/frankenphp-demo)
-- [Go library documentation](https://pkg.go.dev/github.com/dunglas/frankenphp)
-- [Contributing and debugging](https://frankenphp.dev/docs/contributing/)
+* [The worker mode](https://frankenphp.dev/docs/worker/)
+* [Early Hints support (103 HTTP status code)](https://frankenphp.dev/docs/early-hints/)
+* [Real-time](https://frankenphp.dev/docs/mercure/)
+* [Configuration](https://frankenphp.dev/docs/config/)
+* [Docker images](https://frankenphp.dev/docs/docker/)
+* [Deploy in production](docs/production.md)
+* [Create **standalone**, self-executable PHP apps](https://frankenphp.dev/docs/embed/)
+* [Create static binaries](https://frankenphp.dev/docs/static/)
+* [Compile from sources](https://frankenphp.dev/docs/compile/)
+* [Laravel integration](https://frankenphp.dev/docs/laravel/)
+* [Known issues](https://frankenphp.dev/docs/known-issues/)
+* [Demo app (Symfony) and benchmarks](https://github.com/dunglas/frankenphp-demo)
+* [Go library documentation](https://pkg.go.dev/github.com/dunglas/frankenphp)
+* [Contributing and debugging](https://frankenphp.dev/docs/contributing/)
 
 ## Examples and Skeletons
 
-- [Symfony](https://github.com/dunglas/symfony-docker)
-- [API Platform](https://api-platform.com/docs/distribution/)
-- [Laravel](https://frankenphp.dev/docs/laravel/)
-- [Sulu](https://sulu.io/blog/running-sulu-with-frankenphp)
-- [WordPress](https://github.com/StephenMiracle/frankenwp)
-- [Drupal](https://github.com/dunglas/frankenphp-drupal)
-- [Joomla](https://github.com/alexandreelise/frankenphp-joomla)
-- [TYPO3](https://github.com/ochorocho/franken-typo3)
+* [Symfony](https://github.com/dunglas/symfony-docker)
+* [API Platform](https://api-platform.com/docs/distribution/)
+* [Laravel](https://frankenphp.dev/docs/laravel/)
+* [Sulu](https://sulu.io/blog/running-sulu-with-frankenphp)
+* [WordPress](https://github.com/StephenMiracle/frankenwp)
+* [Drupal](https://github.com/dunglas/frankenphp-drupal)
+* [Joomla](https://github.com/alexandreelise/frankenphp-joomla)
+* [TYPO3](https://github.com/ochorocho/franken-typo3)

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 FrankenPHP is a modern application server for PHP built on top of the [Caddy](https://caddyserver.com/) web server.
 
-FrankenPHP gives superpowers to your PHP apps thanks to its stunning features: [*Early Hints*](https://frankenphp.dev/docs/early-hints/), [worker mode](https://frankenphp.dev/docs/worker/), [real-time capabilities](https://frankenphp.dev/docs/mercure/), automatic HTTPS, HTTP/2, and HTTP/3 support...
+FrankenPHP gives superpowers to your PHP apps thanks to its stunning features: [_Early Hints_](https://frankenphp.dev/docs/early-hints/), [worker mode](https://frankenphp.dev/docs/worker/), [real-time capabilities](https://frankenphp.dev/docs/mercure/), automatic HTTPS, HTTP/2, and HTTP/3 support...
 
 FrankenPHP works with any PHP app and makes your Laravel and Symfony projects faster than ever thanks to their official integrations with the worker mode.
 
 FrankenPHP can also be used as a standalone Go library to embed PHP in any app using `net/http`.
 
-[**Learn more** on *frankenphp.dev*](https://frankenphp.dev) and in this slide deck:
+[**Learn more** on _frankenphp.dev_](https://frankenphp.dev) and in this slide deck:
 
 <a href="https://dunglas.dev/2022/10/frankenphp-the-modern-php-app-server-written-in-go/"><img src="https://dunglas.dev/wp-content/uploads/2022/10/frankenphp.png" alt="Slides" width="600"></a>
 
@@ -50,28 +50,28 @@ You can also run command-line scripts with:
 
 ## Docs
 
-* [The worker mode](https://frankenphp.dev/docs/worker/)
-* [Early Hints support (103 HTTP status code)](https://frankenphp.dev/docs/early-hints/)
-* [Real-time](https://frankenphp.dev/docs/mercure/)
-* [Configuration](https://frankenphp.dev/docs/config/)
-* [Docker images](https://frankenphp.dev/docs/docker/)
-* [Deploy in production](docs/production.md)
-* [Create **standalone**, self-executable PHP apps](https://frankenphp.dev/docs/embed/)
-* [Create static binaries](https://frankenphp.dev/docs/static/)
-* [Compile from sources](https://frankenphp.dev/docs/compile/)
-* [Laravel integration](https://frankenphp.dev/docs/laravel/)
-* [Known issues](https://frankenphp.dev/docs/known-issues/)
-* [Demo app (Symfony) and benchmarks](https://github.com/dunglas/frankenphp-demo)
-* [Go library documentation](https://pkg.go.dev/github.com/dunglas/frankenphp)
-* [Contributing and debugging](https://frankenphp.dev/docs/contributing/)
+- [The worker mode](https://frankenphp.dev/docs/worker/)
+- [Early Hints support (103 HTTP status code)](https://frankenphp.dev/docs/early-hints/)
+- [Real-time](https://frankenphp.dev/docs/mercure/)
+- [Configuration](https://frankenphp.dev/docs/config/)
+- [Docker images](https://frankenphp.dev/docs/docker/)
+- [Deploy in production](docs/production.md)
+- [Create **standalone**, self-executable PHP apps](https://frankenphp.dev/docs/embed/)
+- [Create static binaries](https://frankenphp.dev/docs/static/)
+- [Compile from sources](https://frankenphp.dev/docs/compile/)
+- [Laravel integration](https://frankenphp.dev/docs/laravel/)
+- [Known issues](https://frankenphp.dev/docs/known-issues/)
+- [Demo app (Symfony) and benchmarks](https://github.com/dunglas/frankenphp-demo)
+- [Go library documentation](https://pkg.go.dev/github.com/dunglas/frankenphp)
+- [Contributing and debugging](https://frankenphp.dev/docs/contributing/)
 
 ## Examples and Skeletons
 
-* [Symfony](https://github.com/dunglas/symfony-docker)
-* [API Platform](https://api-platform.com/docs/distribution/)
-* [Laravel](https://frankenphp.dev/docs/laravel/)
-* [Sulu](https://sulu.io/blog/running-sulu-with-frankenphp)
-* [WordPress](https://github.com/dunglas/frankenphp-wordpress)
-* [Drupal](https://github.com/dunglas/frankenphp-drupal)
-* [Joomla](https://github.com/alexandreelise/frankenphp-joomla)
-* [TYPO3](https://github.com/ochorocho/franken-typo3)
+- [Symfony](https://github.com/dunglas/symfony-docker)
+- [API Platform](https://api-platform.com/docs/distribution/)
+- [Laravel](https://frankenphp.dev/docs/laravel/)
+- [Sulu](https://sulu.io/blog/running-sulu-with-frankenphp)
+- [WordPress](https://github.com/StephenMiracle/frankenwp)
+- [Drupal](https://github.com/dunglas/frankenphp-drupal)
+- [Joomla](https://github.com/alexandreelise/frankenphp-joomla)
+- [TYPO3](https://github.com/ochorocho/franken-typo3)

--- a/docs/cn/README.md
+++ b/docs/cn/README.md
@@ -10,7 +10,7 @@ FrankenPHP 可与任何 PHP 应用程序一起使用，并且由于提供了与 
 
 FrankenPHP 也可以用作独立的 Go 库，将 PHP 嵌入到任何使用 net/http 的应用程序中。
 
-[**了解更多** *frankenphp.dev*](https://frankenphp.dev/cn) 以及在以下地址中：
+[**了解更多** _frankenphp.dev_](https://frankenphp.dev/cn) 以及在以下地址中：
 
 <a href="https://dunglas.dev/2022/10/frankenphp-the-modern-php-app-server-written-in-go/"><img src="https://dunglas.dev/wp-content/uploads/2022/10/frankenphp.png" alt="Slides" width="600"></a>
 
@@ -50,28 +50,28 @@ docker run -v $PWD:/app/public \
 
 ## 文档
 
-* [worker 模式](worker.md)
-* [早期提示支持(103 HTTP status code)](early-hints.md)
-* [实时功能](mercure.md)
-* [配置](config.md)
-* [Docker 镜像](docker.md)
-* [在生产环境中部署](production.md)
-* [创建独立、可自行执行的 PHP 应用程序](embed.md)
-* [创建静态二进制文件](static.md)
-* [从源代码编译](compile.md)
-* [Laravel 集成](laravel.md)
-* [已知问题](known-issues.md)
-* [演示应用程序 (Symfony) 和性能测试](https://github.com/dunglas/frankenphp-demo)
-* [Go 库文档](https://pkg.go.dev/github.com/dunglas/frankenphp)
-* [贡献和调试](https://frankenphp.dev/docs/contributing/)
+- [worker 模式](worker.md)
+- [早期提示支持(103 HTTP status code)](early-hints.md)
+- [实时功能](mercure.md)
+- [配置](config.md)
+- [Docker 镜像](docker.md)
+- [在生产环境中部署](production.md)
+- [创建独立、可自行执行的 PHP 应用程序](embed.md)
+- [创建静态二进制文件](static.md)
+- [从源代码编译](compile.md)
+- [Laravel 集成](laravel.md)
+- [已知问题](known-issues.md)
+- [演示应用程序 (Symfony) 和性能测试](https://github.com/dunglas/frankenphp-demo)
+- [Go 库文档](https://pkg.go.dev/github.com/dunglas/frankenphp)
+- [贡献和调试](https://frankenphp.dev/docs/contributing/)
 
 ## 示例和框架
 
-* [Symfony](https://github.com/dunglas/symfony-docker)
-* [API Platform](https://api-platform.com/docs/distribution/)
-* [Laravel](laravel.md)
-* [Sulu](https://sulu.io/blog/running-sulu-with-frankenphp)
-* [WordPress](https://github.com/dunglas/frankenphp-wordpress)
-* [Drupal](https://github.com/dunglas/frankenphp-drupal)
-* [Joomla](https://github.com/alexandreelise/frankenphp-joomla)
-* [TYPO3](https://github.com/ochorocho/franken-typo3)
+- [Symfony](https://github.com/dunglas/symfony-docker)
+- [API Platform](https://api-platform.com/docs/distribution/)
+- [Laravel](laravel.md)
+- [Sulu](https://sulu.io/blog/running-sulu-with-frankenphp)
+- [WordPress](https://github.com/StephenMiracle/frankenwp)
+- [Drupal](https://github.com/dunglas/frankenphp-drupal)
+- [Joomla](https://github.com/alexandreelise/frankenphp-joomla)
+- [TYPO3](https://github.com/ochorocho/franken-typo3)

--- a/docs/cn/README.md
+++ b/docs/cn/README.md
@@ -10,7 +10,7 @@ FrankenPHP 可与任何 PHP 应用程序一起使用，并且由于提供了与 
 
 FrankenPHP 也可以用作独立的 Go 库，将 PHP 嵌入到任何使用 net/http 的应用程序中。
 
-[**了解更多** _frankenphp.dev_](https://frankenphp.dev/cn) 以及在以下地址中：
+[**了解更多** *frankenphp.dev*](https://frankenphp.dev/cn) 以及在以下地址中：
 
 <a href="https://dunglas.dev/2022/10/frankenphp-the-modern-php-app-server-written-in-go/"><img src="https://dunglas.dev/wp-content/uploads/2022/10/frankenphp.png" alt="Slides" width="600"></a>
 
@@ -50,28 +50,28 @@ docker run -v $PWD:/app/public \
 
 ## 文档
 
-- [worker 模式](worker.md)
-- [早期提示支持(103 HTTP status code)](early-hints.md)
-- [实时功能](mercure.md)
-- [配置](config.md)
-- [Docker 镜像](docker.md)
-- [在生产环境中部署](production.md)
-- [创建独立、可自行执行的 PHP 应用程序](embed.md)
-- [创建静态二进制文件](static.md)
-- [从源代码编译](compile.md)
-- [Laravel 集成](laravel.md)
-- [已知问题](known-issues.md)
-- [演示应用程序 (Symfony) 和性能测试](https://github.com/dunglas/frankenphp-demo)
-- [Go 库文档](https://pkg.go.dev/github.com/dunglas/frankenphp)
-- [贡献和调试](https://frankenphp.dev/docs/contributing/)
+* [worker 模式](worker.md)
+* [早期提示支持(103 HTTP status code)](early-hints.md)
+* [实时功能](mercure.md)
+* [配置](config.md)
+* [Docker 镜像](docker.md)
+* [在生产环境中部署](production.md)
+* [创建独立、可自行执行的 PHP 应用程序](embed.md)
+* [创建静态二进制文件](static.md)
+* [从源代码编译](compile.md)
+* [Laravel 集成](laravel.md)
+* [已知问题](known-issues.md)
+* [演示应用程序 (Symfony) 和性能测试](https://github.com/dunglas/frankenphp-demo)
+* [Go 库文档](https://pkg.go.dev/github.com/dunglas/frankenphp)
+* [贡献和调试](https://frankenphp.dev/docs/contributing/)
 
 ## 示例和框架
 
-- [Symfony](https://github.com/dunglas/symfony-docker)
-- [API Platform](https://api-platform.com/docs/distribution/)
-- [Laravel](laravel.md)
-- [Sulu](https://sulu.io/blog/running-sulu-with-frankenphp)
-- [WordPress](https://github.com/StephenMiracle/frankenwp)
-- [Drupal](https://github.com/dunglas/frankenphp-drupal)
-- [Joomla](https://github.com/alexandreelise/frankenphp-joomla)
-- [TYPO3](https://github.com/ochorocho/franken-typo3)
+* [Symfony](https://github.com/dunglas/symfony-docker)
+* [API Platform](https://api-platform.com/docs/distribution/)
+* [Laravel](laravel.md)
+* [Sulu](https://sulu.io/blog/running-sulu-with-frankenphp)
+* [WordPress](https://github.com/StephenMiracle/frankenwp)
+* [Drupal](https://github.com/dunglas/frankenphp-drupal)
+* [Joomla](https://github.com/alexandreelise/frankenphp-joomla)
+* [TYPO3](https://github.com/ochorocho/franken-typo3)

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -4,7 +4,7 @@
 
 FrankenPHP est un serveur d'applications moderne pour PHP construit à partir du serveur web [Caddy](https://caddyserver.com/).
 
-FrankenPHP donne des super-pouvoirs à vos applications PHP grâce à ses fonctionnalités à la pointe : [_Early Hints_](early-hints.md), [mode worker](worker.md), [fonctionnalités en temps réel](mercure.md), HTTPS automatique, prise en charge de HTTP/2 et HTTP/3...
+FrankenPHP donne des super-pouvoirs à vos applications PHP grâce à ses fonctionnalités à la pointe : [*Early Hints*](early-hints.md), [mode worker](worker.md), [fonctionnalités en temps réel](mercure.md), HTTPS automatique, prise en charge de HTTP/2 et HTTP/3...
 
 FrankenPHP fonctionne avec n'importe quelle application PHP et rend vos projets Laravel et Symfony plus rapides que jamais grâce à leurs intégrations officielles avec le mode worker.
 
@@ -50,28 +50,28 @@ Vous pouvez également exécuter des scripts en ligne de commande avec :
 
 ## Documentation
 
-- [Le mode worker](worker.md)
-- [Le support des Early Hints (code de statut HTTP 103)](early-hints.md)
-- [Temps réel](mercure.md)
-- [Configuration](config.md)
-- [Images Docker](docker.md)
-- [Déploiement en production](production.md)
-- [Créer des applications PHP **standalone**, auto-exécutables](embed.md)
-- [Créer un build statique](static.md)
-- [Compiler depuis les sources](compile.md)
-- [Intégration Laravel](laravel.md)
-- [Problèmes connus](known-issues.md)
-- [Application de démo (Symfony) et benchmarks](https://github.com/dunglas/frankenphp-demo)
-- [Documentation de la bibliothèque Go](https://pkg.go.dev/github.com/dunglas/frankenphp)
-- [Contribuer et débugger](CONTRIBUTING.md)
+* [Le mode worker](worker.md)
+* [Le support des Early Hints (code de statut HTTP 103)](early-hints.md)
+* [Temps réel](mercure.md)
+* [Configuration](config.md)
+* [Images Docker](docker.md)
+* [Déploiement en production](production.md)
+* [Créer des applications PHP **standalone**, auto-exécutables](embed.md)
+* [Créer un build statique](static.md)
+* [Compiler depuis les sources](compile.md)
+* [Intégration Laravel](laravel.md)
+* [Problèmes connus](known-issues.md)
+* [Application de démo (Symfony) et benchmarks](https://github.com/dunglas/frankenphp-demo)
+* [Documentation de la bibliothèque Go](https://pkg.go.dev/github.com/dunglas/frankenphp)
+* [Contribuer et débugger](CONTRIBUTING.md)
 
 ## Exemples et squelettes
 
-- [Symfony](https://github.com/dunglas/symfony-docker)
-- [API Platform](https://api-platform.com/docs/distribution/)
-- [Laravel](laravel.md)
-- [Sulu](https://sulu.io/blog/running-sulu-with-frankenphp)
-- [WordPress](https://github.com/StephenMiracle/frankenwp)
-- [Drupal](https://github.com/dunglas/frankenphp-drupal)
-- [Joomla](https://github.com/alexandreelise/frankenphp-joomla)
-- [TYPO3](https://github.com/ochorocho/franken-typo3)
+* [Symfony](https://github.com/dunglas/symfony-docker)
+* [API Platform](https://api-platform.com/docs/distribution/)
+* [Laravel](laravel.md)
+* [Sulu](https://sulu.io/blog/running-sulu-with-frankenphp)
+* [WordPress](https://github.com/StephenMiracle/frankenwp)
+* [Drupal](https://github.com/dunglas/frankenphp-drupal)
+* [Joomla](https://github.com/alexandreelise/frankenphp-joomla)
+* [TYPO3](https://github.com/ochorocho/franken-typo3)

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -4,7 +4,7 @@
 
 FrankenPHP est un serveur d'applications moderne pour PHP construit à partir du serveur web [Caddy](https://caddyserver.com/).
 
-FrankenPHP donne des super-pouvoirs à vos applications PHP grâce à ses fonctionnalités à la pointe : [*Early Hints*](early-hints.md), [mode worker](worker.md), [fonctionnalités en temps réel](mercure.md), HTTPS automatique, prise en charge de HTTP/2 et HTTP/3...
+FrankenPHP donne des super-pouvoirs à vos applications PHP grâce à ses fonctionnalités à la pointe : [_Early Hints_](early-hints.md), [mode worker](worker.md), [fonctionnalités en temps réel](mercure.md), HTTPS automatique, prise en charge de HTTP/2 et HTTP/3...
 
 FrankenPHP fonctionne avec n'importe quelle application PHP et rend vos projets Laravel et Symfony plus rapides que jamais grâce à leurs intégrations officielles avec le mode worker.
 
@@ -50,28 +50,28 @@ Vous pouvez également exécuter des scripts en ligne de commande avec :
 
 ## Documentation
 
-* [Le mode worker](worker.md)
-* [Le support des Early Hints (code de statut HTTP 103)](early-hints.md)
-* [Temps réel](mercure.md)
-* [Configuration](config.md)
-* [Images Docker](docker.md)
-* [Déploiement en production](production.md)
-* [Créer des applications PHP **standalone**, auto-exécutables](embed.md)
-* [Créer un build statique](static.md)
-* [Compiler depuis les sources](compile.md)
-* [Intégration Laravel](laravel.md)
-* [Problèmes connus](known-issues.md)
-* [Application de démo (Symfony) et benchmarks](https://github.com/dunglas/frankenphp-demo)
-* [Documentation de la bibliothèque Go](https://pkg.go.dev/github.com/dunglas/frankenphp)
-* [Contribuer et débugger](CONTRIBUTING.md)
+- [Le mode worker](worker.md)
+- [Le support des Early Hints (code de statut HTTP 103)](early-hints.md)
+- [Temps réel](mercure.md)
+- [Configuration](config.md)
+- [Images Docker](docker.md)
+- [Déploiement en production](production.md)
+- [Créer des applications PHP **standalone**, auto-exécutables](embed.md)
+- [Créer un build statique](static.md)
+- [Compiler depuis les sources](compile.md)
+- [Intégration Laravel](laravel.md)
+- [Problèmes connus](known-issues.md)
+- [Application de démo (Symfony) et benchmarks](https://github.com/dunglas/frankenphp-demo)
+- [Documentation de la bibliothèque Go](https://pkg.go.dev/github.com/dunglas/frankenphp)
+- [Contribuer et débugger](CONTRIBUTING.md)
 
 ## Exemples et squelettes
 
-* [Symfony](https://github.com/dunglas/symfony-docker)
-* [API Platform](https://api-platform.com/docs/distribution/)
-* [Laravel](laravel.md)
-* [Sulu](https://sulu.io/blog/running-sulu-with-frankenphp)
-* [WordPress](https://github.com/dunglas/frankenphp-wordpress)
-* [Drupal](https://github.com/dunglas/frankenphp-drupal)
-* [Joomla](https://github.com/alexandreelise/frankenphp-joomla)
-* [TYPO3](https://github.com/ochorocho/franken-typo3)
+- [Symfony](https://github.com/dunglas/symfony-docker)
+- [API Platform](https://api-platform.com/docs/distribution/)
+- [Laravel](laravel.md)
+- [Sulu](https://sulu.io/blog/running-sulu-with-frankenphp)
+- [WordPress](https://github.com/StephenMiracle/frankenwp)
+- [Drupal](https://github.com/dunglas/frankenphp-drupal)
+- [Joomla](https://github.com/alexandreelise/frankenphp-joomla)
+- [TYPO3](https://github.com/ochorocho/franken-typo3)

--- a/docs/tr/README.md
+++ b/docs/tr/README.md
@@ -4,13 +4,13 @@
 
 FrankenPHP, [Caddy](https://caddyserver.com/) web sunucusunun üzerine inşa edilmiş PHP için modern bir uygulama sunucusudur.
 
-FrankenPHP, çarpıcı özellikleri sayesinde PHP uygulamalarınıza süper güçler kazandırır: [Early Hints*](https://frankenphp.dev/docs/early-hints/), [worker modu](https://frankenphp.dev/docs/worker/), [real-time yetenekleri](https://frankenphp.dev/docs/mercure/), otomatik HTTPS, HTTP/2 ve HTTP/3 desteği...
+FrankenPHP, çarpıcı özellikleri sayesinde PHP uygulamalarınıza süper güçler kazandırır: [Early Hints\*](https://frankenphp.dev/docs/early-hints/), [worker modu](https://frankenphp.dev/docs/worker/), [real-time yetenekleri](https://frankenphp.dev/docs/mercure/), otomatik HTTPS, HTTP/2 ve HTTP/3 desteği...
 
 FrankenPHP herhangi bir PHP uygulaması ile çalışır ve worker modu ile resmi entegrasyonları sayesinde Laravel ve Symfony projelerinizi her zamankinden daha performanslı hale getirir.
 
 FrankenPHP, PHP'yi `net/http` kullanarak herhangi bir uygulamaya yerleştirmek için bağımsız bir Go kütüphanesi olarak da kullanılabilir.
 
-[*Frankenphp.dev*](https://frankenphp.dev) adresinden ve bu slayt üzerinden daha fazlasını öğrenin:
+[_Frankenphp.dev_](https://frankenphp.dev) adresinden ve bu slayt üzerinden daha fazlasını öğrenin:
 
 <a href="https://dunglas.dev/2022/10/frankenphp-the-modern-php-app-server-written-in-go/"><img src="https://dunglas.dev/wp-content/uploads/2022/10/frankenphp.png" alt="Slides" width="600"></a>
 
@@ -50,28 +50,28 @@ Ayrıca aşağıdaki tek komut satırı ile de çalıştırabilirsiniz:
 
 ## Docs
 
-* [Worker modu](https://frankenphp.dev/docs/worker/)
-* [Early Hints desteği (103 HTTP durum kodu)](https://frankenphp.dev/docs/early-hints/)
-* [Real-time](https://frankenphp.dev/docs/mercure/)
-* [Konfigürasyon](https://frankenphp.dev/docs/config/)
-* [Docker imajları](https://frankenphp.dev/docs/docker/)
-* [Production'a dağıtım](docs/production.md)
-* [**Bağımsız** kendiliğinden çalıştırılabilir PHP uygulamaları oluşturma](https://frankenphp.dev/docs/embed/)
-* [Statik binary'leri oluşturma](https://frankenphp.dev/docs/static/)
-* [Kaynak dosyalarından derleme](https://frankenphp.dev/docs/compile/)
-* [Laravel entegrasyonu](https://frankenphp.dev/docs/laravel/)
-* [Bilinen sorunlar](https://frankenphp.dev/docs/known-issues/)
-* [Demo uygulama (Symfony) ve kıyaslamalar](https://github.com/dunglas/frankenphp-demo)
-* [Go kütüphane dokümantasonu](https://pkg.go.dev/github.com/dunglas/frankenphp)
-* [Katkıda bulunma ve hata ayıklama](https://frankenphp.dev/docs/contributing/)
+- [Worker modu](https://frankenphp.dev/docs/worker/)
+- [Early Hints desteği (103 HTTP durum kodu)](https://frankenphp.dev/docs/early-hints/)
+- [Real-time](https://frankenphp.dev/docs/mercure/)
+- [Konfigürasyon](https://frankenphp.dev/docs/config/)
+- [Docker imajları](https://frankenphp.dev/docs/docker/)
+- [Production'a dağıtım](docs/production.md)
+- [**Bağımsız** kendiliğinden çalıştırılabilir PHP uygulamaları oluşturma](https://frankenphp.dev/docs/embed/)
+- [Statik binary'leri oluşturma](https://frankenphp.dev/docs/static/)
+- [Kaynak dosyalarından derleme](https://frankenphp.dev/docs/compile/)
+- [Laravel entegrasyonu](https://frankenphp.dev/docs/laravel/)
+- [Bilinen sorunlar](https://frankenphp.dev/docs/known-issues/)
+- [Demo uygulama (Symfony) ve kıyaslamalar](https://github.com/dunglas/frankenphp-demo)
+- [Go kütüphane dokümantasonu](https://pkg.go.dev/github.com/dunglas/frankenphp)
+- [Katkıda bulunma ve hata ayıklama](https://frankenphp.dev/docs/contributing/)
 
 ## Örnekler ve İskeletler
 
-* [Symfony](https://github.com/dunglas/symfony-docker)
-* [API Platform](https://api-platform.com/docs/distribution/)
-* [Laravel](https://frankenphp.dev/docs/laravel/)
-* [Sulu](https://sulu.io/blog/running-sulu-with-frankenphp)
-* [WordPress](https://github.com/dunglas/frankenphp-wordpress)
-* [Drupal](https://github.com/dunglas/frankenphp-drupal)
-* [Joomla](https://github.com/alexandreelise/frankenphp-joomla)
-* [TYPO3](https://github.com/ochorocho/franken-typo3)
+- [Symfony](https://github.com/dunglas/symfony-docker)
+- [API Platform](https://api-platform.com/docs/distribution/)
+- [Laravel](https://frankenphp.dev/docs/laravel/)
+- [Sulu](https://sulu.io/blog/running-sulu-with-frankenphp)
+- [WordPress](https://github.com/StephenMiracle/frankenwp)
+- [Drupal](https://github.com/dunglas/frankenphp-drupal)
+- [Joomla](https://github.com/alexandreelise/frankenphp-joomla)
+- [TYPO3](https://github.com/ochorocho/franken-typo3)

--- a/docs/tr/README.md
+++ b/docs/tr/README.md
@@ -4,13 +4,13 @@
 
 FrankenPHP, [Caddy](https://caddyserver.com/) web sunucusunun üzerine inşa edilmiş PHP için modern bir uygulama sunucusudur.
 
-FrankenPHP, çarpıcı özellikleri sayesinde PHP uygulamalarınıza süper güçler kazandırır: [Early Hints\*](https://frankenphp.dev/docs/early-hints/), [worker modu](https://frankenphp.dev/docs/worker/), [real-time yetenekleri](https://frankenphp.dev/docs/mercure/), otomatik HTTPS, HTTP/2 ve HTTP/3 desteği...
+FrankenPHP, çarpıcı özellikleri sayesinde PHP uygulamalarınıza süper güçler kazandırır: [Early Hints*](https://frankenphp.dev/docs/early-hints/), [worker modu](https://frankenphp.dev/docs/worker/), [real-time yetenekleri](https://frankenphp.dev/docs/mercure/), otomatik HTTPS, HTTP/2 ve HTTP/3 desteği...
 
 FrankenPHP herhangi bir PHP uygulaması ile çalışır ve worker modu ile resmi entegrasyonları sayesinde Laravel ve Symfony projelerinizi her zamankinden daha performanslı hale getirir.
 
 FrankenPHP, PHP'yi `net/http` kullanarak herhangi bir uygulamaya yerleştirmek için bağımsız bir Go kütüphanesi olarak da kullanılabilir.
 
-[_Frankenphp.dev_](https://frankenphp.dev) adresinden ve bu slayt üzerinden daha fazlasını öğrenin:
+[*Frankenphp.dev*](https://frankenphp.dev) adresinden ve bu slayt üzerinden daha fazlasını öğrenin:
 
 <a href="https://dunglas.dev/2022/10/frankenphp-the-modern-php-app-server-written-in-go/"><img src="https://dunglas.dev/wp-content/uploads/2022/10/frankenphp.png" alt="Slides" width="600"></a>
 
@@ -50,28 +50,28 @@ Ayrıca aşağıdaki tek komut satırı ile de çalıştırabilirsiniz:
 
 ## Docs
 
-- [Worker modu](https://frankenphp.dev/docs/worker/)
-- [Early Hints desteği (103 HTTP durum kodu)](https://frankenphp.dev/docs/early-hints/)
-- [Real-time](https://frankenphp.dev/docs/mercure/)
-- [Konfigürasyon](https://frankenphp.dev/docs/config/)
-- [Docker imajları](https://frankenphp.dev/docs/docker/)
-- [Production'a dağıtım](docs/production.md)
-- [**Bağımsız** kendiliğinden çalıştırılabilir PHP uygulamaları oluşturma](https://frankenphp.dev/docs/embed/)
-- [Statik binary'leri oluşturma](https://frankenphp.dev/docs/static/)
-- [Kaynak dosyalarından derleme](https://frankenphp.dev/docs/compile/)
-- [Laravel entegrasyonu](https://frankenphp.dev/docs/laravel/)
-- [Bilinen sorunlar](https://frankenphp.dev/docs/known-issues/)
-- [Demo uygulama (Symfony) ve kıyaslamalar](https://github.com/dunglas/frankenphp-demo)
-- [Go kütüphane dokümantasonu](https://pkg.go.dev/github.com/dunglas/frankenphp)
-- [Katkıda bulunma ve hata ayıklama](https://frankenphp.dev/docs/contributing/)
+* [Worker modu](https://frankenphp.dev/docs/worker/)
+* [Early Hints desteği (103 HTTP durum kodu)](https://frankenphp.dev/docs/early-hints/)
+* [Real-time](https://frankenphp.dev/docs/mercure/)
+* [Konfigürasyon](https://frankenphp.dev/docs/config/)
+* [Docker imajları](https://frankenphp.dev/docs/docker/)
+* [Production'a dağıtım](docs/production.md)
+* [**Bağımsız** kendiliğinden çalıştırılabilir PHP uygulamaları oluşturma](https://frankenphp.dev/docs/embed/)
+* [Statik binary'leri oluşturma](https://frankenphp.dev/docs/static/)
+* [Kaynak dosyalarından derleme](https://frankenphp.dev/docs/compile/)
+* [Laravel entegrasyonu](https://frankenphp.dev/docs/laravel/)
+* [Bilinen sorunlar](https://frankenphp.dev/docs/known-issues/)
+* [Demo uygulama (Symfony) ve kıyaslamalar](https://github.com/dunglas/frankenphp-demo)
+* [Go kütüphane dokümantasonu](https://pkg.go.dev/github.com/dunglas/frankenphp)
+* [Katkıda bulunma ve hata ayıklama](https://frankenphp.dev/docs/contributing/)
 
 ## Örnekler ve İskeletler
 
-- [Symfony](https://github.com/dunglas/symfony-docker)
-- [API Platform](https://api-platform.com/docs/distribution/)
-- [Laravel](https://frankenphp.dev/docs/laravel/)
-- [Sulu](https://sulu.io/blog/running-sulu-with-frankenphp)
-- [WordPress](https://github.com/StephenMiracle/frankenwp)
-- [Drupal](https://github.com/dunglas/frankenphp-drupal)
-- [Joomla](https://github.com/alexandreelise/frankenphp-joomla)
-- [TYPO3](https://github.com/ochorocho/franken-typo3)
+* [Symfony](https://github.com/dunglas/symfony-docker)
+* [API Platform](https://api-platform.com/docs/distribution/)
+* [Laravel](https://frankenphp.dev/docs/laravel/)
+* [Sulu](https://sulu.io/blog/running-sulu-with-frankenphp)
+* [WordPress](https://github.com/StephenMiracle/frankenwp)
+* [Drupal](https://github.com/dunglas/frankenphp-drupal)
+* [Joomla](https://github.com/alexandreelise/frankenphp-joomla)
+* [TYPO3](https://github.com/ochorocho/franken-typo3)


### PR DESCRIPTION
The FrankenWP repo is in a solid place. We can use this as a resource to manage implementation questions and support with WordPress integration. Organizations are starting to use this repo at scale in production environments.