### PR TITLE
fix: missing build tag for fastabs

### DIFF
--- a/internal/fastabs/filepath_unix.go
+++ b/internal/fastabs/filepath_unix.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package fastabs
 
 import (


### PR DESCRIPTION
See https://github.com/golang/go/issues/51572