### PR TITLE
Update Docs: Expand on how Laravel Octane uses Caddyfiles

### DIFF
--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -64,7 +64,7 @@ The `octane:frankenphp` command can take the following options:
 * `--admin-port`: The port the admin server should be available on (default: `2019`)
 * `--workers`: The number of workers that should be available to handle requests (default: `auto`)
 * `--max-requests`: The number of requests to process before reloading the server (default: `500`)
-* `--caddyfile`: The path to the FrankenPHP `Caddyfile` file (default: [stubbed Caddyfile in Laravel Octane](https://github.com/laravel/octane/blob/2.x/src/Commands/stubs/Caddyfile))
+* `--caddyfile`: The path to the FrankenPHP `Caddyfile` file (default: [stubbed `Caddyfile` in Laravel Octane](https://github.com/laravel/octane/blob/2.x/src/Commands/stubs/Caddyfile))
 * `--https`: Enable HTTPS, HTTP/2, and HTTP/3, and automatically generate and renew certificates
 * `--http-redirect`: Enable HTTP to HTTPS redirection (only enabled if --https is passed)
 * `--watch`: Automatically reload the server when the application is modified

--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -71,8 +71,6 @@ The `octane:frankenphp` command can take the following options:
 * `--poll`: Use file system polling while watching in order to watch files over a network
 * `--log-level`: Log messages at or above the specified log level
 
-> Note: When using Laravel Octane environment variables will not be respected in your Caddyfile, instead Laravel Octane will add envrionment variables into the FrankenPHP process based on the above arguments. [See how here](https://github.com/laravel/octane/blob/2.x/src/Commands/StartFrankenPhpCommand.php#L92).
-
 Learn more about [Laravel Octane in its official documentation](https://laravel.com/docs/octane).
 
 ## Laravel Apps As Standalone Binaries

--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -64,12 +64,14 @@ The `octane:frankenphp` command can take the following options:
 * `--admin-port`: The port the admin server should be available on (default: `2019`)
 * `--workers`: The number of workers that should be available to handle requests (default: `auto`)
 * `--max-requests`: The number of requests to process before reloading the server (default: `500`)
-* `--caddyfile`: The path to the FrankenPHP `Caddyfile` file
+* `--caddyfile`: The path to the FrankenPHP `Caddyfile` file (default: [stubbed Caddyfile in Laravel Octane](https://github.com/laravel/octane/blob/2.x/src/Commands/stubs/Caddyfile))
 * `--https`: Enable HTTPS, HTTP/2, and HTTP/3, and automatically generate and renew certificates
 * `--http-redirect`: Enable HTTP to HTTPS redirection (only enabled if --https is passed)
 * `--watch`: Automatically reload the server when the application is modified
 * `--poll`: Use file system polling while watching in order to watch files over a network
 * `--log-level`: Log messages at or above the specified log level
+
+> Note: When using Laravel Octane environment variables will not be respected in your Caddyfile, instead Laravel Octane will add envrionment variables into the FrankenPHP process based on the above arguments. [See how here](https://github.com/laravel/octane/blob/2.x/src/Commands/StartFrankenPhpCommand.php#L92).
 
 Learn more about [Laravel Octane in its official documentation](https://laravel.com/docs/octane).
 


### PR DESCRIPTION
I was having some trouble ascertaining whether the default Caddyfile `/etc/caddy/Caddyfile` is used while using Laravel Octane, but I found it it's actually using a stubbed Caddyfile from the Octane repo. 

This is still a bit misleading, as when you go to the stubbed Caddyfile it looks like you can use the environment variables that it has templated within it. This however doesn't work because when Octane boots up a process it will only add environment variables that are defined in [this file](https://github.com/laravel/octane/blob/2.x/src/Commands/StartFrankenPhpCommand.php#L92). So, I also added a warning that env vars will not be respected when using Laravel Octane.