### PR TITLE
Make the branch from which Watcher is built a release branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ COPY --link internal internal
 COPY --link testdata testdata
 
 # install edant/watcher (necessary for file watching)
-ARG EDANT_WATCHER_VERSION=next
+ARG EDANT_WATCHER_VERSION=release
 WORKDIR /usr/local/src/watcher
 RUN curl -L https://github.com/e-dant/watcher/archive/refs/heads/$EDANT_WATCHER_VERSION.tar.gz | tar xz
 WORKDIR /usr/local/src/watcher/watcher-$EDANT_WATCHER_VERSION/watcher-c

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -108,7 +108,7 @@ COPY --link internal internal
 COPY --link testdata testdata
 
 # install edant/watcher (necessary for file watching)
-ARG EDANT_WATCHER_VERSION=next
+ARG EDANT_WATCHER_VERSION=release
 WORKDIR /usr/local/src/watcher
 RUN curl -L https://github.com/e-dant/watcher/archive/refs/heads/$EDANT_WATCHER_VERSION.tar.gz | tar xz
 WORKDIR /usr/local/src/watcher/watcher-$EDANT_WATCHER_VERSION/watcher-c

--- a/build-static.sh
+++ b/build-static.sh
@@ -144,7 +144,7 @@ if [ "${os}" = "linux" ]; then
 fi
 
 # install edant/watcher for file watching (static version)
-git clone --branch="${EDANT_WATCHER_VERSION:-next}" https://github.com/e-dant/watcher watcher
+git clone --branch="${EDANT_WATCHER_VERSION:-release}" https://github.com/e-dant/watcher watcher
 cd watcher/watcher-c
 cc -c -o libwatcher.o ./src/watcher-c.cpp -I ./include -I ../include -std=c++17 -Wall -Wextra -fPIC
 ar rcs libwatcher.a libwatcher.o

--- a/dev-alpine.Dockerfile
+++ b/dev-alpine.Dockerfile
@@ -64,7 +64,7 @@ RUN git clone --branch=PHP-8.3 https://github.com/php/php-src.git . && \
 	php --version
 
 # install edant/watcher (necessary for file watching)
-ARG EDANT_WATCHER_VERSION=next
+ARG EDANT_WATCHER_VERSION=release
 WORKDIR /usr/local/src/watcher
 RUN git clone --branch=$EDANT_WATCHER_VERSION https://github.com/e-dant/watcher .
 WORKDIR /usr/local/src/watcher/watcher-c

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -66,7 +66,7 @@ RUN git clone --branch=PHP-8.3 https://github.com/php/php-src.git . && \
 	php --version
 
 # install edant/watcher (necessary for file watching)
-ARG EDANT_WATCHER_VERSION=next
+ARG EDANT_WATCHER_VERSION=release
 WORKDIR /usr/local/src/watcher
 RUN git clone --branch=$EDANT_WATCHER_VERSION https://github.com/e-dant/watcher .
 WORKDIR /usr/local/src/watcher/watcher-c


### PR DESCRIPTION
https://github.com/dunglas/frankenphp/pull/1013 Builds a C library from [e-dant/watcher at the `next` branch](https://github.com/e-dant/watcher/tree/next), a development branch, because the `release` branch did not have the necessary feature (the C library) at the time.

Today (or, just now, really), version [0.12.0 of that repo](https://github.com/e-dant/watcher/releases/tag/release%2F0.12.0) was released. The C library is there among the other changes.

Some other options exist which still lift us off the development branch:
- Pin the builds to a specific release
- Use binaries from the [release assets](https://github.com/e-dant/watcher/releases/tag/release%2F0.12.0) instead of building things

But, this is a simple fix, the API very seldom changes, and the build seemed happy in #1013, so just switching up the branches to the (rolling) top of the releases seemed simplest.