### PR TITLE
fix: reset sapi response code

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -451,6 +451,9 @@ int frankenphp_update_server_context(
     ctx->finished = false;
 
     SG(server_context) = ctx;
+
+    // It is not reset by zend engine, set it to 200.
+    SG(sapi_headers).http_response_code = 200;
   } else {
     ctx = (frankenphp_server_context *)SG(server_context);
   }

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -451,12 +451,12 @@ int frankenphp_update_server_context(
     ctx->finished = false;
 
     SG(server_context) = ctx;
-
-    // It is not reset by zend engine, set it to 200.
-    SG(sapi_headers).http_response_code = 200;
   } else {
     ctx = (frankenphp_server_context *)SG(server_context);
   }
+
+  // It is not reset by zend engine, set it to 200.
+  SG(sapi_headers).http_response_code = 200;
 
   ctx->main_request = main_request;
   ctx->current_request = current_request;

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -247,7 +247,7 @@ func testResponseHeaders(t *testing.T, opts *testOptions) {
 		body, _ := io.ReadAll(resp.Body)
 
 		if i%3 != 0 {
-			assert.Equal(t, i, resp.StatusCode)
+			assert.Equal(t, i+100, resp.StatusCode)
 		} else {
 			assert.Equal(t, 200, resp.StatusCode)
 		}

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -246,6 +246,12 @@ func testResponseHeaders(t *testing.T, opts *testOptions) {
 		resp := w.Result()
 		body, _ := io.ReadAll(resp.Body)
 
+		if i%3 != 0 {
+			assert.Equal(t, i, resp.StatusCode)
+		} else {
+			assert.Equal(t, 200, resp.StatusCode)
+		}
+
 		assert.Contains(t, string(body), "'X-Powered-By' => 'PH")
 		assert.Contains(t, string(body), "'Foo' => 'bar',")
 		assert.Contains(t, string(body), "'Foo2' => 'bar2',")

--- a/testdata/response-headers.php
+++ b/testdata/response-headers.php
@@ -7,7 +7,9 @@ return function () {
     header('Foo2: bar2');
     header('Invalid');
     header('I: ' . ($_GET['i'] ?? 'i not set'));
-    http_response_code(201);
-    
+    if ($_GET['i'] % 3) {
+        http_response_code($_GET['i'] + 100);
+    }
+
     var_export(apache_response_headers());
 };


### PR DESCRIPTION
It turns out that the zend engine does NOT reset the sapi response code between requests. This PR resets the response code when configuring a new request -- as it appears to affect workers AND non-worker requests.

fixes: #960