### PR TITLE
Update compile.md use -z option tar

### DIFF
--- a/docs/compile.md
+++ b/docs/compile.md
@@ -73,7 +73,7 @@ sudo make install
 You can now use the Go library and compile our Caddy build:
 
 ```console
-curl -L https://github.com/dunglas/frankenphp/archive/refs/heads/main.tar.gz | tar x
+curl -L https://github.com/dunglas/frankenphp/archive/refs/heads/main.tar.gz | tar xz
 cd frankenphp-main/caddy/frankenphp
 CGO_CFLAGS=$(php-config --includes) CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" go build
 ```


### PR DESCRIPTION
``Archive is compressed, need to use -z option

Ubuntu 22.04, following instuctions results in an error:

`$ curl -L https://github.com/dunglas/frankenphp/archive/refs/heads/main.tar.gz | tar x
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  2200    0  2200    0     0   1288      0 --:--:--  0:00:01 --:--:--  1288tar: Archive is compressed. Use -z option
tar: Error is not recoverable: exiting now
100 17745    0 17745    0     0  10241      0 --:--:--  0:00:01 --:--:--  607k
curl: (23) Failure writing output to destination
`

fixed by adding -z option:

`$ curl -L https://github.com/dunglas/frankenphp/archive/refs/heads/main.tar.gz | tar xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 2123k    0 2123k    0     0  1178k      0 --:--:--  0:00:01 --:--:-- 3129k
`