### PR TITLE
Fix: Allows disabling root symlinks

### DIFF
--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -317,10 +317,10 @@ func (f *FrankenPHPModule) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 
 			case "resolve_root_symlink":
 				if d.NextArg() {
-                    v, err := strconv.ParseBool(d.Val());
-                    if err != nil {
-                        return err
-                    }
+					v, err := strconv.ParseBool(d.Val());
+					if err != nil {
+						return err
+					}
 					if d.NextArg() {
 						return d.ArgErr()
 					}

--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -323,9 +323,10 @@ func (f *FrankenPHPModule) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 						if d.NextArg() {
 							return d.ArgErr()
 						}
+					} else {
+					    return d.ArgErr()
 					}
 
-					return d.ArgErr()
 				}
 				rrs := true
 				f.ResolveRootSymlink = &rrs

--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -316,17 +316,19 @@ func (f *FrankenPHPModule) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				f.preparedEnv[args[0]+"\x00"] = args[1]
 
 			case "resolve_root_symlink":
-				if d.NextArg() {
-					v, err := strconv.ParseBool(d.Val());
-					if err != nil {
-						return err
-					}
-					if d.NextArg() {
-						return d.ArgErr()
-					}
-
-					f.ResolveRootSymlink = &v
+				if !d.NextArg() {
+					continue
 				}
+
+				v, err := strconv.ParseBool(d.Val())
+				if err != nil {
+					return err
+				}
+				if d.NextArg() {
+					return d.ArgErr()
+				}
+
+				f.ResolveRootSymlink = &v
 			}
 		}
 	}

--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -317,10 +317,10 @@ func (f *FrankenPHPModule) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 
 			case "resolve_root_symlink":
 				if d.NextArg() {
-					v, err := strconv.ParseBool(d.Val())
-					if(err !== nil) {
-						return err
-					}
+                    v, err := strconv.ParseBool(d.Val());
+                    if err != nil {
+                        return err
+                    }
 					if d.NextArg() {
 						return d.ArgErr()
 					}

--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -324,11 +324,9 @@ func (f *FrankenPHPModule) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 							return d.ArgErr()
 						}
 					} else {
-					    return d.ArgErr()
+						return d.ArgErr()
 					}
 				}
-				rrs := true
-				f.ResolveRootSymlink = &rrs
 			}
 		}
 	}

--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -326,7 +326,6 @@ func (f *FrankenPHPModule) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					} else {
 					    return d.ArgErr()
 					}
-
 				}
 				rrs := true
 				f.ResolveRootSymlink = &rrs

--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -317,15 +317,15 @@ func (f *FrankenPHPModule) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 
 			case "resolve_root_symlink":
 				if d.NextArg() {
-					if v, err := strconv.ParseBool(d.Val()); err == nil {
-						f.ResolveRootSymlink = &v
-
-						if d.NextArg() {
-							return d.ArgErr()
-						}
-					} else {
+					v, err := strconv.ParseBool(d.Val())
+					if(err !== nil) {
+						return err
+					}
+					if d.NextArg() {
 						return d.ArgErr()
 					}
+
+					f.ResolveRootSymlink = &v
 				}
 			}
 		}


### PR DESCRIPTION
Currently this configuration in the Caddyfile will always throw an error if `resolve_root_symlink `has a second argument
```
php_server {
    resolve_root_symlink false
}
```

This pull request fixes the behaviour, so it works in accordance to [the docs](https://frankenphp.dev/docs/config/#caddyfile-config) and allows disabling checking for symlinks.

Not checking for symlinks actually makes a 'Hello World' in frankenphp about 5% faster as you can see in the following flamegraph (`path/filepath.EvalSymlinks`):

![torch-test3](https://github.com/user-attachments/assets/85edfaac-3255-4d37-bfb3-ee2183f3dd23)

