### PR TITLE
Update frankenphp.c for compilation on FreeBSD

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -21,6 +21,7 @@
 #if defined(__linux__)
 #include <sys/prctl.h>
 #elif defined(__FreeBSD__) || defined(__OpenBSD__)
+#include <pthread.h>
 #include <pthread_np.h>
 #endif
 


### PR DESCRIPTION
Compilation would fail on FreeBSD due to a missing header file (``pthread.h``). This commit adds a ``#include`` for it.