### PR TITLE
refactor: use build tags to disable, instead of to enable a feature

### DIFF
--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -119,7 +119,7 @@ jobs:
           } >> "$GITHUB_ENV"
       -
         name: Compile tests
-        run: go test -${{ matrix.sanitizer }} -v -x -c
+        run: go test -tags=nowatcher -${{ matrix.sanitizer }} -v -x -c
       -
         name: Run tests
         run: ./frankenphp.test -test.v

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -97,6 +97,7 @@ jobs:
         name: Add PHP to the PATH
         run: echo "$(pwd)/php/target/bin" >> "$GITHUB_PATH"
       -
+        if: matrix.sanitizer != 'msan'
         uses: actions/checkout@v4
         name: Checkout watcher
         with:
@@ -104,6 +105,7 @@ jobs:
           ref: ${{ env.EDANT_WATCHER_VERSION }}
           path: 'edant/watcher'
       -
+        if: matrix.sanitizer != 'msan'
         name: Compile edant/watcher
         run: |
           cd edant/watcher/watcher-c/
@@ -119,7 +121,7 @@ jobs:
           } >> "$GITHUB_ENV"
       -
         name: Compile tests
-        run: go test -tags=nowatcher -${{ matrix.sanitizer }} -v -x -c
+        run: go test  ${{ matrix.sanitizer == 'msan' && '-tags=nowatcher' || '' }} -${{ matrix.sanitizer }} -v -x -c
       -
         name: Run tests
         run: ./frankenphp.test -test.v

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ ENV CGO_CPPFLAGS=$PHP_CPPFLAGS
 ENV CGO_LDFLAGS="-lssl -lcrypto -lreadline -largon2 -lcurl -lonig -lz $PHP_LDFLAGS"
 
 WORKDIR /go/src/app/caddy/frankenphp
-RUN GOBIN=/usr/local/bin go install -tags 'brotli,watcher,nobadger,nomysql,nopgx' -ldflags "-w -s -X 'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP $FRANKENPHP_VERSION PHP $PHP_VERSION Caddy'" && \
+RUN GOBIN=/usr/local/bin go install -tags 'nobadger,nomysql,nopgx' -ldflags "-w -s -X 'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP $FRANKENPHP_VERSION PHP $PHP_VERSION Caddy'" && \
 	setcap cap_net_bind_service=+ep /usr/local/bin/frankenphp && \
 	cp Caddyfile /etc/caddy/Caddyfile && \
 	frankenphp version

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -125,7 +125,7 @@ ENV CGO_CPPFLAGS=$PHP_CPPFLAGS
 ENV CGO_LDFLAGS="-lssl -lcrypto -lreadline -largon2 -lcurl -lonig -lz $PHP_LDFLAGS"
 
 WORKDIR /go/src/app/caddy/frankenphp
-RUN GOBIN=/usr/local/bin go install -tags 'brotli,watcher,nobadger,nomysql,nopgx' -ldflags "-w -s -extldflags '-Wl,-z,stack-size=0x80000' -X 'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP $FRANKENPHP_VERSION PHP $PHP_VERSION Caddy'" && \
+RUN GOBIN=/usr/local/bin go install -tags 'nobadger,nomysql,nopgx' -ldflags "-w -s -extldflags '-Wl,-z,stack-size=0x80000' -X 'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP $FRANKENPHP_VERSION PHP $PHP_VERSION Caddy'" && \
 	setcap cap_net_bind_service=+ep /usr/local/bin/frankenphp && \
 	upx --best /usr/local/bin/frankenphp && \
 	frankenphp version

--- a/build-static.sh
+++ b/build-static.sh
@@ -249,7 +249,7 @@ fi
 
 cd caddy/frankenphp/
 go env
-go build -buildmode=pie -tags "cgo,netgo,osusergo,static_build,brotli,watcher,nobadger,nomysql,nopgx" -ldflags "-linkmode=external -extldflags '-static-pie ${extraExtldflags}' ${extraLdflags} -X 'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP ${FRANKENPHP_VERSION} PHP ${LIBPHP_VERSION} Caddy'" -o "../../dist/${bin}"
+go build -buildmode=pie -tags "cgo,netgo,osusergo,static_build,nobadger,nomysql,nopgx" -ldflags "-linkmode=external -extldflags '-static-pie ${extraExtldflags}' ${extraLdflags} -X 'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP ${FRANKENPHP_VERSION} PHP ${LIBPHP_VERSION} Caddy'" -o "../../dist/${bin}"
 cd ../..
 
 if [ -d "${EMBED}" ]; then

--- a/caddy/br-skip.go
+++ b/caddy/br-skip.go
@@ -1,4 +1,4 @@
-//go:build !brotli
+//go:build nobrotli
 
 package caddy
 

--- a/caddy/br.go
+++ b/caddy/br.go
@@ -1,4 +1,4 @@
-//go:build brotli
+//go:build !nobrotli
 
 package caddy
 

--- a/caddy/watcher_test.go
+++ b/caddy/watcher_test.go
@@ -1,4 +1,4 @@
-//go:build watcher
+//go:build !nowatcher
 
 package caddy_test
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -78,7 +78,7 @@ WORKDIR /go/src/app
 COPY . .
 
 WORKDIR /go/src/app/caddy/frankenphp
-RUN go build -buildvcs=false -tags 'brotli,watcher,nobadger,nomysql,nopgx'
+RUN go build -buildvcs=false -tags 'nobadger,nomysql,nopgx'
 
 WORKDIR /go/src/app
 CMD [ "zsh" ]

--- a/internal/watcher/watch_pattern.go
+++ b/internal/watcher/watch_pattern.go
@@ -1,4 +1,4 @@
-//go:build watcher
+//go:build !nowatcher
 
 package watcher
 

--- a/internal/watcher/watch_pattern_test.go
+++ b/internal/watcher/watch_pattern_test.go
@@ -1,4 +1,4 @@
-//go:build watcher
+//go:build !nowatcher
 
 package watcher
 

--- a/internal/watcher/watcher-c.h
+++ b/internal/watcher/watcher-c.h
@@ -2,7 +2,6 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdlib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -63,16 +62,6 @@ void *wtr_watcher_open(char const *const path, wtr_watcher_callback callback,
                        void *context);
 
 bool wtr_watcher_close(void *watcher);
-
-/*  The user, or the language we're working with,
-    might not prefer a callback-style API.
-    We provide a pipe-based API for these cases.
-    Instead of forwarding events to a callback,
-    we write json-serialized events to a pipe. */
-void *wtr_watcher_open_pipe(char const *const path, int *read_fd,
-                            int *write_fd);
-
-bool wtr_watcher_close_pipe(void *watcher, int read_fd, int write_fd);
 
 #ifdef __cplusplus
 }

--- a/internal/watcher/watcher-skip.go
+++ b/internal/watcher/watcher-skip.go
@@ -1,4 +1,4 @@
-//go:build !watcher
+//go:build nowatcher
 
 package watcher
 

--- a/internal/watcher/watcher.c
+++ b/internal/watcher/watcher.c
@@ -1,5 +1,5 @@
 // clang-format off
-//go:build watcher
+//go:build !nowatcher
 // clang-format on
 #include "_cgo_export.h"
 #include "watcher-c.h"

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -1,4 +1,6 @@
-//go:build watcher
+//go:build !nowatcher
+
+//go:generate curl --silent https://raw.githubusercontent.com/e-dant/watcher/refs/heads/release/watcher-c/include/wtr/watcher-c.h -o watcher-c.h
 
 package watcher
 

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -1,4 +1,4 @@
-//go:build watcher
+//go:build !nowatcher
 
 package frankenphp_test
 


### PR DESCRIPTION
Also, add a way to fetch the latest C header provided by watcher using `go generate`.