### PR TITLE
chore: Add prefer-pre-built option for spc download

### DIFF
--- a/build-static.sh
+++ b/build-static.sh
@@ -115,7 +115,7 @@ else
     fi
 
     ./bin/spc doctor --auto-fix
-    ./bin/spc download --with-php="${PHP_VERSION}" --for-extensions="${PHP_EXTENSIONS}" --for-libs="${PHP_EXTENSION_LIBS}" --ignore-cache-sources=php-src
+    ./bin/spc download --with-php="${PHP_VERSION}" --for-extensions="${PHP_EXTENSIONS}" --for-libs="${PHP_EXTENSION_LIBS}" --ignore-cache-sources=php-src --prefer-pre-built
     # shellcheck disable=SC2086
     ./bin/spc build --debug --enable-zts --build-embed ${extraOpts} "${PHP_EXTENSIONS}" --with-libs="${PHP_EXTENSION_LIBS}"
 fi


### PR DESCRIPTION
With this option, we will have faster download and faster build. I tested on my M2 mac: with pre-built used 702s, originally used 1072s.