### PR TITLE
Fix: empty request headers.

### DIFF
--- a/caddy/caddy_test.go
+++ b/caddy/caddy_test.go
@@ -607,6 +607,7 @@ func TestAllDefinedServerVars(t *testing.T) {
 			"Content-Length: 14", // maliciously set to 14
 			"Special-Chars: <%00>",
 			"Host: Malicous Host",
+			"X-Empty-Header:",
 		},
 		bytes.NewBufferString("foo=bar"),
 		http.StatusOK,

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -711,7 +711,7 @@ void frankenphp_register_variable_safe(char *key, char *val, size_t val_len,
     return;
   }
   if (val == NULL) {
-	val = "";
+    val = "";
   }
   size_t new_val_len = val_len;
   if (!should_filter_var ||

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -707,8 +707,11 @@ void frankenphp_register_variables_from_request_info(
  * see: php_variables.c -> php_register_variable_ex (#1106) */
 void frankenphp_register_variable_safe(char *key, char *val, size_t val_len,
                                        zval *track_vars_array) {
-  if (val == NULL || key == NULL) {
+  if (key == NULL) {
     return;
+  }
+  if (val == NULL) {
+	val = "";
   }
   size_t new_val_len = val_len;
   if (!should_filter_var ||

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -952,13 +952,10 @@ func FuzzRequest(f *testing.F) {
 			assert.Contains(t, string(body), fmt.Sprintf("[PATH_INFO] => /%s", fuzzedString))
 			assert.Contains(t, string(body), fmt.Sprintf("[PATH_TRANSLATED] => %s", filepath.Join(absPath, fuzzedString)))
 
-			// The header should only be present if the fuzzed string is not empty
-			if len(fuzzedString) > 0 {
-				assert.Contains(t, string(body), fmt.Sprintf("[CONTENT_TYPE] => %s", fuzzedString))
-				assert.Contains(t, string(body), fmt.Sprintf("[HTTP_FUZZED] => %s", fuzzedString))
-			} else {
-				assert.NotContains(t, string(body), "[HTTP_FUZZED]")
-			}
+			// Headers should always be present even if empty
+			assert.Contains(t, string(body), fmt.Sprintf("[CONTENT_TYPE] => %s", fuzzedString))
+			assert.Contains(t, string(body), fmt.Sprintf("[HTTP_FUZZED] => %s", fuzzedString))
+
 		}, &testOptions{workerScript: "request-headers.php"})
 	})
 }

--- a/testdata/server-all-vars-ordered.php
+++ b/testdata/server-all-vars-ordered.php
@@ -33,6 +33,7 @@ foreach ([
              'REMOTE_USER',
              'REQUEST_METHOD',
              'REQUEST_URI',
+             'HTTP_X_EMPTY_HEADER',
          ] as $name) {
     echo "$name:" . $_SERVER[$name] . "\n";
 }

--- a/testdata/server-all-vars-ordered.txt
+++ b/testdata/server-all-vars-ordered.txt
@@ -30,4 +30,5 @@ QUERY_STRING:specialChars=%3E\x00%00</>
 REMOTE_USER:user
 REQUEST_METHOD:POST
 REQUEST_URI:/server-all-vars-ordered.php/path?specialChars=%3E\x00%00</>
+HTTP_X_EMPTY_HEADER:
 </pre>


### PR DESCRIPTION
This PR fixes empty request headers as mentioned in #1181. I originally though this was a by-product of #1106, but that PR just enforces the wrong behavior.

The problem comes from the fact that pinning an empty string makes the string NULL instead of empty (something to keep in mind).