### PR TITLE
$_SERVER['FRANKENPHP_WORKER'] must not be NULL-terminated

### DIFF
--- a/testdata/_executor.php
+++ b/testdata/_executor.php
@@ -1,7 +1,7 @@
 <?php
 
 $fn = require $_SERVER['SCRIPT_FILENAME'];
-if (!isset($_SERVER['FRANKENPHP_WORKER'])) {
+if ('1' !== ($_SERVER['FRANKENPHP_WORKER'] ?? null)) {
     $fn();
     exit(0);
 }

--- a/worker.go
+++ b/worker.go
@@ -53,7 +53,7 @@ func startWorkers(fileName string, nbWorkers int, env PreparedEnv) error {
 		env = make(PreparedEnv, 1)
 	}
 
-	env["FRANKENPHP_WORKER\x00"] = "1\x00"
+	env["FRANKENPHP_WORKER\x00"] = "1"
 
 	l := getLogger()
 	for i := 0; i < nbWorkers; i++ {


### PR DESCRIPTION
`$_SERVER['FRANKENPHP_WORKER']` terminates by a NULL character and shouldn't.

The problem was introduced in https://github.com/dunglas/frankenphp/pull/540 and discovered in https://github.com/dunglas/frankenphp/pull/796.