### PR TITLE
Removes worker panic when the watcher is enabled.

### DIFF
--- a/testdata/failing-worker.php
+++ b/testdata/failing-worker.php
@@ -1,9 +1,9 @@
 <?php
 
-$fail = random_int(1, 100) < 1;
-$wait = random_int(1, 5);
+$fail = random_int(1, 100) < 10;
+$wait = random_int(1000 * 100, 1000 * 500); // wait 100ms - 500ms
 
-sleep($wait);
+usleep($wait);
 if ($fail) {
     exit(1);
 }

--- a/worker.go
+++ b/worker.go
@@ -28,7 +28,7 @@ const minWorkerErrorBackoff = 100 * time.Millisecond
 const maxWorkerConsecutiveFailures = 5
 
 var (
-    isInitialBoot    bool = true
+	isInitialBoot    bool = true
 	workersReadyWG   sync.WaitGroup
 	workerShutdownWG sync.WaitGroup
 	workersAreReady  atomic.Bool


### PR DESCRIPTION
This PR should fix #1087

When workers have started once successfully and a watcher is defined, then we'll log a warning instead of crashing on the exponential backoff.

This PR also allows to set a lower treshhold on the failure count. I additionally adjusted the wait time in `failing-worker.php`, which makes tests faster again (~7s instead of ~16s)