### PR TITLE
Fix user creation example in Ubuntu-based docker images

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -149,7 +149,7 @@ Here is a sample `Dockerfile` doing this:
 ```dockerfile
 FROM dunglas/frankenphp
 
-ARG USER=www-data
+ARG USER=appuser
 
 RUN \
 	# Use "adduser -D ${USER}" for alpine based distros
@@ -173,7 +173,7 @@ the webserver as a non-root user, and without the need for any capability:
 ```dockerfile
 FROM dunglas/frankenphp
 
-ARG USER=www-data
+ARG USER=appuser
 
 RUN \
 	# Use "adduser -D ${USER}" for alpine based distros

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -153,7 +153,7 @@ ARG USER=www-data
 
 RUN \
 	# Use "adduser -D ${USER}" for alpine based distros
-	useradd -D ${USER}; \
+	useradd ${USER}; \
 	# Add additional capability to bind to port 80 and 443
 	setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/frankenphp; \
 	# Give write access to /data/caddy and /config/caddy
@@ -177,7 +177,7 @@ ARG USER=www-data
 
 RUN \
 	# Use "adduser -D ${USER}" for alpine based distros
-	useradd -D ${USER}; \
+	useradd ${USER}; \
 	# Remove default capability
 	setcap -r /usr/local/bin/frankenphp; \
 	# Give write access to /data/caddy and /config/caddy


### PR DESCRIPTION
The `adduser` command uses `-D` to mean "create with defaults". The `useradd` command uses `-D` to mean "show or edit the defaults".

The comment says "make this change in Alpine images", but the actual code line below it is wrong for the Debian-based images.

man pages:

- [`useradd`](https://manpages.debian.org/jessie/passwd/useradd.8.en.html)
- [`adduser`](https://manpages.debian.org/jessie/adduser/adduser.8.en.html)
