### PR TITLE
clarify mercure URLs

### DIFF
--- a/docs/mercure.md
+++ b/docs/mercure.md
@@ -8,6 +8,6 @@ No JS library or SDK required!
 ![Mercure](mercure-hub.png)
 
 To enable the Mercure hub, update the `Caddyfile` as described [on Mercure's site](https://mercure.rocks/docs/hub/config).
-The URL to send data is `http://php/.well-known/mercure`, the public URL for clients is at the path `/.well-known/mercure`.
+The path to send data as well as the path of the public URL for clients is `/.well-known/mercure`.  When running FrankenPHP inside Docker, the full send URL would look like `http://php//.well-known/mercure` (with `php` being the name of the container running FrankenPHP).
 
 To push Mercure updates from your code, we recommend the [Symfony Mercure Component](https://symfony.com/components/Mercure) (you don't need the Symfony full stack framework to use it).

--- a/docs/mercure.md
+++ b/docs/mercure.md
@@ -1,13 +1,15 @@
 # Real-time
 
 FrankenPHP comes with a built-in [Mercure](https://mercure.rocks) hub!
-Mercure allows to push events in real-time to all the connected devices: they will receive a JavaScript event instantly.
+Mercure allows you to push real-time events to all the connected devices: they will receive a JavaScript event instantly.
 
-No JS library or SDK required!
+No JS library or SDK is required!
 
 ![Mercure](mercure-hub.png)
 
 To enable the Mercure hub, update the `Caddyfile` as described [on Mercure's site](https://mercure.rocks/docs/hub/config).
-The path to send data as well as the path of the public URL for clients is `/.well-known/mercure`.  When running FrankenPHP inside Docker, the full send URL would look like `http://php//.well-known/mercure` (with `php` being the name of the container running FrankenPHP).
 
-To push Mercure updates from your code, we recommend the [Symfony Mercure Component](https://symfony.com/components/Mercure) (you don't need the Symfony full stack framework to use it).
+The path of the Mercure hub is `/.well-known/mercure`. 
+When running FrankenPHP inside Docker, the full send URL would look like `http://php/.well-known/mercure` (with `php` being the container's name running FrankenPHP).
+
+To push Mercure updates from your code, we recommend the [Symfony Mercure Component](https://symfony.com/components/Mercure) (you don't need the Symfony full-stack framework to use it).

--- a/docs/mercure.md
+++ b/docs/mercure.md
@@ -8,5 +8,6 @@ No JS library or SDK required!
 ![Mercure](mercure-hub.png)
 
 To enable the Mercure hub, update the `Caddyfile` as described [on Mercure's site](https://mercure.rocks/docs/hub/config).
+The URL to send data is `http://php/.well-known/mercure`, the public URL for clients is at the path `/.well-known/mercure`.
 
 To push Mercure updates from your code, we recommend the [Symfony Mercure Component](https://symfony.com/components/Mercure) (you don't need the Symfony full stack framework to use it).


### PR DESCRIPTION
it took me quite a while to figure what the URLs are (they are defined in the compose.yaml file). i think it would be worth it to explain here, because none of the linked pages talk about that.