### PR TITLE
fix(metrics): handle the case where the worker is already assigned to a thread

### DIFF
--- a/caddy/watcher_test.go
+++ b/caddy/watcher_test.go
@@ -15,7 +15,7 @@ func TestWorkerWithInactiveWatcher(t *testing.T) {
 		{
 			skip_install_trust
 			admin localhost:2999
-			http_port 9080
+			http_port `+testPort+`
 
 			frankenphp {
 				worker {
@@ -26,13 +26,13 @@ func TestWorkerWithInactiveWatcher(t *testing.T) {
 			}
 		}
 
-		localhost:9080 {
+		localhost:`+testPort+` {
 			root ../testdata
 			rewrite worker-with-watcher.php
 			php
 		}
 		`, "caddyfile")
 
-	tester.AssertGetResponse("http://localhost:9080", http.StatusOK, "requests:1")
-	tester.AssertGetResponse("http://localhost:9080", http.StatusOK, "requests:2")
+	tester.AssertGetResponse("http://localhost:"+testPort, http.StatusOK, "requests:1")
+	tester.AssertGetResponse("http://localhost:"+testPort, http.StatusOK, "requests:2")
 }

--- a/php_thread.go
+++ b/php_thread.go
@@ -6,6 +6,7 @@ import "C"
 import (
 	"net/http"
 	"runtime"
+	"sync"
 	"unsafe"
 )
 
@@ -19,6 +20,7 @@ type phpThread struct {
 	worker            *worker
 	requestChan       chan *http.Request
 	knownVariableKeys map[string]*C.zend_string
+	readiedOnce       sync.Once
 }
 
 func initPHPThreads(numThreads int) {
@@ -28,7 +30,7 @@ func initPHPThreads(numThreads int) {
 	}
 }
 
-func (thread phpThread) getActiveRequest() *http.Request {
+func (thread *phpThread) getActiveRequest() *http.Request {
 	if thread.workerRequest != nil {
 		return thread.workerRequest
 	}
@@ -46,5 +48,5 @@ func (thread *phpThread) pinString(s string) *C.char {
 
 // C strings must be null-terminated
 func (thread *phpThread) pinCString(s string) *C.char {
-	return thread.pinString(s+"\x00")
+	return thread.pinString(s + "\x00")
 }

--- a/worker.go
+++ b/worker.go
@@ -254,7 +254,6 @@ func restartWorkers(workerOpts []workerOpt) {
 
 func assignThreadToWorker(thread *phpThread) {
 	fc := thread.mainRequest.Context().Value(contextKey).(*FrankenPHPContext)
-	metrics.ReadyWorker(fc.scriptFilename)
 	worker, ok := workers[fc.scriptFilename]
 	if !ok {
 		panic("worker not found for script: " + fc.scriptFilename)
@@ -277,6 +276,8 @@ func go_frankenphp_worker_handle_request_start(threadIndex C.uintptr_t) C.bool {
 	if thread.worker == nil {
 		assignThreadToWorker(thread)
 	}
+	// inform metrics that the worker is ready
+	metrics.ReadyWorker(thread.worker.fileName)
 
 	if c := logger.Check(zapcore.DebugLevel, "waiting for request"); c != nil {
 		c.Write(zap.String("worker", thread.worker.fileName))

--- a/worker.go
+++ b/worker.go
@@ -356,7 +356,6 @@ func go_frankenphp_finish_request(threadIndex C.uintptr_t, isWorkerRequest bool)
 		defer workers[fc.scriptFilename].threadMutex.Unlock()
 		for i, t := range workers[fc.scriptFilename].threads {
 			if t == thread {
-				logger.Error("Removing worker thread", zap.String("worker", fc.scriptFilename), zap.Int("thread", int(threadIndex)))
 				// remove thread from worker threads
 				workers[fc.scriptFilename].threads = append(workers[fc.scriptFilename].threads[:i], workers[fc.scriptFilename].threads[i+1:]...)
 				break

--- a/worker.go
+++ b/worker.go
@@ -148,6 +148,12 @@ func (worker *worker) startNewWorkerThread() {
 		select {
 		case _, ok := <-workersDone:
 			if !ok {
+				metrics.StopWorker(worker.fileName, StopReasonShutdown)
+
+				if c := logger.Check(zapcore.DebugLevel, "terminated"); c != nil {
+					c.Write(zap.String("worker", worker.fileName))
+				}
+
 				return
 			}
 			// continue on since the channel is still open

--- a/worker.go
+++ b/worker.go
@@ -273,8 +273,10 @@ func go_frankenphp_worker_handle_request_start(threadIndex C.uintptr_t) C.bool {
 	if thread.worker == nil {
 		assignThreadToWorker(thread)
 	}
-	// inform metrics that the worker is ready
-	metrics.ReadyWorker(thread.worker.fileName)
+	thread.readiedOnce.Do(func() {
+		// inform metrics that the worker is ready
+		metrics.ReadyWorker(thread.worker.fileName)
+	})
 
 	if c := logger.Check(zapcore.DebugLevel, "waiting for request"); c != nil {
 		c.Write(zap.String("worker", thread.worker.fileName))

--- a/worker.go
+++ b/worker.go
@@ -355,14 +355,5 @@ func go_frankenphp_finish_request(threadIndex C.uintptr_t, isWorkerRequest bool)
 
 	if isWorkerRequest {
 		thread.Unpin()
-		workers[fc.scriptFilename].threadMutex.Lock()
-		defer workers[fc.scriptFilename].threadMutex.Unlock()
-		for i, t := range workers[fc.scriptFilename].threads {
-			if t == thread {
-				// remove thread from worker threads
-				workers[fc.scriptFilename].threads = append(workers[fc.scriptFilename].threads[:i], workers[fc.scriptFilename].threads[i+1:]...)
-				break
-			}
-		}
 	}
 }

--- a/worker.go
+++ b/worker.go
@@ -191,12 +191,7 @@ func (worker *worker) startNewWorkerThread() {
 		metrics.StopWorker(worker.fileName, StopReasonCrash)
 	}
 
-	metrics.StopWorker(worker.fileName, StopReasonShutdown)
-
-	// TODO: check if the termination is expected
-	if c := logger.Check(zapcore.DebugLevel, "terminated"); c != nil {
-		c.Write(zap.String("worker", worker.fileName))
-	}
+	// unreachable
 }
 
 func (worker *worker) handleRequest(r *http.Request) {


### PR DESCRIPTION
fixes #1163 

There are also some miscellaneous fixes in here as well.

1. I noticed that using the watcher introduced race conditions with the "ready waitgroup"
2. I removed atomics and tried to wrap my head around what was going on
3. I discovered #1172 
4. Instead of a WG, I used a channel to avoid race conditions and is also much simpler to reason about.
5. I found a potential memory leak when a worker restarts

cc: @AlliBalliBaba 