### PR TITLE
docs: fix build/curl instructions

### DIFF
--- a/docs/fr/compile.md
+++ b/docs/fr/compile.md
@@ -66,7 +66,7 @@ sudo make install
 Vous pouvez maintenant compilez FrankenPHP :
 
 ```console
-curl -L https://github.com/dunglas/frankenphp/archive/refs/heads/main.tar.gz | tar x
+curl -L https://github.com/dunglas/frankenphp/archive/refs/heads/main.tar.gz | tar xz
 cd frankenphp-main/caddy/frankenphp
 CGO_CFLAGS=$(php-config --includes) CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" go build
 ```


### PR DESCRIPTION
The `z` was missing and there was an error after download:

```
tar: Archive is compressed. Use -z option
tar: Error is not recoverable: exiting now
```