### PR TITLE
handle worker failures gracefully

### DIFF
--- a/caddy/caddy_test.go
+++ b/caddy/caddy_test.go
@@ -445,6 +445,18 @@ func TestWorkerMetrics(t *testing.T) {
 	# HELP frankenphp_testdata_index_php_worker_request_count
 	# TYPE frankenphp_testdata_index_php_worker_request_count counter
 	frankenphp_testdata_index_php_worker_request_count 10
+
+	# HELP frankenphp_testdata_index_php_ready_workers Running workers that have successfully called frankenphp_handle_request at least once
+	# TYPE frankenphp_testdata_index_php_ready_workers gauge
+	frankenphp_testdata_index_php_ready_workers 2
+
+	# HELP frankenphp_testdata_index_php_worker_crashes Number of PHP worker crashes for this worker
+	# TYPE frankenphp_testdata_index_php_worker_crashes counter
+	frankenphp_testdata_index_php_worker_crashes 0
+
+	# HELP frankenphp_testdata_index_php_worker_restarts Number of PHP worker restarts for this worker
+	# TYPE frankenphp_testdata_index_php_worker_restarts counter
+	frankenphp_testdata_index_php_worker_restarts 0
 	`
 
 	require.NoError(t,
@@ -456,6 +468,9 @@ func TestWorkerMetrics(t *testing.T) {
 			"frankenphp_testdata_index_php_busy_workers",
 			"frankenphp_testdata_index_php_total_workers",
 			"frankenphp_testdata_index_php_worker_request_count",
+			"frankenphp_testdata_index_php_worker_crashes",
+			"frankenphp_testdata_index_php_worker_restarts",
+			"frankenphp_testdata_index_php_ready_workers",
 		))
 }
 
@@ -531,6 +546,18 @@ func TestAutoWorkerConfig(t *testing.T) {
 	# HELP frankenphp_testdata_index_php_worker_request_count
 	# TYPE frankenphp_testdata_index_php_worker_request_count counter
 	frankenphp_testdata_index_php_worker_request_count 10
+
+	# HELP frankenphp_testdata_index_php_ready_workers Running workers that have successfully called frankenphp_handle_request at least once
+	# TYPE frankenphp_testdata_index_php_ready_workers gauge
+	frankenphp_testdata_index_php_ready_workers ` + workers + `
+
+	# HELP frankenphp_testdata_index_php_worker_crashes Number of PHP worker crashes for this worker
+	# TYPE frankenphp_testdata_index_php_worker_crashes counter
+	frankenphp_testdata_index_php_worker_crashes 0
+
+	# HELP frankenphp_testdata_index_php_worker_restarts Number of PHP worker restarts for this worker
+	# TYPE frankenphp_testdata_index_php_worker_restarts counter
+	frankenphp_testdata_index_php_worker_restarts 0
 	`
 
 	require.NoError(t,
@@ -542,5 +569,8 @@ func TestAutoWorkerConfig(t *testing.T) {
 			"frankenphp_testdata_index_php_busy_workers",
 			"frankenphp_testdata_index_php_total_workers",
 			"frankenphp_testdata_index_php_worker_request_count",
+			"frankenphp_testdata_index_php_worker_crashes",
+			"frankenphp_testdata_index_php_worker_restarts",
+			"frankenphp_testdata_index_php_ready_workers",
 		))
 }

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -6,6 +6,9 @@ When [Caddy metrics](https://caddyserver.com/docs/metrics) are enabled, FrankenP
 * `frankenphp_[worker]_busy_workers`: The number of workers currently processing a request.
 * `frankenphp_[worker]_worker_request_time`: The time spent processing requests by all workers.
 * `frankenphp_[worker]_worker_request_count`: The number of requests processed by all workers.
+* `frankenphp_[worker]_ready_workers`: The number of workers that have called `frankenphp_handle_request` at least once.
+* `frankenphp_[worker]_worker_crashes`: The number of times a worker has unexpectedly terminated.
+* `frankenphp_[worker]_worker_restarts`: The number of times a worker has been deliberately restarted.
 * `frankenphp_total_threads`: The total number of PHP threads.
 * `frankenphp_busy_threads`: The number of PHP threads currently processing a request (running workers always consume a thread).
 

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -121,6 +121,14 @@ A workaround to using this type of code in worker mode is to restart the worker 
 
 The previous worker snippet allows configuring a maximum number of request to handle by setting an environment variable named `MAX_REQUESTS`.
 
+### Worker failures
+
+If a worker script crashes with a non-zero exit code, FrankenPHP will restart it with an exponential backoff strategy.
+If the worker script stays up longer than the last backoff * 2,
+it will not penalize the worker script and restart it again.
+However, if the worker script continues to fail with a non-zero exit code in a short period of time
+(for example, having a typo in a script), FrankenPHP will crash with the error: `too many consecutive failures`.
+
 ## Superglobals Behavior
 
 [PHP superglobals](https://www.php.net/manual/en/language.variables.superglobals.php) (`$_SERVER`, `$_ENV`, `$_GET`...)

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -121,7 +121,7 @@ A workaround to using this type of code in worker mode is to restart the worker 
 
 The previous worker snippet allows configuring a maximum number of request to handle by setting an environment variable named `MAX_REQUESTS`.
 
-### Worker failures
+### Worker Failures
 
 If a worker script crashes with a non-zero exit code, FrankenPHP will restart it with an exponential backoff strategy.
 If the worker script stays up longer than the last backoff * 2,

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -342,7 +342,7 @@ PHP_FUNCTION(frankenphp_handle_request) {
     ctx->worker_ready = true;
 
     /* Mark the worker as ready to handle requests */
-    go_frankenphp_worker_ready();
+    go_frankenphp_worker_ready(ctx->main_request);
   }
 
 #ifdef ZEND_MAX_EXECUTION_TIMERS

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -125,6 +125,9 @@ type FrankenPHPContext struct {
 	// Whether the request is already closed by us
 	closed sync.Once
 
+	// whether the context is ready to receive requests
+	ready bool
+
 	responseWriter http.ResponseWriter
 	exitStatus     C.int
 

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -609,6 +609,18 @@ func testRequestHeaders(t *testing.T, opts *testOptions) {
 	}, opts)
 }
 
+func TestFailingWorker(t *testing.T) {
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, i int) {
+		req := httptest.NewRequest("GET", "http://example.com/failing-worker.php", nil)
+		w := httptest.NewRecorder()
+		handler(w, req)
+
+		resp := w.Result()
+		body, _ := io.ReadAll(resp.Body)
+		assert.Contains(t, string(body), "ok")
+	}, &testOptions{workerScript: "failing-worker.php"})
+}
+
 func TestFileUpload_module(t *testing.T) { testFileUpload(t, &testOptions{}) }
 func TestFileUpload_worker(t *testing.T) {
 	testFileUpload(t, &testOptions{workerScript: "file-upload.php"})

--- a/metrics.go
+++ b/metrics.go
@@ -263,6 +263,18 @@ func (m *PrometheusMetrics) Shutdown() {
 		m.registry.Unregister(c)
 	}
 
+	for _, c := range m.workerCrashes {
+		m.registry.Unregister(c)
+	}
+
+	for _, c := range m.workerRestarts {
+		m.registry.Unregister(c)
+	}
+
+	for _, g := range m.readyWorkers {
+		m.registry.Unregister(g)
+	}
+
 	m.totalThreads = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "frankenphp_total_threads",
 		Help: "Total number of PHP threads",

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -38,6 +38,9 @@ func createPrometheusMetrics() *PrometheusMetrics {
 		busyWorkers:        make(map[string]prometheus.Gauge),
 		workerRequestTime:  make(map[string]prometheus.Counter),
 		workerRequestCount: make(map[string]prometheus.Counter),
+		workerCrashes:      make(map[string]prometheus.Counter),
+		workerRestarts:     make(map[string]prometheus.Counter),
+		readyWorkers:       make(map[string]prometheus.Gauge),
 		mu:                 sync.Mutex{},
 	}
 }

--- a/testdata/failing-worker.php
+++ b/testdata/failing-worker.php
@@ -1,0 +1,18 @@
+<?php
+
+$fail = random_int(1, 100) > 50;
+$wait = random_int(1, 5);
+
+sleep($wait);
+if($fail) {
+    exit(1);
+}
+
+while(frankenphp_handle_request(function() {
+    echo "ok";
+})) {
+    $fail = random_int(1, 100) > 50;
+    if ($fail) {
+        exit(1);
+    }
+}

--- a/testdata/failing-worker.php
+++ b/testdata/failing-worker.php
@@ -1,6 +1,6 @@
 <?php
 
-$fail = random_int(1, 100) > 50;
+$fail = random_int(1, 100) < 10;
 $wait = random_int(1, 5);
 
 sleep($wait);
@@ -11,7 +11,7 @@ if($fail) {
 while(frankenphp_handle_request(function() {
     echo "ok";
 })) {
-    $fail = random_int(1, 100) > 50;
+    $fail = random_int(1, 100) < 10;
     if ($fail) {
         exit(1);
     }

--- a/testdata/failing-worker.php
+++ b/testdata/failing-worker.php
@@ -4,11 +4,11 @@ $fail = random_int(1, 100) < 10;
 $wait = random_int(1, 5);
 
 sleep($wait);
-if($fail) {
+if ($fail) {
     exit(1);
 }
 
-while(frankenphp_handle_request(function() {
+while (frankenphp_handle_request(function () {
     echo "ok";
 })) {
     $fail = random_int(1, 100) < 10;

--- a/testdata/failing-worker.php
+++ b/testdata/failing-worker.php
@@ -1,6 +1,6 @@
 <?php
 
-$fail = random_int(1, 100) < 10;
+$fail = random_int(1, 100) < 1;
 $wait = random_int(1, 5);
 
 sleep($wait);

--- a/worker.go
+++ b/worker.go
@@ -21,7 +21,7 @@ var (
 	workersReadyWG      sync.WaitGroup
 )
 
-// TODO: start all the worker in parallell to reduce the boot time
+// TODO: start all the worker in parallel to reduce the boot time
 func initWorkers(opt []workerOpt) error {
 	for _, w := range opt {
 		if err := startWorkers(w.fileName, w.num, w.env); err != nil {

--- a/worker.go
+++ b/worker.go
@@ -127,6 +127,11 @@ func startWorkers(fileName string, nbWorkers int, env PreparedEnv) error {
 
 				// TODO: make the max restart configurable
 				if _, ok := workersRequestChans.Load(absFileName); ok {
+					if fc.ready {
+						fc.ready = false
+						workersReadyWG.Add(1)
+					}
+
 					metrics.StopWorker(absFileName)
 					workersReadyWG.Add(1)
 					if fc.exitStatus == 0 {
@@ -190,7 +195,10 @@ func stopWorkers() {
 }
 
 //export go_frankenphp_worker_ready
-func go_frankenphp_worker_ready() {
+func go_frankenphp_worker_ready(mrh C.uintptr_t) {
+	mainRequest := cgo.Handle(mrh).Value().(*http.Request)
+	fc := mainRequest.Context().Value(contextKey).(*FrankenPHPContext)
+	fc.ready = true
 	workersReadyWG.Done()
 }
 

--- a/worker.go
+++ b/worker.go
@@ -59,9 +59,9 @@ func startWorkers(fileName string, nbWorkers int, env PreparedEnv) error {
 
 	l := getLogger()
 
-	maxBackoff := 16 * time.Second
-	minBackoff := 100 * time.Millisecond
-	maxConsecutiveFailures := 3
+	const maxBackoff = 16 * time.Second
+	const minBackoff = 100 * time.Millisecond
+	const maxConsecutiveFailures = 3
 
 	for i := 0; i < nbWorkers; i++ {
 		go func() {
@@ -144,8 +144,7 @@ func startWorkers(fileName string, nbWorkers int, env PreparedEnv) error {
 							// if we end up here, the worker has not been up for backoff*2
 							// this is probably due to a syntax error or another fatal error
 							if failureCount >= maxConsecutiveFailures {
-								logger.Fatal("Worker had too many consecutive unexpected terminations", zap.String("worker", absFileName))
-								panic("Too many consecutive failures")
+								panic(fmt.Errorf("workers %q: too many consecutive failures", absFileName))
 							} else {
 								failureCount += 1
 							}

--- a/worker.go
+++ b/worker.go
@@ -138,6 +138,12 @@ func startWorkers(fileName string, nbWorkers int, env PreparedEnv) error {
 						if c := l.Check(zapcore.InfoLevel, "restarting"); c != nil {
 							c.Write(zap.String("worker", absFileName))
 						}
+
+						// a normal restart resets the backoff and failure count
+						backingOffLock.Lock()
+						backoff = minBackoff
+						failureCount = 0
+						backingOffLock.Unlock()
 					} else {
 						if c := l.Check(zapcore.ErrorLevel, "unexpected termination, restarting"); c != nil {
 							c.Write(zap.String("worker", absFileName), zap.Int("failure_count", failureCount), zap.Int("exit_status", int(fc.exitStatus)), zap.Duration("waiting", backoff))

--- a/worker.go
+++ b/worker.go
@@ -146,7 +146,9 @@ func startWorkers(fileName string, nbWorkers int, env PreparedEnv) error {
 						backingOffLock.Unlock()
 					} else {
 						if c := l.Check(zapcore.ErrorLevel, "unexpected termination, restarting"); c != nil {
+							backingOffLock.RLock()
 							c.Write(zap.String("worker", absFileName), zap.Int("failure_count", failureCount), zap.Int("exit_status", int(fc.exitStatus)), zap.Duration("waiting", backoff))
+							backingOffLock.RUnlock()
 						}
 
 						upFunc.Do(func() {

--- a/worker.go
+++ b/worker.go
@@ -210,7 +210,7 @@ func go_frankenphp_worker_ready(mrh C.uintptr_t) {
 	mainRequest := cgo.Handle(mrh).Value().(*http.Request)
 	fc := mainRequest.Context().Value(contextKey).(*FrankenPHPContext)
 	fc.ready = true
-	metrics.ReadyWorker(fc.scriptName)
+	metrics.ReadyWorker(fc.scriptFilename)
 	workersReadyWG.Done()
 }
 


### PR DESCRIPTION
Inspired by #1013, this change keeps track of worker failures, implements an exponential backoff, and will eventually panic if there are too many failures.

This is a better alternative to writing hundreds of megabytes per second into log files.

It uses an algorithm to try to detect the difference between a crashing script and a fatal application error that just needs to be logged and can be safely restarted. It does this by waiting for the script to be up for at least "backoff * 2" seconds. If it is up at least that long, it will continue "crash-looping" until the application cannot stay up more than 32 seconds for at least 3 iterations. At that point, FrankenPHP itself will crash.

If we are happy with this algorithm, I'll create some tests and documentation.