### PR TITLE
perf: cgi-mode 1700% improvement

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -858,7 +858,6 @@ int frankenphp_request_startup() {
   if (php_request_startup() == SUCCESS) {
     return SUCCESS;
   }
-  memset(local_ctx, 0, sizeof(frankenphp_server_context));
 
   php_request_shutdown((void *)0);
 

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -756,6 +756,10 @@ static void *php_thread(void *arg) {
   while (go_handle_request()) {
   }
 
+  #ifdef ZTS
+    ts_free_thread();
+  #endif
+
   return NULL;
 }
 

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -450,7 +450,7 @@ int frankenphp_update_server_context(
 #ifdef ZTS
     /* initial resource fetch */
     if (local_ctx == NULL) {
-        (void)ts_resource(0);
+      (void)ts_resource(0);
     }
 #ifdef PHP_WIN32
     ZEND_TSRMLS_CACHE_UPDATE();
@@ -756,9 +756,9 @@ static void *php_thread(void *arg) {
   while (go_handle_request()) {
   }
 
-  #ifdef ZTS
-    ts_free_thread();
-  #endif
+#ifdef ZTS
+  ts_free_thread();
+#endif
 
   return NULL;
 }


### PR DESCRIPTION
This one was a doozy to track down... I had a guess it was on the PHP side of things and it wasn't until I got this flame graph that I was able to confirm it.

![cgi-mode](https://github.com/user-attachments/assets/7ea257ec-2394-4fe1-8f2c-44865fe6ec4b)

But I also knew @dunglas had optimized the heck out of this code. While I was in there, I went with the obvious `todo` and made the `server_context` into a thread-local variable and used the variable as a sentinel value for whether or not to free the server_context.

If anything, I am most worried about that part... though we do a `memset` to `0` at the beginning of each request... so it is probably fine.

Aaaannnyway. Along the journey to get here, I learned that having a mutex lock at the beginning of each request effectively makes the requests single-threaded. There's another PR that speeds this up even more ... but needless to say, when I made the above changes and didn't see the expected performance increase, I had to dig into `ts_resource(0)`... and lo-and-behold: a mutex.

/tableflip

Well, from there, I started investigating what is _really_ going on under the hood, and I'm 85% sure this is ok: delete `ts_free_thread` and only call `ts_resource(0)` once per thread... This appears to work fine. That being said, tests aren't passing locally, we will see if they pass here...

Here's the current flame graph:

![torch](https://github.com/user-attachments/assets/88b5a689-d5db-4d34-8543-4201941ad1e0)
