### PR TITLE
Fix: Load the os env once at startup.

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -334,12 +334,12 @@ func Init(options ...Option) error {
 	}
 
 	// load the os environment once
-    // prevents potential segfaults if it's is accessed from anywhere else
-    cachedEnv = make(map[string]string, len(os.Environ()))
-    for _, envVar := range os.Environ() {
-        key, val, _ := strings.Cut(envVar, "=")
-        cachedEnv[key] = val
-    }
+	// prevents potential segfaults if it's is accessed from anywhere else
+	cachedEnv = make(map[string]string, len(os.Environ()))
+	for _, envVar := range os.Environ() {
+		key, val, _ := strings.Cut(envVar, "=")
+		cachedEnv[key] = val
+	}
 
 	shutdownWG.Add(1)
 	done = make(chan struct{})


### PR DESCRIPTION
While doing some extensive testing on #1137, I noticed that the `TestEnv` test will sporadically still segfault. This can be reproduced by doing the following multiple times:

`go test -run TestEnv -count 100`

This might be related to some Laravel segfaults people have reporting (that are hard to track down definitively)

This led me to believe that reading the env from go at runtime also isn't fully safe since extensions (and cli scripts?) might potentially access it, which circumvents the go locks.
The changes in this branch seem to fix the segfault by just loading the env once at startup and writing changes from putenv and getenv into this 'cached environment'.

I don't know if this is the best solution, but I think FPM wouldn't even persist changes from putenv across requests.