### PR TITLE
feat: log the number of threads and workers during startup

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -325,7 +325,7 @@ func Init(options ...Option) error {
 		return err
 	}
 
-	logger.Info("FrankenPHP started 🐘", zap.String("php_version", Version().Version))
+	logger.Info("FrankenPHP started 🐘", zap.String("php_version", Version().Version), zap.Int("num_threads", opt.numThreads))
 	if EmbeddedAppPath != "" {
 		logger.Info("embedded PHP app 📦", zap.String("path", EmbeddedAppPath))
 	}

--- a/worker.go
+++ b/worker.go
@@ -74,7 +74,7 @@ func startWorkers(fileName string, nbWorkers int, env PreparedEnv) error {
 					panic(err)
 				}
 
-				l.Debug("starting", zap.String("worker", absFileName))
+				l.Debug("starting", zap.String("worker", absFileName), zap.Int("num", nbWorkers))
 				if err := ServeHTTP(nil, r); err != nil {
 					panic(err)
 				}


### PR DESCRIPTION
This helps debug thread outage issues in prod.

Also, if only one CPU is available (common with cloud machines VMs), we start only 2 threads by default (so we can handle only 2 requests simultaneously).
What do you think about starting something like at least 4 (or event 8) threads by default @withinboredom?