### PR TITLE
ci: update artifact actions to v4

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -209,7 +209,7 @@ jobs:
         if: fromJson(needs.prepare.outputs.push)
         uses: actions/upload-artifact@v4
         with:
-          name: metadata-runner-${{ github.run_id }}-${{ matrix.variant }}-${{ matrix.platform }}
+          name: metadata-runner-${{ matrix.variant }}-${{ matrix.platform }}
           path: /tmp/metadata/runner/*
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -200,7 +200,7 @@ jobs:
         if: fromJson(needs.prepare.outputs.push)
         uses: actions/upload-artifact@v4
         with:
-          name: metadata-builder-${{ github.run_id }}-${{ matrix.variant }}-${{ matrix.platform }}
+          name: metadata-builder-${{ matrix.variant }}-${{ matrix.platform }}
           path: /tmp/metadata/builder/*
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -198,18 +198,18 @@ jobs:
       -
         name: Upload builder metadata
         if: fromJson(needs.prepare.outputs.push)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: metadata-builder-${{ matrix.variant }}
+          name: metadata-builder-${{ github.run_id }}-${{ matrix.variant }}-${{ matrix.platform }}
           path: /tmp/metadata/builder/*
           if-no-files-found: error
           retention-days: 1
       -
         name: Upload runner metadata
         if: fromJson(needs.prepare.outputs.push)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: metadata-runner-${{ matrix.variant }}
+          name: metadata-runner-${{ github.run_id }}-${{ matrix.variant }}-${{ matrix.platform }}
           path: /tmp/metadata/runner/*
           if-no-files-found: error
           retention-days: 1
@@ -237,10 +237,11 @@ jobs:
     steps:
       -
         name: Download metadata
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: metadata-${{ matrix.target }}-${{ matrix.variant }}
+          pattern: metadata-${{ matrix.target }}-${{ github.run_id }}-${{ matrix.variant }}-*
           path: /tmp/metadata
+          merge-multiple: true
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -239,7 +239,7 @@ jobs:
         name: Download metadata
         uses: actions/download-artifact@v4
         with:
-          pattern: metadata-${{ matrix.target }}-${{ github.run_id }}-${{ matrix.variant }}-*
+          pattern: metadata-${{ matrix.target }}-${{ matrix.variant }}-*
           path: /tmp/metadata
           merge-multiple: true
       -


### PR DESCRIPTION
Closes #443 

The main changes, for v4 compatibility, include the following:

- Adaptation of the pattern in the download step to handle dynamic names.
- Considering breaking changes, notably the impossibility of downloading multiple times within the same artifact.