### PR TITLE
Fixes passing caddy env variables from #1016

### DIFF
--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -275,7 +275,7 @@ func (f *FrankenPHPModule) Provision(ctx caddy.Context) error {
 	if f.preparedEnv == nil {
 		f.preparedEnv = frankenphp.PrepareEnv(f.Env)
 
-		for e := range f.preparedEnv {
+		for _, e := range f.preparedEnv {
 			if needReplacement(e) {
 				f.preparedEnvNeedsReplacement = true
 
@@ -287,7 +287,7 @@ func (f *FrankenPHPModule) Provision(ctx caddy.Context) error {
 	return nil
 }
 
-// needReplacement checks if a string contains placeholdes.
+// needReplacement checks if a string contains placeholders.
 func needReplacement(s string) bool {
 	return strings.Contains(s, "{") || strings.Contains(s, "}")
 }

--- a/caddy/caddy_test.go
+++ b/caddy/caddy_test.go
@@ -223,6 +223,40 @@ func TestJsonEnv(t *testing.T) {
 	tester.AssertGetResponse("http://localhost:9080/worker-env.php", http.StatusOK, "bazbar")
 }
 
+func TestCustomCaddyVariablesInEnv(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`
+		{
+			skip_install_trust
+			admin localhost:2999
+			http_port 9080
+			https_port 9443
+
+			frankenphp {
+				worker {
+					file ../testdata/worker-env.php
+					num 1
+					env FOO world
+				}
+			}
+		}
+
+		localhost:9080 {
+			route {
+				map 1 {my_customvar} {
+					default "hello "
+				}
+				php {
+					root ../testdata
+					env FOO {my_customvar}
+				}
+			}
+		}
+		`, "caddyfile")
+
+	tester.AssertGetResponse("http://localhost:9080/worker-env.php", http.StatusOK, "hello world")
+}
+
 func TestPHPServerDirective(t *testing.T) {
 	tester := caddytest.NewTester(t)
 	tester.InitServer(`


### PR DESCRIPTION
Should fix #1016, turns out you were using the key to check for '{' instead of the value @dunglas .