### PR TITLE
fix(static): remove libphp.a from the Docker image

### DIFF
--- a/static-builder.Dockerfile
+++ b/static-builder.Dockerfile
@@ -106,4 +106,5 @@ COPY --link caddy caddy
 COPY --link internal internal
 
 RUN --mount=type=secret,id=github-token GITHUB_TOKEN=$(cat /run/secrets/github-token) ./build-static.sh && \
-	rm -Rf dist/static-php-cli/source/*
+	rm -Rf dist/static-php-cli/source/* && \
+    rm dist/static-php-cli/buildroot/lib/libphp.a


### PR DESCRIPTION
Will fix issues with people compiling other extensions.