### PR TITLE
WIP: fixing slow cgi mode

### DIFF
--- a/frankenphp.h
+++ b/frankenphp.h
@@ -40,7 +40,7 @@ typedef struct frankenphp_config {
 } frankenphp_config;
 frankenphp_config frankenphp_get_config();
 
-int frankenphp_init(int num_threads);
+int frankenphp_init(int num_threads, int non_worker_threads);
 
 int frankenphp_update_server_context(
     bool create, uintptr_t current_request, uintptr_t main_request,


### PR DESCRIPTION
This is currently VERY draft-state.

Goals:

1. Make CGI mode multi-threaded (WIP)
2. Reuse the PHP context (similar to FPM/worker mode) so it doesn't have to be recreated from scratch each request. (not started)
3. Allow specifying a maximum number of requests before restarting. (not started)

This PR intends to start a number of threads that handle non-worker requests. Like FPM/worker mode, it reuses the PHP context from the previous request to cut down on latency.

fixes #836 