### PR TITLE
fix: watcher pattern matching and retrying

### DIFF
--- a/internal/watcher/watch_pattern.go
+++ b/internal/watcher/watch_pattern.go
@@ -10,9 +10,10 @@ import (
 )
 
 type watchPattern struct {
-	dir      string
-	patterns []string
-	trigger  chan struct{}
+	dir          string
+	patterns     []string
+	trigger      chan struct{}
+	failureCount int
 }
 
 func parseFilePatterns(filePatterns []string) ([]*watchPattern, error) {
@@ -90,7 +91,9 @@ func isValidPattern(fileName string, dir string, patterns []string) bool {
 	if !strings.HasPrefix(fileName, dir) {
 		return false
 	}
-	fileNameWithoutDir := strings.TrimLeft(fileName, dir+"/")
+
+	// remove the dir and '/' from the filename
+	fileNameWithoutDir := strings.TrimPrefix(strings.TrimPrefix(fileName, dir), "/")
 
 	// if the pattern has size 1 we can match it directly against the filename
 	if len(patterns) == 1 {

--- a/internal/watcher/watch_pattern_test.go
+++ b/internal/watcher/watch_pattern_test.go
@@ -36,6 +36,7 @@ func TestWatchesCorrectDir(t *testing.T) {
 	hasDir(t, "/path/*.php", "/path")
 	hasDir(t, "/path/*/*.php", "/path")
 	hasDir(t, "/path/?dir/*.php", "/path")
+	hasDir(t, "/path/{dir1,dir2}/**/*.php", "/path")
 	hasDir(t, ".", relativeDir(t, ""))
 	hasDir(t, "./", relativeDir(t, ""))
 	hasDir(t, "./**", relativeDir(t, ""))
@@ -130,14 +131,18 @@ func TestValidExtendedPatterns(t *testing.T) {
 	shouldMatch(t, "/path/*.{php,twig}", "/path/file.php")
 	shouldMatch(t, "/path/*.{php,twig}", "/path/file.twig")
 	shouldMatch(t, "/path/**/{file.php,file.twig}", "/path/subpath/file.twig")
-	shouldMatch(t, "/path/{folder1,folder2}/file.php", "/path/folder1/file.php")
+	shouldMatch(t, "/path/{dir1,dir2}/file.php", "/path/dir1/file.php")
+	shouldMatch(t, "/path/{dir1,dir2}/file.php", "/path/dir2/file.php")
+	shouldMatch(t, "/path/{dir1,dir2}/**/*.php", "/path/dir1/subpath/file.php")
+	shouldMatch(t, "/path/{dir1,dir2}/**/*.php", "/path/dir2/subpath/file.php")
 }
 
 func TestInValidExtendedPatterns(t *testing.T) {
 	shouldNotMatch(t, "/path/*.{php}", "/path/file.txt")
 	shouldNotMatch(t, "/path/*.{php,twig}", "/path/file.txt")
 	shouldNotMatch(t, "/path/{file.php,file.twig}", "/path/file.txt")
-	shouldNotMatch(t, "/path/{folder1,folder2}/file.php", "/path/folder3/file.php")
+	shouldNotMatch(t, "/path/{dir1,dir2}/file.php", "/path/dir3/file.php")
+	shouldNotMatch(t, "/path/{dir1,dir2}/**/*.php", "/path/dir1/subpath/file.txt")
 }
 
 func relativeDir(t *testing.T, relativePath string) string {

--- a/internal/watcher/watch_pattern_test.go
+++ b/internal/watcher/watch_pattern_test.go
@@ -133,8 +133,8 @@ func TestValidExtendedPatterns(t *testing.T) {
 	shouldMatch(t, "/path/**/{file.php,file.twig}", "/path/subpath/file.twig")
 	shouldMatch(t, "/path/{dir1,dir2}/file.php", "/path/dir1/file.php")
 	shouldMatch(t, "/path/{dir1,dir2}/file.php", "/path/dir2/file.php")
-	shouldMatch(t, "/path/{dir1,dir2}/**/*.php", "/path/dir1/subpath/file.php")
-	shouldMatch(t, "/path/{dir1,dir2}/**/*.php", "/path/dir2/subpath/file.php")
+	shouldMatch(t, "/app/{app,config,resources}/**/*.php", "/app/app/subpath/file.php")
+	shouldMatch(t, "/app/{app,config,resources}/**/*.php", "/app/config/subpath/file.php")
 }
 
 func TestInValidExtendedPatterns(t *testing.T) {

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -84,7 +84,7 @@ func retryWatching(watchPattern *watchPattern) {
 	if watchPattern.failureCount >= maxFailureCount {
 		return
 	}
-	logger.Debug("watcher was closed prematurely, retrying...", zap.String("dir", watchPattern.dir))
+	logger.Info("watcher was closed prematurely, retrying...", zap.String("dir", watchPattern.dir))
 
 	watchPattern.failureCount++
 	session, err := startSession(watchPattern)

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -84,7 +84,7 @@ func retryWatching(watchPattern *watchPattern) {
 	if watchPattern.failureCount >= maxFailureCount {
 		return
 	}
-	logger.Warn("watcher was closed prematurely, retrying...", zap.String("dir", watchPattern.dir))
+	logger.Debug("watcher was closed prematurely, retrying...", zap.String("dir", watchPattern.dir))
 
 	watchPattern.failureCount++
 	session, err := startSession(watchPattern)


### PR DESCRIPTION
This PR fixes 2 small issues I noticed after testing the watcher on some real-life projects.

For once, this fixes an issue where pattern matching sometimes wasn't working with repeating folder-names (aka `/app/app/app`)

On the other hand, I noticed that `epoll` sometimes closes its connection after a while (at least on WSL), causing the watcher stop prematurely. This PR listens for the watcher 'stop' event and tries restarting the watcher 5 times before giving up.
(if I manage to definitely track down why epoll does this, I'll also forward it to `e-dant/watcher`)