### PR TITLE
fix: Ignore watcher dir creation error if the watcher exists

### DIFF
--- a/build-static.sh
+++ b/build-static.sh
@@ -126,7 +126,7 @@ if [ "${GITHUB_TOKEN}" ]; then
 fi
 
 # Compile e-dant/watcher as a static library
-mkdir watcher
+mkdir -p watcher
 cd watcher
 curl -f --retry 5 "${curlGitHubHeaders[@]}" https://api.github.com/repos/e-dant/watcher/releases/latest |
 	grep tarball_url |


### PR DESCRIPTION
Docker presented the error when building on linux/arm64. Applying the `-p` flag to `mkdir` allowed for successful builds.

```shell
0.324 + curlGitHubHeaders=(--header "X-GitHub-Api-Version: 2022-11-28")
0.324 + '[' '' ']'
0.324 + mkdir watcher
0.324 mkdir: can't create directory 'watcher': File exists
```