### PR TITLE
docs:using octane:frankenphp instead of octane:start

### DIFF
--- a/docs/cn/laravel.md
+++ b/docs/cn/laravel.md
@@ -51,13 +51,13 @@ composer require laravel/octane
 php artisan octane:install --server=frankenphp
 ```
 
-Octane 服务可以通过 `octane:start` Artisan 命令启动。
+Octane 服务可以通过 `octane:frankenphp` Artisan 命令启动。
 
 ```console
-php artisan octane:start
+php artisan octane:frankenphp
 ```
 
-`octane:start` 命令可以采用以下选项：
+`octane:frankenphp` 命令可以采用以下选项：
 
 * `--host`: 服务器应绑定到的 IP 地址（默认值: `127.0.0.1`）
 * `--port`: 服务器应可用的端口（默认值: `8000`）

--- a/docs/fr/laravel.md
+++ b/docs/fr/laravel.md
@@ -52,13 +52,13 @@ Après avoir installé Octane, vous pouvez exécuter la commande Artisan `octane
 php artisan octane:install --server=frankenphp
 ```
 
-Le serveur Octane peut être démarré via la commande Artisan `octane:start`.
+Le serveur Octane peut être démarré via la commande Artisan `octane:frankenphp`.
 
 ```console
-php artisan octane:start
+php artisan octane:frankenphp
 ```
 
-La commande `octane:start` peut prendre les options suivantes :
+La commande `octane:frankenphp` peut prendre les options suivantes :
 
 * `--host` : L'adresse IP à laquelle le serveur doit se lier (par défaut : `127.0.0.1`)
 * `--port` : Le port sur lequel le serveur doit être disponible (par défaut : `8000`)

--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -51,13 +51,13 @@ After installing Octane, you may execute the `octane:install` Artisan command, w
 php artisan octane:install --server=frankenphp
 ```
 
-The Octane server can be started via the `octane:start` Artisan command.
+The Octane server can be started via the `octane:frankenphp` Artisan command.
 
 ```console
-php artisan octane:start
+php artisan octane:frankenphp
 ```
 
-The `octane:start` command can take the following options:
+The `octane:frankenphp` command can take the following options:
 
 * `--host`: The IP address the server should bind to (default: `127.0.0.1`)
 * `--port`: The port the server should be available on (default: `8000`)

--- a/docs/tr/laravel.md
+++ b/docs/tr/laravel.md
@@ -51,13 +51,13 @@ Octane'ı kurduktan sonra, Octane'ın yapılandırma dosyasını uygulamanıza y
 php artisan octane:install --server=frankenphp
 ```
 
-Octane sunucusu `octane:start` Artisan komutu aracılığıyla başlatılabilir.
+Octane sunucusu `octane:frankenphp` Artisan komutu aracılığıyla başlatılabilir.
 
 ```console
-php artisan octane:start
+php artisan octane:frankenphp
 ```
 
-`octane:start` komutu aşağıdaki seçenekleri alabilir:
+`octane:frankenphp` komutu aşağıdaki seçenekleri alabilir:
 
 * `--host`: Sunucunun bağlanması gereken IP adresi (varsayılan: `127.0.0.1`)
 * `--port`: Sunucunun erişilebilir olması gereken port (varsayılan: `8000`)


### PR DESCRIPTION
To be more consistent with official Laravel documentation

(Basically 'octane:start' command , will check your environment's Octane server and call 'octane:frankenphp' )