### PR TITLE
fix: properly close context on worker script timeouts and crashes.

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -618,6 +618,13 @@ func go_handle_request(threadIndex C.uintptr_t) bool {
 			panic(ScriptExecutionError)
 		}
 
+		// if the script has errored or timed out, make sure any pending worker requests are closed
+		if fc.exitStatus > 0 && thread.workerRequest != nil {
+			fc := thread.workerRequest.Context().Value(contextKey).(*FrankenPHPContext)
+			maybeCloseContext(fc)
+			thread.workerRequest = nil
+		}
+
 		return true
 	}
 }


### PR DESCRIPTION
I noticed that PHP timeouts will fully stop the script's execution and not just continue to the next iteration in worker mode.

This PR fixes this issue in part by making sure the context gets closed if a worker request is still pending and the PHP script returned a non-zero status code.

To reproduce, just set `max_execution_time = 2` in the `php.ini` and execute a worker script with `sleep(3);`. Ideally, timeouts would not stop the script execution (if that's even possible).