### PR TITLE
docs: use tree id so the current time is used as mod time of each file

### DIFF
--- a/docs/embed.md
+++ b/docs/embed.md
@@ -24,7 +24,7 @@ For instance, for a Symfony app, you can use the following commands:
 ```console
 # Export the project to get rid of .git/, etc
 mkdir $TMPDIR/my-prepared-app
-git archive HEAD | tar -x -C $TMPDIR/my-prepared-app
+git archive $(git rev-parse HEAD^{tree}) | tar -x -C $TMPDIR/my-prepared-app
 cd $TMPDIR/my-prepared-app
 
 # Set proper environment variables


### PR DESCRIPTION
So I've been willing to try FrankenPHP for a while now to create a static binary. After following the docs I got it up and running quite easily.

But, after a while (say 2 days), I was getting "file not found" errors when running the `php-cli` and notices _some_ files in the the local temp. directory where missing. Compiling the binary again fixes the problem. Also, removing the directory altogether fixes the problem since then it will recreate _all_ files.

After some digging I found out that `git archive HEAD` uses the commit time as modification time of each file. Could this cause the cache to be partially deleted? (older files first)

- https://git-scm.com/docs/git-archive#_description

Note that I cannot (yet) confirm that this actually fixes the "file not found" errors I'm getting. I will see what it does after 2 or 3 days.

At any case, is this a know issue? 🤔 