### PR TITLE
implement getenv and putenv in go

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -507,7 +507,7 @@ PHP_MINIT_FUNCTION(frankenphp)
         php_error(E_WARNING, "Failed to find built-in putenv function");
     }
 
-    // Override putenv
+    // Override getenv
     func = zend_hash_str_find_ptr(CG(function_table), "getenv", sizeof("getenv") - 1);
     if (func != NULL && func->type == ZEND_INTERNAL_FUNCTION) {
         ((zend_internal_function *)func)->handler = ZEND_FN(frankenphp_getenv);

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -277,23 +277,8 @@ PHP_FUNCTION(frankenphp_getenv) {
   ZEND_PARSE_PARAMETERS_END();
 
   if (!name) {
-    struct go_getfullenv_return full_env = go_getfullenv(thread_index);
-
     array_init(return_value);
-    for (int i = 0; i < full_env.r1; i++) {
-      go_string key = full_env.r0[i * 2];
-      go_string val = full_env.r0[i * 2 + 1];
-
-      // create PHP strings for key and value
-      zend_string *key_str = zend_string_init(key.data, key.len, 0);
-      zend_string *val_str = zend_string_init(val.data, val.len, 0);
-
-      // add to the associative array
-      add_assoc_str(return_value, ZSTR_VAL(key_str), val_str);
-
-      // release the key string
-      zend_string_release(key_str);
-    }
+    go_getfullenv((uintptr_t) return_value);
 
     return;
   }

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -331,8 +331,6 @@ PHP_FUNCTION(frankenphp_request_headers) {
 
     add_assoc_stringl_ex(return_value, key.data, key.len, val.data, val.len);
   }
-
-  go_apache_request_cleanup(thread_index);
 }
 /* }}} */
 

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -780,7 +780,7 @@ static void frankenphp_register_variables(zval *track_vars_array) {
   /* in non-worker mode we import the os environment regularly */
   if (!ctx->has_main_request) {
     get_full_env(track_vars_array);
-    //php_import_environment_variables(track_vars_array);
+    // php_import_environment_variables(track_vars_array);
     go_register_variables(thread_index, track_vars_array);
     return;
   }
@@ -790,7 +790,7 @@ static void frankenphp_register_variables(zval *track_vars_array) {
     os_environment = malloc(sizeof(zval));
     array_init(os_environment);
     get_full_env(os_environment);
-    //php_import_environment_variables(os_environment);
+    // php_import_environment_variables(os_environment);
   }
   zend_hash_copy(Z_ARR_P(track_vars_array), Z_ARR_P(os_environment),
                  (copy_ctor_func_t)zval_add_ref);

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -300,47 +300,13 @@ PHP_FUNCTION(frankenphp_getenv) {
     return;
   }
 
-  go_string *value = NULL;
-  int value_len = 0;
-
   go_string gname = {name_len, name};
 
   struct go_getenv_return result = go_getenv(thread_index, &gname);
 
   if (result.r0) {
-    if (name == NULL) {
-      // Initialize an empty array
-      array_init(return_value);
-
-      char *key;
-      char *val;
-
-      for (int i = 0; i < value_len; i++) {
-        go_string *env = value + i;
-        key = env->data;
-        // find the equal sign
-        val = strchr(key, '=');
-        if (val != NULL) {
-          // create PHP strings for key and value
-          zend_string *key_str = zend_string_init(key, val - key, 0);
-          zend_string *val_str =
-              zend_string_init(val + 1, env->len - (val - key) - 1, 0);
-
-          // add to the associative array
-          add_assoc_str(return_value, ZSTR_VAL(key_str), val_str);
-
-          // release the key string
-          zend_string_release(key_str);
-        }
-      }
-
-      // Free the strings allocated in Go
-      free(value);
-    } else {
-      // Return the single environment variable as a string
-      RETVAL_STRINGL(result.r1->data, result.r1->len);
-      free(value);
-    }
+    // Return the single environment variable as a string
+    RETVAL_STRINGL(result.r1->data, result.r1->len);
   } else {
     // Environment variable does not exist
     RETVAL_FALSE;

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -776,7 +776,7 @@ static void frankenphp_register_variables(zval *track_vars_array) {
   /* https://www.php.net/manual/en/reserved.variables.server.php */
 
   /* In CGI mode, we consider the environment to be a part of the server
-   * variables
+   * variables.
    */
 
   frankenphp_server_context *ctx = SG(server_context);

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -257,9 +257,7 @@ PHP_FUNCTION(frankenphp_putenv) {
     RETURN_FALSE;
   }
 
-  int result = go_putenv(setting, (int)setting_len);
-
-  if (result) {
+  if (go_putenv(setting, (int)setting_len)) {
     RETURN_TRUE;
   } else {
     RETURN_FALSE;

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -243,90 +243,89 @@ PHP_FUNCTION(frankenphp_finish_request) { /* {{{ */
 } /* }}} */
 
 /* {{{ Call go's putenv to prevent race conditions */
-PHP_FUNCTION(frankenphp_putenv)
-{
-    char *setting;
-	size_t setting_len;
+PHP_FUNCTION(frankenphp_putenv) {
+  char *setting;
+  size_t setting_len;
 
-    ZEND_PARSE_PARAMETERS_START(1, 1)
-        Z_PARAM_STRING(setting, setting_len)
-    ZEND_PARSE_PARAMETERS_END();
+  ZEND_PARSE_PARAMETERS_START(1, 1)
+  Z_PARAM_STRING(setting, setting_len)
+  ZEND_PARSE_PARAMETERS_END();
 
-    // Cast str_len to int (ensure it fits in an int)
-    if (setting_len > INT_MAX) {
-        php_error(E_WARNING, "String length exceeds maximum integer value");
-        RETURN_FALSE;
-    }
+  // Cast str_len to int (ensure it fits in an int)
+  if (setting_len > INT_MAX) {
+    php_error(E_WARNING, "String length exceeds maximum integer value");
+    RETURN_FALSE;
+  }
 
-    int result = go_putenv(setting, (int)setting_len);
+  int result = go_putenv(setting, (int)setting_len);
 
-    if (result) {
-        RETURN_TRUE;
-    } else {
-        RETURN_FALSE;
-    }
+  if (result) {
+    RETURN_TRUE;
+  } else {
+    RETURN_FALSE;
+  }
 } /* }}} */
 
 /* {{{ Call go's getenv to prevent race conditions */
 PHP_FUNCTION(frankenphp_getenv) {
-    char *name = NULL;
-    size_t name_len = 0;
-    bool local_only = 0;
+  char *name = NULL;
+  size_t name_len = 0;
+  bool local_only = 0;
 
-    ZEND_PARSE_PARAMETERS_START(0, 2)
-        Z_PARAM_OPTIONAL
-        Z_PARAM_STRING_OR_NULL(name, name_len)
-        Z_PARAM_BOOL(local_only)
-    ZEND_PARSE_PARAMETERS_END();
+  ZEND_PARSE_PARAMETERS_START(0, 2)
+  Z_PARAM_OPTIONAL
+  Z_PARAM_STRING_OR_NULL(name, name_len)
+  Z_PARAM_BOOL(local_only)
+  ZEND_PARSE_PARAMETERS_END();
 
-    char *value = NULL;
-    int value_len = 0;
+  char *value = NULL;
+  int value_len = 0;
 
-    int result = go_getenv(name, (int)name_len, &value, &value_len);
+  int result = go_getenv(name, (int)name_len, &value, &value_len);
 
-    if (result) {
-            if (name == NULL) {
-                // Initialize an empty array
-                array_init(return_value);
+  if (result) {
+    if (name == NULL) {
+      // Initialize an empty array
+      array_init(return_value);
 
-                char *env = value;
-                char *end = value + value_len;
-                while (env < end && *env != '\0') {
-                    size_t len = strlen(env);
-                    char *key_value = env; // key=value format
+      char *env = value;
+      char *end = value + value_len;
+      while (env < end && *env != '\0') {
+        size_t len = strlen(env);
+        char *key_value = env; // key=value format
 
-                    // Find the position of '=' to split key and value
-                    char *equal_sign = strchr(key_value, '=');
-                    if (equal_sign != NULL) {
-                        size_t key_len = equal_sign - key_value;
-                        size_t val_len = len - key_len - 1; // Exclude '='
+        // Find the position of '=' to split key and value
+        char *equal_sign = strchr(key_value, '=');
+        if (equal_sign != NULL) {
+          size_t key_len = equal_sign - key_value;
+          size_t val_len = len - key_len - 1; // Exclude '='
 
-                        // Create PHP strings for key and value
-                        zend_string *key = zend_string_init(key_value, key_len, 0);
-                        zend_string *val = zend_string_init(equal_sign + 1, val_len, 0);
+          // Create PHP strings for key and value
+          zend_string *key = zend_string_init(key_value, key_len, 0);
+          zend_string *val = zend_string_init(equal_sign + 1, val_len, 0);
 
-                        // Add to the associative array
-                        add_assoc_str(return_value, ZSTR_VAL(key), val);
+          // Add to the associative array
+          add_assoc_str(return_value, ZSTR_VAL(key), val);
 
-                        // Release the key string
-                        zend_string_release(key);
-                    }
-
-                    // Move to the next environment variable
-                    env += len + 1;
-                }
-
-                // Free the C string allocated in Go
-                free(value);
-            } else {
-                // Return the single environment variable as a string
-                RETVAL_STRINGL(value, value_len);
-                free(value);
-            }
-        } else {
-            // Environment variable does not exist
-            RETVAL_FALSE;
+          // Release the key string
+          zend_string_release(key);
         }
+
+        // Move to the next environment variable
+        env += len + 1;
+      }
+
+      // Free the C string allocated in Go
+      free(value);
+    } else {
+      // Return the single environment variable as a string
+      RETVAL_STRINGL(value, value_len);
+      free(value);
+    }
+  } else {
+    // Environment variable does not exist
+    RETVAL_FALSE;
+  }
 } /* }}} */
 
 /* {{{ Fetch all HTTP request headers */
@@ -495,38 +494,39 @@ PHP_FUNCTION(headers_send) {
   RETURN_LONG(sapi_send_headers());
 }
 
-PHP_MINIT_FUNCTION(frankenphp)
-{
-    zend_function *func;
+PHP_MINIT_FUNCTION(frankenphp) {
+  zend_function *func;
 
-    // Override putenv
-    func = zend_hash_str_find_ptr(CG(function_table), "putenv", sizeof("putenv") - 1);
-    if (func != NULL && func->type == ZEND_INTERNAL_FUNCTION) {
-        ((zend_internal_function *)func)->handler = ZEND_FN(frankenphp_putenv);
-    } else {
-        php_error(E_WARNING, "Failed to find built-in putenv function");
-    }
+  // Override putenv
+  func = zend_hash_str_find_ptr(CG(function_table), "putenv",
+                                sizeof("putenv") - 1);
+  if (func != NULL && func->type == ZEND_INTERNAL_FUNCTION) {
+    ((zend_internal_function *)func)->handler = ZEND_FN(frankenphp_putenv);
+  } else {
+    php_error(E_WARNING, "Failed to find built-in putenv function");
+  }
 
-    // Override getenv
-    func = zend_hash_str_find_ptr(CG(function_table), "getenv", sizeof("getenv") - 1);
-    if (func != NULL && func->type == ZEND_INTERNAL_FUNCTION) {
-        ((zend_internal_function *)func)->handler = ZEND_FN(frankenphp_getenv);
-    } else {
-        php_error(E_WARNING, "Failed to find built-in getenv function");
-    }
+  // Override getenv
+  func = zend_hash_str_find_ptr(CG(function_table), "getenv",
+                                sizeof("getenv") - 1);
+  if (func != NULL && func->type == ZEND_INTERNAL_FUNCTION) {
+    ((zend_internal_function *)func)->handler = ZEND_FN(frankenphp_getenv);
+  } else {
+    php_error(E_WARNING, "Failed to find built-in getenv function");
+  }
 
-    return SUCCESS;
+  return SUCCESS;
 }
 
 static zend_module_entry frankenphp_module = {
     STANDARD_MODULE_HEADER,
     "frankenphp",
-    ext_functions, /* function table */
+    ext_functions,         /* function table */
     PHP_MINIT(frankenphp), /* initialization */
-    NULL,          /* shutdown */
-    NULL,          /* request initialization */
-    NULL,          /* request shutdown */
-    NULL,          /* information */
+    NULL,                  /* shutdown */
+    NULL,                  /* request initialization */
+    NULL,                  /* request shutdown */
+    NULL,                  /* information */
     TOSTRING(FRANKENPHP_VERSION),
     STANDARD_MODULE_PROPERTIES};
 

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -520,8 +520,7 @@ func go_putenv(str *C.char, length C.int) C.bool {
 		}
 	} else {
 		// No '=', unset the environment variable
-		err := os.Unsetenv(envString)
-		if err != nil {
+		if os.Unsetenv(envString) != nil {
 			return false // Failure
 		}
 	}

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -510,7 +510,7 @@ func go_putenv(str *C.char, length C.int) C.bool {
 	envString := string(s)
 
 	// Check if '=' is present in the string
-	if idx := strings.IndexByte(envString, '='); idx != -1 && idx < len(envString)-1 {
+	if idx := strings.IndexByte(envString, '='); idx != -1 {
 		// '=' found, set the environment variable
 		key := envString[:idx]
 		val := envString[idx+1:]

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -502,7 +502,7 @@ func ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) error 
 }
 
 //export go_putenv
-func go_putenv(str *C.char, length C.int) C.int {
+func go_putenv(str *C.char, length C.int) C.bool {
 	// Create a byte slice from C string with a specified length
 	s := C.GoBytes(unsafe.Pointer(str), length)
 
@@ -517,21 +517,21 @@ func go_putenv(str *C.char, length C.int) C.int {
 
 		err := os.Setenv(key, val)
 		if err != nil {
-			return C.int(0) // Failure
+			return false // Failure
 		}
 	} else {
 		// No '=', unset the environment variable
 		err := os.Unsetenv(envString)
 		if err != nil {
-			return C.int(0) // Failure
+			return false // Failure
 		}
 	}
 
-	return C.int(1) // Success
+	return true // Success
 }
 
 //export go_getenv
-func go_getenv(name *C.char, length C.int, value **C.char, value_len *C.int) C.int {
+func go_getenv(name *C.char, length C.int, value **C.char, value_len *C.int) C.bool {
 	if name == nil {
 		// Get all environment variables
 		env := os.Environ()
@@ -541,7 +541,7 @@ func go_getenv(name *C.char, length C.int, value **C.char, value_len *C.int) C.i
 		*value = C.CString(concatenatedEnv)
 		// Set the length of the concatenated string
 		*value_len = C.int(len(concatenatedEnv))
-		return C.int(1) // Success
+		return true // Success
 	}
 
 	// Create a byte slice from C string with a specified length
@@ -556,7 +556,7 @@ func go_getenv(name *C.char, length C.int, value **C.char, value_len *C.int) C.i
 		// Environment variable does not exist
 		*value = nil
 		*value_len = 0
-		return C.int(0) // Return 0 to indicate failure
+		return false // Return 0 to indicate failure
 	}
 
 	// Convert Go string to C string
@@ -564,7 +564,7 @@ func go_getenv(name *C.char, length C.int, value **C.char, value_len *C.int) C.i
 	*value = cValue
 	*value_len = C.int(len(envValue))
 
-	return C.int(1) // Return 1 to indicate success
+	return true // Return 1 to indicate success
 }
 
 //export go_handle_request

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -592,6 +592,7 @@ func go_handle_request(threadIndex C.uintptr_t) bool {
 		defer func() {
 			maybeCloseContext(fc)
 			thread.mainRequest = nil
+			thread.Unpin()
 		}()
 
 		if err := updateServerContext(r, true, false); err != nil {
@@ -715,8 +716,6 @@ func go_register_variables(threadIndex C.uintptr_t, trackVarsArray *C.zval) {
 
 	C.frankenphp_register_bulk_variables(&knownVariables[0], dvsd, C.size_t(l), trackVarsArray)
 
-	thread.Unpin()
-
 	fc.env = nil
 }
 
@@ -757,11 +756,6 @@ func go_apache_request_headers(threadIndex C.uintptr_t, hasActiveRequest bool) (
 	thread.Pin(sd)
 
 	return sd, C.size_t(len(r.Header))
-}
-
-//export go_apache_request_cleanup
-func go_apache_request_cleanup(threadIndex C.uintptr_t) {
-	phpThreads[threadIndex].Unpin()
 }
 
 func addHeader(fc *FrankenPHPContext, cString *C.char, length C.int) {

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -510,7 +510,7 @@ func go_putenv(str *C.char, length C.int) C.bool {
 	envString := string(s)
 
 	// Check if '=' is present in the string
-	if idx := strings.IndexByte(envString, '='); idx != -1 {
+	if idx := strings.IndexByte(envString, '='); idx != -1 && idx < len(envString)-1 {
 		// '=' found, set the environment variable
 		key := envString[:idx]
 		val := envString[idx+1:]

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -515,8 +515,7 @@ func go_putenv(str *C.char, length C.int) C.bool {
 		key := envString[:idx]
 		val := envString[idx+1:]
 
-		err := os.Setenv(key, val)
-		if err != nil {
+		if os.Setenv(key, val) != nil {
 			return false // Failure
 		}
 	} else {

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -510,11 +510,7 @@ func go_putenv(str *C.char, length C.int) C.bool {
 	envString := string(s)
 
 	// Check if '=' is present in the string
-	if idx := strings.IndexByte(envString, '='); idx != -1 {
-		// '=' found, set the environment variable
-		key := envString[:idx]
-		val := envString[idx+1:]
-
+	if key, val, found := strings.Cut(envString, "="); found {
 		if os.Setenv(key, val) != nil {
 			return false // Failure
 		}

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -637,7 +637,12 @@ func testEnv(t *testing.T, opts *testOptions) {
 		resp := w.Result()
 		body, _ := io.ReadAll(resp.Body)
 
-		assert.Equal(t, "Set MY_VAR successfully.\nMY_VAR = HelloWorld\nUnset MY_VAR successfully.\nMY_VAR is unset.\nUnset NON_EXISTING_VAR successfully.\n", string(body))
+		// execute the script as regular php script
+		cmd := exec.Command("php", "testdata/test-env.php", strconv.Itoa(i))
+		stdoutStderr, err := cmd.CombinedOutput()
+		require.NoError(t, err)
+
+		assert.Equal(t, string(stdoutStderr), string(body))
 	}, opts)
 }
 

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -637,7 +637,7 @@ func testEnv(t *testing.T, opts *testOptions) {
 		resp := w.Result()
 		body, _ := io.ReadAll(resp.Body)
 
-		assert.Equal(t, fmt.Sprintf("Set MY_VAR successfully.\nMY_VAR = HelloWorld\nUnset MY_VAR successfully.\nMY_VAR is unset.\nUnset NON_EXISTING_VAR successfully.\n"), string(body))
+		assert.Equal(t, "Set MY_VAR successfully.\nMY_VAR = HelloWorld\nUnset MY_VAR successfully.\nMY_VAR is unset.\nUnset NON_EXISTING_VAR successfully.\n", string(body))
 	}, opts)
 }
 

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -640,7 +640,10 @@ func testEnv(t *testing.T, opts *testOptions) {
 		// execute the script as regular php script
 		cmd := exec.Command("php", "testdata/test-env.php", strconv.Itoa(i))
 		stdoutStderr, err := cmd.CombinedOutput()
-		require.NoError(t, err)
+		if err != nil {
+			// php is not installed or other issue, use the hardcoded output below:
+			stdoutStderr = []byte("Set MY_VAR successfully.\nMY_VAR = HelloWorld\nUnset MY_VAR successfully.\nMY_VAR is unset.\nMY_VAR set to empty successfully.\nMY_VAR =\nUnset NON_EXISTING_VAR successfully.\n")
+		}
 
 		assert.Equal(t, string(stdoutStderr), string(body))
 	}, opts)

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -622,6 +622,25 @@ func TestFailingWorker(t *testing.T) {
 	}, &testOptions{workerScript: "failing-worker.php"})
 }
 
+func TestEnv(t *testing.T) {
+	testEnv(t, &testOptions{})
+}
+func TestEnvWorker(t *testing.T) {
+	testEnv(t, &testOptions{workerScript: "test-env.php"})
+}
+func testEnv(t *testing.T, opts *testOptions) {
+	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, i int) {
+		req := httptest.NewRequest("GET", fmt.Sprintf("http://example.com/test-env.php?var=%d", i), nil)
+		w := httptest.NewRecorder()
+		handler(w, req)
+
+		resp := w.Result()
+		body, _ := io.ReadAll(resp.Body)
+
+		assert.Equal(t, fmt.Sprintf("Set MY_VAR successfully.\nMY_VAR = HelloWorld\nUnset MY_VAR successfully.\nMY_VAR is unset.\nUnset NON_EXISTING_VAR successfully.\n"), string(body))
+	}, opts)
+}
+
 func TestFileUpload_module(t *testing.T) { testFileUpload(t, &testOptions{}) }
 func TestFileUpload_worker(t *testing.T) {
 	testFileUpload(t, &testOptions{workerScript: "file-upload.php"})

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -642,7 +642,7 @@ func testEnv(t *testing.T, opts *testOptions) {
 		stdoutStderr, err := cmd.CombinedOutput()
 		if err != nil {
 			// php is not installed or other issue, use the hardcoded output below:
-			stdoutStderr = []byte("Set MY_VAR successfully.\nMY_VAR = HelloWorld\nUnset MY_VAR successfully.\nMY_VAR is unset.\nMY_VAR set to empty successfully.\nMY_VAR =\nUnset NON_EXISTING_VAR successfully.\n")
+			stdoutStderr = []byte("Set MY_VAR successfully.\nMY_VAR = HelloWorld\nUnset MY_VAR successfully.\nMY_VAR is unset.\nMY_VAR set to empty successfully.\nMY_VAR = \nUnset NON_EXISTING_VAR successfully.\n")
 		}
 
 		assert.Equal(t, string(stdoutStderr), string(body))

--- a/testdata/test-env.php
+++ b/testdata/test-env.php
@@ -1,31 +1,37 @@
 <?php
-// Setting an environment variable
-$result = putenv('MY_VAR=HelloWorld');
-if ($result) {
-    echo "Set MY_VAR successfully.\n";
-    echo "MY_VAR = " . getenv('MY_VAR') . "\n";
-} else {
-    echo "Failed to set MY_VAR.\n";
-}
 
-// Unsetting the environment variable
-$result = putenv('MY_VAR');
-if ($result) {
-    echo "Unset MY_VAR successfully.\n";
-    $value = getenv('MY_VAR');
-    if ($value === false) {
-        echo "MY_VAR is unset.\n";
+require_once __DIR__.'/_executor.php';
+
+return function() {
+    $var = 'MY_VAR_' . $_GET['var'];
+    // Setting an environment variable
+    $result = putenv("$var=HelloWorld");
+    if ($result) {
+        echo "Set MY_VAR successfully.\n";
+        echo "MY_VAR = " . getenv($var) . "\n";
     } else {
-        echo "MY_VAR = " . $value . "\n";
+        echo "Failed to set MY_VAR.\n";
     }
-} else {
-    echo "Failed to unset MY_VAR.\n";
-}
 
-// Attempt to unset a non-existing variable
-$result = putenv('NON_EXISTING_VAR');
-if ($result) {
-    echo "Unset NON_EXISTING_VAR successfully.\n";
-} else {
-    echo "Failed to unset NON_EXISTING_VAR.\n";
-}
+    // Unsetting the environment variable
+    $result = putenv($var);
+    if ($result) {
+        echo "Unset MY_VAR successfully.\n";
+        $value = getenv($var);
+        if ($value === false) {
+            echo "MY_VAR is unset.\n";
+        } else {
+            echo "MY_VAR = " . $value . "\n";
+        }
+    } else {
+        echo "Failed to unset MY_VAR.\n";
+    }
+
+    // Attempt to unset a non-existing variable
+    $result = putenv('NON_EXISTING_VAR' . $_GET['var']);
+    if ($result) {
+        echo "Unset NON_EXISTING_VAR successfully.\n";
+    } else {
+        echo "Failed to unset NON_EXISTING_VAR.\n";
+    }
+};

--- a/testdata/test-env.php
+++ b/testdata/test-env.php
@@ -1,0 +1,31 @@
+<?php
+// Setting an environment variable
+$result = putenv('MY_VAR=HelloWorld');
+if ($result) {
+    echo "Set MY_VAR successfully.\n";
+    echo "MY_VAR = " . getenv('MY_VAR') . "\n";
+} else {
+    echo "Failed to set MY_VAR.\n";
+}
+
+// Unsetting the environment variable
+$result = putenv('MY_VAR');
+if ($result) {
+    echo "Unset MY_VAR successfully.\n";
+    $value = getenv('MY_VAR');
+    if ($value === false) {
+        echo "MY_VAR is unset.\n";
+    } else {
+        echo "MY_VAR = " . $value . "\n";
+    }
+} else {
+    echo "Failed to unset MY_VAR.\n";
+}
+
+// Attempt to unset a non-existing variable
+$result = putenv('NON_EXISTING_VAR');
+if ($result) {
+    echo "Unset NON_EXISTING_VAR successfully.\n";
+} else {
+    echo "Failed to unset NON_EXISTING_VAR.\n";
+}

--- a/testdata/test-env.php
+++ b/testdata/test-env.php
@@ -3,7 +3,7 @@
 require_once __DIR__.'/_executor.php';
 
 return function() {
-    $var = 'MY_VAR_' . $_GET['var'];
+    $var = 'MY_VAR_' . ($_GET['var'] ?? '');
     // Setting an environment variable
     $result = putenv("$var=HelloWorld");
     if ($result) {
@@ -27,8 +27,21 @@ return function() {
         echo "Failed to unset MY_VAR.\n";
     }
 
+    $result = putenv("$var=");
+    if ($result) {
+        echo "MY_VAR set to empty successfully.\n";
+        $value = getenv($var);
+        if ($value === false) {
+            echo "MY_VAR is unset.\n";
+        } else {
+            echo "MY_VAR = " . $value . "\n";
+        }
+    } else {
+        echo "Failed to set MY_VAR.\n";
+    }
+
     // Attempt to unset a non-existing variable
-    $result = putenv('NON_EXISTING_VAR' . $_GET['var']);
+    $result = putenv('NON_EXISTING_VAR' . ($_GET['var'] ?? ''));
     if ($result) {
         echo "Unset NON_EXISTING_VAR successfully.\n";
     } else {

--- a/worker.go
+++ b/worker.go
@@ -310,4 +310,6 @@ func go_frankenphp_finish_request(threadIndex C.uintptr_t, isWorkerRequest bool)
 
 		c.Write(fields...)
 	}
+
+	thread.Unpin()
 }


### PR DESCRIPTION
Inspired by the discussion in #1080, this is an ultra-risky implementation that should fix #915. Basically, Go uses RWLocks to prevent multiple threads from writing to the environment, while PHP uses TSRM. TSRM and Go don't know about each other and if one happens to be reading the environment while the other is writing to it, a segfault is bound to happen.

So... this PR replaces the built-in `getenv` and `putenv` with ones that defer to Go. See #1080 discussions for why this may not be the best solution, but maybe it is a 'good enough' solution to prevent segfaults from concurrent environmental accesses in Go and PHP. If we are happy with this approach, this will need many tests to ensure the behavior is exactly the same as the built-in ones.

For example, a missing feature is setting the `TZ` environment variable which should trigger a reset of the current timezone... however, that would bleed into other threads currently running, so it isn't ideal. In fact, it might be good that it doesn't work.