### PR TITLE
perf: only import os environment variables once per worker thread

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -423,9 +423,7 @@ static zend_module_entry frankenphp_module = {
 static void frankenphp_request_shutdown() {
   frankenphp_server_context *ctx = SG(server_context);
 
-  bool is_worker_request = ctx->has_main_request && ctx->has_active_request;
-
-  if (is_worker_request) {
+  if (ctx->has_main_request && ctx->has_active_request) {
     frankenphp_destroy_super_globals();
   }
 


### PR DESCRIPTION
I noticed that [php_import_environment_variables](https://github.com/php/php-src/blob/3da6818c9e1210a76fc4cc4a1f83f66ffce76293/main/php_variables.c#L629) will lock and increasingly slow down the server as more environment variables are imported.
Since many frameworks will cache environment variables in production, the import often ends up being redundant. I think it would make sense to only import them once per thread, at least in worker mode.

Some open points:
- How do other SAPIs optimize this? (not yet sure what exactly's happening here: [litespeed](https://github.com/php/php-src/blob/3da6818c9e1210a76fc4cc4a1f83f66ffce76293/sapi/litespeed/lsapi_main.c#L214)  [fpm](https://github.com/php/php-src/blob/3da6818c9e1210a76fc4cc4a1f83f66ffce76293/sapi/fpm/fpm/fpm_env.c#L219) )
- Should this be an optional configuration in the Caddyfile?
- Should this also be possible in non-worker mode?

Here is a graph showing that the server slows down with an increasing amount of environment variables . 
When we load the environment from a `zval` that's cached on the thread, the slowdown is much less significant:
![graph-environment-variables](https://github.com/user-attachments/assets/b68ac218-f293-4c0e-a5a1-e7c36db6fe6d)
the env variables have ~40 characters each
Note that 10 threads is the 'ideal' amount of threads on my 20 core machine when PHP does minimal work
