### PR TITLE
fix: sapi_module.getenv() should delegate to Go

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -752,6 +752,12 @@ static void frankenphp_log_message(const char *message, int syslog_type_int) {
   go_log((char *)message, syslog_type_int);
 }
 
+static char *frankenphp_getenv(const char *name, size_t name_len) {
+  go_string gname = {name_len, (char *)name};
+
+  return go_sapi_getenv(thread_index, &gname);
+}
+
 sapi_module_struct frankenphp_sapi_module = {
     "frankenphp", /* name */
     "FrankenPHP", /* pretty name */
@@ -765,7 +771,7 @@ sapi_module_struct frankenphp_sapi_module = {
     frankenphp_ub_write,   /* unbuffered write */
     frankenphp_sapi_flush, /* flush */
     NULL,                  /* get uid */
-    NULL,                  /* getenv */
+    frankenphp_getenv,     /* getenv */
 
     php_error, /* error handler */
 

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -575,6 +575,18 @@ func go_getenv(threadIndex C.uintptr_t, name *C.go_string) (C.bool, *C.go_string
 	return true, value // Return 1 to indicate success
 }
 
+//export go_sapi_getenv
+func go_sapi_getenv(threadIndex C.uintptr_t, name *C.go_string) *C.char {
+	envName := C.GoStringN(name.data, C.int(name.len))
+
+	envValue, exists := os.LookupEnv(envName)
+	if !exists {
+		return nil
+	}
+
+	return phpThreads[threadIndex].pinCString(envValue)
+}
+
 //export go_handle_request
 func go_handle_request(threadIndex C.uintptr_t) bool {
 	select {


### PR DESCRIPTION
Ensure that `sapi_module.getenv()` delegates to Go's `os.LookupEnv()`.

See https://github.com/dunglas/frankenphp/pull/1141#issuecomment-2461886536 for the details.

It's only a first step to have thread-safe environment variables support.