### PR TITLE
Fixes the split path default for the php-server command

### DIFF
--- a/caddy/php-server.go
+++ b/caddy/php-server.go
@@ -128,7 +128,7 @@ func cmdPHPServer(fs caddycmd.Flags) (int, error) {
 	}
 
 	const indexFile = "index.php"
-	extensions := []string{"php"}
+	extensions := []string{".php"}
 	tryFiles := []string{"{http.request.uri.path}", "{http.request.uri.path}/" + indexFile, indexFile}
 
 	rrs := true


### PR DESCRIPTION
Fixes #1125

The default for `SplitPath` should be '.php' like [here](https://github.com/dunglas/frankenphp/blob/dad858b69762e1f7ab7ed6d31d4db616939e35d9/caddy/caddy.go#L264) in caddy.go