### PR TITLE
ci: add reminder to delete sensitive environment variables

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -74,7 +74,7 @@ body:
     attributes:
       label: PHP configuration
       description: |
-        Please copy and paste the output of the `phpinfo()` function.
+        Please copy and paste the output of the `phpinfo()` function -- remember to remove **sensitive information** like passwords, API keys, etc.
       render: shell
     validations:
       required: true


### PR DESCRIPTION
phpinfo often contains environment variables. Depending on the environment it comes from, these variables may sometimes contain sensitive information (such as passwords, api keys, etc). This PR just adds a reminder to the issue template to delete these variables from the output before submitting.