### PR TITLE
add -lstdc++ to CGO_LDFLAGS if a c++ extension is enabled

### DIFF
--- a/build-static.sh
+++ b/build-static.sh
@@ -131,6 +131,11 @@ if [ "${os}" = "mac" ]; then
 fi
 
 CGO_LDFLAGS="${CGO_LDFLAGS} ${PWD}/buildroot/lib/libbrotlicommon.a ${PWD}/buildroot/lib/libbrotlienc.a ${PWD}/buildroot/lib/libbrotlidec.a $(./buildroot/bin/php-config --ldflags || true) $(./buildroot/bin/php-config --libs || true)"
+if [ "${os}" = "linux" ]; then
+    if echo "${PHP_EXTENSIONS}" | grep -qE "\b(intl|imagick|grpc|v8js|protobuf|mongodb|tbb)\b"; then
+        CGO_LDFLAGS="${CGO_LDFLAGS} -lstdc++"
+    fi
+fi
 export CGO_LDFLAGS
 
 LIBPHP_VERSION="$(./buildroot/bin/php-config --version)"


### PR DESCRIPTION
Unfortunately php --libs doesn't always list libstdc++ even if it's required for intl/icu. Therefore add -lstdc++ if a c++ extension is built on linux.