### PR TITLE
use escaped path instead of unescaped path

### DIFF
--- a/cgi.go
+++ b/cgi.go
@@ -112,7 +112,7 @@ func computeKnownVariables(request *http.Request, p *runtime.Pinner) (cArr [27]C
 	setKnownServerVariable(p, &cArr, remotePort, port)
 	setKnownServerVariable(p, &cArr, documentRoot, fc.documentRoot)
 	setKnownServerVariable(p, &cArr, pathInfo, fc.pathInfo)
-	setKnownServerVariable(p, &cArr, phpSelf, request.URL.Path)
+	setKnownServerVariable(p, &cArr, phpSelf, request.URL.EscapedPath())
 	setKnownServerVariable(p, &cArr, documentUri, fc.docURI)
 	setKnownServerVariable(p, &cArr, scriptFilename, fc.scriptFilename)
 	setKnownServerVariable(p, &cArr, scriptName, fc.scriptName)

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -172,9 +172,9 @@ func NewRequestWithContext(r *http.Request, opts ...RequestOption) (*http.Reques
 		fc.logger = getLogger()
 	}
 
-	if splitPos := splitPos(fc, r.URL.Path); splitPos > -1 {
-		fc.docURI = r.URL.Path[:splitPos]
-		fc.pathInfo = r.URL.Path[splitPos:]
+	if splitPos := splitPos(fc, r.URL.EscapedPath()); splitPos > -1 {
+		fc.docURI = r.URL.EscapedPath()[:splitPos]
+		fc.pathInfo = r.URL.EscapedPath()[splitPos:]
 
 		// Strip PATH_INFO from SCRIPT_NAME
 		fc.scriptName = strings.TrimSuffix(r.URL.Path, fc.pathInfo)


### PR DESCRIPTION
It appears that nginx + fpm will not unescape a path, while FrankenPHP will. Thus the following url is a 404 with nginx + fpm: `https://withinboredom.info/2024/08/12%2foptimizing-cgo-handles/`

However, with FrankenPHP, it gets translated into `https://withinboredom.info/2024/08/1/optimizing-cgo-handles/` and is not a 404.

For applications where they are expecting the original path (`//analytics/original%2fpath`), this will result in an error. Instead, we should send PHP the actual requested path.

This PR sends the escaped path instead of the unscaped path which still sanitizes the url, but leaves the original escapes intact.