### PR TITLE
perf: use buffered chans for requests

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -333,7 +333,7 @@ func Init(options ...Option) error {
 
 	shutdownWG.Add(1)
 	done = make(chan struct{})
-	requestChan = make(chan *http.Request)
+	requestChan = make(chan *http.Request, opt.numThreads)
 	initPHPThreads(opt.numThreads)
 
 	if C.frankenphp_init(C.int(opt.numThreads)) != 0 {


### PR DESCRIPTION
Currently, the request channel isn't buffered. This means that if two requests come in concurrently, one is blocked even if two workers are immediately available. Ideally, the buffer would be equal to the number of threads, thus if you had four workers, four requests can be added to the channel immediately, without blocking.