### PR TITLE
docs: update php.ini path

### DIFF
--- a/docs/cn/config.md
+++ b/docs/cn/config.md
@@ -2,21 +2,24 @@
 
 FrankenPHP，Caddy 以及 Mercure 和 Vulcain 模块可以使用 [Caddy 支持的格式](https://caddyserver.com/docs/getting-started#your-first-config) 进行配置。
 
-在 Docker 镜像中，`Caddyfile` 位于 `/etc/caddy/Caddyfile`。
-
-您也可以像往常一样使用 `php.ini` 配置 PHP。
-
-在 Docker 镜像中，默认不存在 `php.ini`，您可以手动创建它或从官方模板中复制。
+在[Docker 映像](docker.md) 中，`Caddyfile` 位于 `/etc/caddy/Caddyfile`。
+静态二进制文件会在启动时所在的目录中查找 `Caddyfile`。
+PHP 本身可以[使用 `php.ini` 文件](https://www.php.net/manual/zh/configuration.file.php)进行配置。
+默认情况下，随 Docker 映像提供的 PHP 和静态二进制文件中包含的 PHP 将在启动 FrankenPHP 的目录和 `/usr/local/etc/php/` 中查找`php.ini` 文件。它们还会从 `/usr/local/etc/php/conf.d/` 中加载所有以 `.ini` 结尾的文件。
+默认情况下没有 `php.ini` 文件，因此应复制 PHP 项目提供的官方模板。
+在 Docker 上，模板在镜像中提供：
 
 ```dockerfile
 FROM dunglas/frankenphp
 
-# 开发:
-RUN cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini
-
 # 生产:
 RUN cp $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
+
+# 开发:
+RUN cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini
 ```
+
+如果不使用 Docker，请复制[PHP 源代码](https://github.com/php/php-src/)中提供的`php.ini-production`或`php.ini-development`中的一个。
 
 ## Caddyfile 配置
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -3,23 +3,27 @@
 FrankenPHP, Caddy as well as the Mercure and Vulcain modules can be configured using [the formats supported by Caddy](https://caddyserver.com/docs/getting-started#your-first-config).
 
 In [the Docker images](docker.md), the `Caddyfile` is located at `/etc/caddy/Caddyfile`.
+The static binary will look for the `Caddyfile` in the directory in which it is started.
 
-You can also configure PHP using `php.ini` as usual.
+PHP itself can be configured [using a `php.ini` file](https://www.php.net/manual/en/configuration.file.php).
 
-In the Docker images, the `php.ini` file is not present, you can create it manually  or copy an official template:
+By default, the PHP supplied with the Docker images and the one included in the static binary will look for a `php.ini` file in the directory where FrankenPHP is started and in `/usr/local/etc/php/`. They will also load all files ending in `.ini` from `/usr/local/etc/php/conf.d/`.
+
+No `php.ini` file is present by default, you should copy an official template provided by the PHP project.
+
+On Docker, the templates are provided in the images:
 
 ```dockerfile
 FROM dunglas/frankenphp
 
-# Developement:
-RUN cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini
-
-# Or production:
+# Production:
 RUN cp $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
+
+# Or developement:
+RUN cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini
 ```
 
-The static binary will look for a `php.ini` file in the current working directory,
-in `/lib/` as well as [the other standard locations](https://www.php.net/manual/en/configuration.file.php).
+Docker kullanmıyorsanız, [PHP kaynak kodu](https://github.com/php/php-src/) ile birlikte verilen `php.ini-production` veya `php.ini-development` dosyalarından birini kopyalayın.
 
 ## Caddyfile Config
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -23,7 +23,7 @@ RUN cp $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
 RUN cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini
 ```
 
-Docker kullanmıyorsanız, [PHP kaynak kodu](https://github.com/php/php-src/) ile birlikte verilen `php.ini-production` veya `php.ini-development` dosyalarından birini kopyalayın.
+If you don't use Docker, copy one of `php.ini-production` or `php.ini-development` provided [in the PHP sources](https://github.com/php/php-src/).
 
 ## Caddyfile Config
 

--- a/docs/fr/config.md
+++ b/docs/fr/config.md
@@ -2,24 +2,26 @@
 
 FrankenPHP, Caddy ainsi que les modules Mercure et Vulcain peuvent être configurés en utilisant [les formats pris en charge par Caddy](https://caddyserver.com/docs/getting-started#your-first-config).
 
-Dans l'image Docker, le chemin du `Caddyfile` est `/etc/caddy/Caddyfile`.
+Dans [les images Docker](docker.md), le `Caddyfile` est situé dans `/etc/caddy/Caddyfile`.
+Le binaire statique cherchera le `Caddyfile` dans le répertoire dans lequel il est démarré.
+PHP lui-même peut être configuré [en utilisant un fichier `php.ini`](https://www.php.net/manual/fr/configuration.file.php).
 
-Vous pouvez également configurer PHP en utilisant `php.ini` comme d'habitude.
+Par défaut, le PHP fourni avec les images Docker et celui inclus dans le binaire statique cherchera un fichier `php.ini` dans le répertoire où FrankenPHP est démarré et dans `/usr/local/etc/php/`. Ils chargeront également tous les fichiers se terminant par `.ini` dans `/usr/local/etc/php/conf.d/`.
 
-Dans l'image Docker, le fichier `php.ini` n'est pas présent, vous pouvez le créer manuellement ou copier un template officiel :
+Aucun fichier `php.ini` n'est présent par défaut, vous devriez copier un modèle officiel fourni par le projet PHP.
+Sur Docker, les modèles sont fournis dans les images :
 
 ```dockerfile
 FROM dunglas/frankenphp
 
-# Développement :
-RUN cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini
-
-# Ou production :
+# Production :
 RUN cp $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
+
+# Ou développement :
+RUN cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini
 ```
 
-Le binaire statique cherchera un fichier `php.ini` dans le répertoire de travail courant,
-dans `/lib/` ainsi que [les autres emplacements standards](https://www.php.net/manual/fr/configuration.file.php).
+Si vous n'utilisez pas Docker, copiez l'un des fichiers `php.ini-production` ou `php.ini-development` fournis [dans les sources de PHP](https://github.com/php/php-src/).
 
 ## Configuration du Caddyfile
 

--- a/docs/tr/config.md
+++ b/docs/tr/config.md
@@ -22,6 +22,8 @@ RUN cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini
 RUN cp $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
 ```
 
+Docker kullanmıyorsanız, [PHP kaynak kodu](https://github.com/php/php-src/) ile birlikte verilen `php.ini-production` veya `php.ini-development` dosyalarından birini kopyalayın.
+
 ## Caddyfile Konfigürasyonu
 
 FrankenPHP yürütücüsünü kaydetmek için `frankenphp` [global seçenek](https://caddyserver.com/docs/caddyfile/concepts#global-options) ayarlanmalıdır, ardından PHP uygulamanızı sunmak için site blokları içinde `php_server` veya `php` [HTTP yönergeleri](https://caddyserver.com/docs/caddyfile/concepts#directives) kullanılabilir.

--- a/docs/tr/config.md
+++ b/docs/tr/config.md
@@ -2,11 +2,15 @@
 
 FrankenPHP, Caddy'nin yanı sıra Mercure ve Vulcain modülleri [Caddy tarafından desteklenen formatlar](https://caddyserver.com/docs/getting-started#your-first-config) kullanılarak yapılandırılabilir.
 
-Docker imajında, `Caddyfile` `/etc/caddy/Caddyfile` dosyası olarak bulunur.
+Docker imajlarında] (docker.md), `Caddyfile` `/etc/caddy/Caddyfile` adresinde bulunur.
+Statik ikili, başlatıldığı dizinde `Caddyfile` dosyasını arayacaktır.
 
-PHP'yi her zamanki gibi `php.ini` kullanarak da yapılandırabilirsiniz.
+PHP'nin kendisi [bir `php.ini` dosyası kullanılarak yapılandırılabilir](https://www.php.net/manual/tr/configuration.file.php).
 
-Docker imajında `php.ini` dosyası mevcut değildir, elle oluşturabilir veya resmi bir şablonu kopyalayabilirsiniz:
+Varsayılan olarak, Docker imajlarıyla birlikte verilen PHP ve statik ikili dosyada bulunan PHP, FrankenPHP'nin başlatıldığı dizinde ve `/usr/local/etc/php/` içinde bir `php.ini` dosyası arayacaktır. Ayrıca `.ini` ile biten tüm dosyaları `/usr/local/etc/php/conf.d/` dizininden yükleyecektir.
+
+Öntanımlı olarak `php.ini` dosyası yoktur, PHP projesi tarafından sağlanan resmi bir şablonu kopyalamanız gerekir.
+Docker'da şablonlar imajlar içinde sağlanır:
 
 ```dockerfile
 FROM dunglas/frankenphp


### PR DESCRIPTION
We changed the default `php.ini` path in Static PHP CLI: https://github.com/crazywhalecc/static-php-cli/pull/553

This PR updates the docs accordingly.

The Chinese and Turkish translations were done using DeepL, so I'm not sure of their quality.