### PR TITLE
ci: bump super-linter from 6.8 to 7.2.1 and fix codebase

### DIFF
--- a/.github/actions/watcher/action.yaml
+++ b/.github/actions/watcher/action.yaml
@@ -3,22 +3,19 @@ description: Install e-dant/watcher
 runs:
   using: composite
   steps:
-    -
-      name: Determine e-dant/watcher version
+    - name: Determine e-dant/watcher version
       id: determine-watcher-version
       run: echo version="$(gh release view --repo e-dant/watcher --json tagName --template '{{ .tagName }}')" >> "${GITHUB_OUTPUT}"
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
-    -
-      name: Cache e-dant/watcher
+    - name: Cache e-dant/watcher
       id: cache-watcher
       uses: actions/cache@v4
       with:
         path: watcher/target
         key: watcher-${{ runner.os }}-${{ runner.arch }}-${{ steps.determine-watcher-version.outputs.version }}-${{ env.CC && env.CC || 'gcc' }}
-    -
-      if: steps.cache-watcher.outputs.cache-hit != 'true'
+    - if: steps.cache-watcher.outputs.cache-hit != 'true'
       name: Compile e-dant/watcher
       run: |
         mkdir watcher
@@ -30,8 +27,7 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
-    -
-      name: Update LD_LIBRARY_PATH
+    - name: Update LD_LIBRARY_PATH
       run: |
         sudo sh -c "echo ${PWD}/watcher/target/lib > /etc/ld.so.conf.d/watcher.conf"
         sudo ldconfig

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,15 +1,13 @@
 ---
 version: 2
 updates:
-  -
-    package-ecosystem: gomod
+  - package-ecosystem: gomod
     directory: /
     schedule:
       interval: weekly
     commit-message:
       prefix: chore
-  -
-    package-ecosystem: gomod
+  - package-ecosystem: gomod
     directory: /caddy
     schedule:
       interval: weekly
@@ -18,12 +16,9 @@ updates:
     # These packages must be in sync with versions
     # used by github.com/caddyserver/caddy/v2
     ignore:
-      -
-        dependency-name: github.com/google/cel-go
-      -
-        dependency-name: github.com/quic-go/*
-  -
-    package-ecosystem: github-actions
+      - dependency-name: github.com/google/cel-go
+      - dependency-name: github.com/quic-go/*
+  - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
   push:
     branches:
       - main
@@ -18,11 +18,11 @@ on:
     inputs:
       #checkov:skip=CKV_GHA_7
       version:
-        description: 'FrankenPHP version'
+        description: "FrankenPHP version"
         required: false
         type: string
   schedule:
-    - cron:  '0 4 * * *'
+    - cron: "0 4 * * *"
 permissions:
   contents: read
 env:
@@ -42,8 +42,7 @@ jobs:
       skip: ${{ steps.check.outputs.skip }}
       ref: ${{ steps.check.outputs.ref || (github.event_name == 'workflow_dispatch' && inputs.version) || '' }}
     steps:
-      -
-        name: Check PHP versions
+      - name: Check PHP versions
         id: check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -77,17 +76,14 @@ jobs:
             echo ref="$(gh release view --repo dunglas/frankenphp --json tagName --jq '.tagName')"
             echo skip=false
           } >> "${GITHUB_OUTPUT}"
-      -
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         if: ${{ !fromJson(steps.check.outputs.skip) }}
         with:
           ref: ${{ steps.check.outputs.ref }}
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         if: ${{ !fromJson(steps.check.outputs.skip) }}
         uses: docker/setup-buildx-action@v3
-      -
-        name: Create variants matrix
+      - name: Create variants matrix
         if: ${{ !fromJson(steps.check.outputs.skip) }}
         id: matrix
         shell: bash
@@ -114,55 +110,44 @@ jobs:
         variant: ${{ fromJson(needs.prepare.outputs.variants) }}
         platform: ${{ fromJson(needs.prepare.outputs.platforms) }}
         include:
-          -
-            race: ""
+          - race: ""
             qemu: true
-          -
-            platform: linux/amd64
+          - platform: linux/amd64
             qemu: false
             race: "-race" # The Go race detector is only supported on amd64
-          -
-            platform: linux/386
+          - platform: linux/386
             qemu: false
         exclude:
           # arm/v6 is only available for Alpine: https://github.com/docker-library/golang/issues/502
-          -
-            variant: php-${{ needs.prepare.outputs.php82_version }}-bookworm
+          - variant: php-${{ needs.prepare.outputs.php82_version }}-bookworm
             platform: linux/arm/v6
-          -
-            variant: php-${{ needs.prepare.outputs.php83_version }}-bookworm
+          - variant: php-${{ needs.prepare.outputs.php83_version }}-bookworm
             platform: linux/arm/v6
     steps:
-      -
-        name: Prepare
+      - name: Prepare
         id: prepare
         run: |
           platform=${{ matrix.platform }}
           echo "sanitized_platform=${platform//\//-}" >> "${GITHUB_OUTPUT}"
-      -
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.prepare.outputs.ref }}
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         if: matrix.qemu
         uses: docker/setup-qemu-action@v3
         with:
           platforms: ${{ matrix.platform }}
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
           platforms: ${{ matrix.platform }}
-      -
-        name: Login to DockerHub
+      - name: Login to DockerHub
         if: fromJson(needs.prepare.outputs.push)
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
-      -
-        name: Build
+      - name: Build
         id: build
         uses: docker/bake-action@v5
         with:
@@ -187,8 +172,7 @@ jobs:
           SHA: ${{ github.sha }}
           VERSION: ${{ (github.ref_type == 'tag' && github.ref_name) || needs.prepare.outputs.ref || 'dev' }}
           PHP_VERSION: ${{ needs.prepare.outputs.php_version }}
-      -
-        # Workaround for https://github.com/actions/runner/pull/2477#issuecomment-1501003600
+      - # Workaround for https://github.com/actions/runner/pull/2477#issuecomment-1501003600
         name: Export metadata
         if: fromJson(needs.prepare.outputs.push)
         run: |
@@ -201,8 +185,7 @@ jobs:
           touch "/tmp/metadata/runner/${runnerDigest#sha256:}"
         env:
           METADATA: ${{ steps.build.outputs.metadata }}
-      -
-        name: Upload builder metadata
+      - name: Upload builder metadata
         if: fromJson(needs.prepare.outputs.push)
         uses: actions/upload-artifact@v4
         with:
@@ -210,8 +193,7 @@ jobs:
           path: /tmp/metadata/builder/*
           if-no-files-found: error
           retention-days: 1
-      -
-        name: Upload runner metadata
+      - name: Upload runner metadata
         if: fromJson(needs.prepare.outputs.push)
         uses: actions/upload-artifact@v4
         with:
@@ -219,8 +201,7 @@ jobs:
           path: /tmp/metadata/runner/*
           if-no-files-found: error
           retention-days: 1
-      -
-        name: Run tests
+      - name: Run tests
         if: ${{ !matrix.qemu && !fromJson(needs.prepare.outputs.push) }}
         run: |
           docker run --platform=${{ matrix.platform }} --rm \
@@ -230,7 +211,7 @@ jobs:
           METADATA: ${{ steps.build.outputs.metadata }}
   # Adapted from https://docs.docker.com/build/ci/github-actions/multi-platform/
   push:
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
     needs:
       - prepare
       - build
@@ -239,26 +220,22 @@ jobs:
       fail-fast: false
       matrix:
         variant: ${{ fromJson(needs.prepare.outputs.variants) }}
-        target: ['builder', 'runner']
+        target: ["builder", "runner"]
     steps:
-      -
-        name: Download metadata
+      - name: Download metadata
         uses: actions/download-artifact@v4
         with:
           pattern: metadata-${{ matrix.target }}-${{ matrix.variant }}-*
           path: /tmp/metadata
           merge-multiple: true
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Login to DockerHub
+      - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
-      -
-        name: Create manifest list and push
+      - name: Create manifest list and push
         working-directory: /tmp/metadata
         run: |
           set -x
@@ -267,10 +244,9 @@ jobs:
             $(printf "${IMAGE_NAME}@sha256:%s " *)
         env:
           METADATA: ${{ needs.prepare.outputs.metadata }}
-      -
-        name: Inspect image
+      - name: Inspect image
         run: |
           # shellcheck disable=SC2046,SC2086
-          docker buildx imagetools inspect $(jq -cr '.target."${{ matrix.target }}-${{ matrix.variant }}".tags | first' <<< ${METADATA}) 
+          docker buildx imagetools inspect $(jq -cr '.target."${{ matrix.target }}-${{ matrix.variant }}".tags | first' <<< ${METADATA})
         env:
           METADATA: ${{ needs.prepare.outputs.metadata }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,20 +10,18 @@ on:
 permissions:
   contents: read
   packages: read
-  statuses: write  
+  statuses: write
 jobs:
   build:
     name: Lint Code Base
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout Code
+      - name: Checkout Code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      -
-        name: Lint Code Base
-        uses: super-linter/super-linter/slim@v6.8.0
+      - name: Lint Code Base
+        uses: super-linter/super-linter/slim@v7.2.1
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
@@ -38,6 +36,9 @@ jobs:
           VALIDATE_PHP_PHPSTAN: false
           VALIDATE_PHP_PSALM: false
           VALIDATE_TERRAGRUNT: false
+          VALIDATE_DOCKERFILE_HADOLINT: false
           # Prettier and StandardJS are incompatible
           VALIDATE_JAVASCRIPT_PRETTIER: false
           VALIDATE_TYPESCRIPT_PRETTIER: false
+          # Conflicts with MARKDOWN
+          VALIDATE_MARKDOWN_PRETTIER: false

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -5,12 +5,12 @@ on:
     branches:
       - main
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
   push:
     branches:
       - main
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
 permissions:
   contents: read
 jobs:
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sanitizer: ['asan', 'msan']
+        sanitizer: ["asan", "msan"]
     env:
       CFLAGS: -g -O0 -fsanitize=${{ matrix.sanitizer == 'asan' && 'address' || 'memory' }} -DZEND_TRACK_ARENA_ALLOC
       LDFLAGS: -fsanitize=${{ matrix.sanitizer == 'asan' && 'address' || 'memory' }}
@@ -31,34 +31,28 @@ jobs:
       LIBRARY_PATH: ${{ github.workspace }}/php/target/lib:${{ github.workspace }}/watcher/target/lib
       LD_LIBRARY_PATH: ${{ github.workspace }}/php/target/lib
     steps:
-      -
-        name: Remove local PHP
+      - name: Remove local PHP
         run: sudo apt-get remove --purge --autoremove 'php*' 'libmemcached*'
-      -
-        uses: actions/checkout@v4
-      -
-        uses: actions/setup-go@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: "1.22"
           cache-dependency-path: |
             go.sum 
             caddy/go.sum
-      -
-        name: Determine PHP version
+      - name: Determine PHP version
         id: determine-php-version
         run: |
           curl -fsSL 'https://www.php.net/releases/index.php?json&max=1&version=8.4' -o version.json
           echo version="$(jq -r 'keys[0]' version.json)" >> "$GITHUB_OUTPUT"
           echo archive="$(jq -r '.[] .source[] | select(.filename |endswith(".xz")) | "https://www.php.net/distributions/" + .filename' version.json)" >> "$GITHUB_OUTPUT"
-      -
-        name: Cache PHP
+      - name: Cache PHP
         id: cache-php
         uses: actions/cache@v4
         with:
           path: php/target
           key: php-sanitizers-${{ matrix.sanitizer }}-${{ runner.arch }}-${{ steps.determine-php-version.outputs.version }}
-      -
-        if: steps.cache-php.outputs.cache-hit != 'true'
+      - if: steps.cache-php.outputs.cache-hit != 'true'
         name: Compile PHP
         run: |
           mkdir php/
@@ -92,22 +86,17 @@ jobs:
             --prefix="$(pwd)/target/"
           make -j"$(getconf _NPROCESSORS_ONLN)"
           make install
-      -
-        name: Add PHP to the PATH
+      - name: Add PHP to the PATH
         run: echo "$(pwd)/php/target/bin" >> "$GITHUB_PATH"
-      -
-        name: Install e-dant/watcher
+      - name: Install e-dant/watcher
         uses: ./.github/actions/watcher
-      -
-        name: Set Set CGO flags
+      - name: Set Set CGO flags
         run: |
           {
             echo "CGO_CFLAGS=$CFLAGS -I${PWD}/watcher/target/include $(php-config --includes)"
             echo "CGO_LDFLAGS=$LDFLAGS $(php-config --ldflags) $(php-config --libs)"
           } >> "$GITHUB_ENV"
-      -
-        name: Compile tests
+      - name: Compile tests
         run: go test  ${{ matrix.sanitizer == 'msan' && '-tags=nowatcher' || '' }} -${{ matrix.sanitizer }} -v -x -c
-      -
-        name: Run tests
+      - name: Run tests
         run: ./frankenphp.test -test.v

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
   push:
     branches:
       - main
@@ -18,17 +18,17 @@ on:
     inputs:
       #checkov:skip=CKV_GHA_7
       version:
-        description: 'FrankenPHP version'
+        description: "FrankenPHP version"
         required: false
         type: string
   schedule:
-    - cron:  '0 0 * * *'
+    - cron: "0 0 * * *"
 permissions:
   contents: write
   id-token: write
   attestations: write
 env:
-  IMAGE_NAME: ${{ (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.version) || startsWith(github.ref, 'refs/tags/')) && 'dunglas/frankenphp' || 'dunglas/frankenphp-dev' }}    
+  IMAGE_NAME: ${{ (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.version) || startsWith(github.ref, 'refs/tags/')) && 'dunglas/frankenphp' || 'dunglas/frankenphp-dev' }}
 jobs:
   prepare:
     runs-on: ubuntu-latest
@@ -38,8 +38,7 @@ jobs:
       metadata: ${{ steps.matrix.outputs.metadata }}
       ref: ${{ steps.check.outputs.ref }}
     steps:
-      -
-        name: Get version
+      - name: Get version
         id: check
         if: github.event_name == 'schedule'
         run: |
@@ -51,15 +50,12 @@ jobs:
           echo "ref=${ref}" >> "${GITHUB_OUTPUT}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      -
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           ref: ${{ steps.check.outputs.ref }}
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Create platforms matrix
+      - name: Create platforms matrix
         id: matrix
         run: |
           METADATA="$(docker buildx bake --print static-builder | jq -c)"
@@ -78,52 +74,43 @@ jobs:
         debug: [false]
         mimalloc: [false]
         include:
-          -
-            qemu: true
-          -
-            platform: linux/amd64
+          - qemu: true
+          - platform: linux/amd64
             qemu: false
-          -
-            platform: linux/amd64
+          - platform: linux/amd64
             qemu: false
             debug: true
-          -
-            platform: linux/amd64
+          - platform: linux/amd64
             qemu: false
             mimalloc: true
     name: Build ${{ matrix.platform }} static binary${{ matrix.debug && ' (debug)' || '' }}${{ matrix.mimalloc && ' (mimalloc)' || '' }}
     runs-on: ubuntu-latest
-    needs: [ prepare ]
+    needs: [prepare]
     steps:
       - name: Prepare
         id: prepare
         run: |
           platform=${{ matrix.platform }}
           echo "sanitized_platform=${platform//\//-}" >> "${GITHUB_OUTPUT}"
-      -
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.prepare.outputs.ref }}
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         if: matrix.qemu
         uses: docker/setup-qemu-action@v3
         with:
           platforms: ${{ matrix.platform }}
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
           platforms: ${{ matrix.platform }}
-      -
-        name: Login to DockerHub
+      - name: Login to DockerHub
         if: ${{ fromJson(needs.prepare.outputs.push) && !matrix.debug && !matrix.mimalloc }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}    
-      -
-        name: Build
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Build
         id: build
         uses: docker/bake-action@v5
         with:
@@ -144,8 +131,7 @@ jobs:
           SHA: ${{ github.sha }}
           VERSION: ${{ (github.ref_type == 'tag' && github.ref_name) || needs.prepare.outputs.ref || 'dev' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      -
-        # Workaround for https://github.com/actions/runner/pull/2477#issuecomment-1501003600
+      - # Workaround for https://github.com/actions/runner/pull/2477#issuecomment-1501003600
         name: Export metadata
         if: fromJson(needs.prepare.outputs.push) && !matrix.debug && !matrix.mimalloc
         run: |
@@ -156,8 +142,7 @@ jobs:
           touch "/tmp/metadata/${digest#sha256:}"
         env:
           METADATA: ${{ steps.build.outputs.metadata }}
-      -
-        name: Upload metadata
+      - name: Upload metadata
         if: fromJson(needs.prepare.outputs.push) && !matrix.debug && !matrix.mimalloc
         uses: actions/upload-artifact@v4
         with:
@@ -165,8 +150,7 @@ jobs:
           path: /tmp/metadata/*
           if-no-files-found: error
           retention-days: 1
-      -
-        name: Copy binary
+      - name: Copy binary
         if: ${{ !fromJson(needs.prepare.outputs.push) || matrix.debug || matrix.mimalloc }}
         run: |
           digest=$(jq -r '."static-builder"."containerimage.config.digest"' <<< "${METADATA}")
@@ -175,21 +159,18 @@ jobs:
         env:
           METADATA: ${{ steps.build.outputs.metadata }}
           BINARY: frankenphp-linux-${{ matrix.platform == 'linux/amd64' && 'x86_64' || 'aarch64' }}
-      -
-        name: Upload artifact
+      - name: Upload artifact
         if: ${{ !fromJson(needs.prepare.outputs.push) }}
         uses: actions/upload-artifact@v4
         with:
           name: frankenphp-linux-${{ matrix.platform == 'linux/amd64' && 'x86_64' || 'aarch64' }}${{ matrix.debug && '-debug' || '' }}${{ matrix.mimalloc && '-mimalloc' || '' }}
           path: frankenphp-linux-${{ matrix.platform == 'linux/amd64' && 'x86_64' || 'aarch64' }}${{ matrix.debug && '-debug' || '' }}${{ matrix.mimalloc && '-mimalloc' || '' }}
-      -
-        name: Upload special assets
+      - name: Upload special assets
         if: fromJson(needs.prepare.outputs.push) && (matrix.debug || matrix.mimalloc) && (needs.prepare.outputs.ref || github.ref_type == 'tag')
         run: gh release upload "${{ (github.ref_type == 'tag' && github.ref_name) || needs.prepare.outputs.ref }}" frankenphp-linux-x86_64${{ matrix.debug && '-debug' || '' }}${{ matrix.mimalloc && '-mimalloc' || '' }} --repo dunglas/frankenphp --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      -
-        if: fromJson(needs.prepare.outputs.push) && (matrix.debug || matrix.mimalloc) && (needs.prepare.outputs.ref || github.ref_type == 'tag')
+      - if: fromJson(needs.prepare.outputs.push) && (matrix.debug || matrix.mimalloc) && (needs.prepare.outputs.ref || github.ref_type == 'tag')
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: ${{ github.workspace }}/frankenphp-linux-x86_64${{ matrix.debug && '-debug' || '' }}${{ matrix.mimalloc && '-mimalloc' || '' }}
@@ -202,24 +183,20 @@ jobs:
       - build-linux
     if: fromJson(needs.prepare.outputs.push)
     steps:
-      -
-        name: Download metadata
+      - name: Download metadata
         uses: actions/download-artifact@v4
         with:
           pattern: metadata-static-builder-*
           path: /tmp/metadata
           merge-multiple: true
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Login to DockerHub
+      - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
-      -
-        name: Create manifest list and push
+      - name: Create manifest list and push
         working-directory: /tmp/metadata
         run: |
           # shellcheck disable=SC2046,SC2086
@@ -227,29 +204,25 @@ jobs:
             $(printf "${IMAGE_NAME}@sha256:%s " *)
         env:
           METADATA: ${{ needs.prepare.outputs.metadata }}
-      -
-        name: Inspect image
+      - name: Inspect image
         run: |
           # shellcheck disable=SC2046,SC2086
           docker buildx imagetools inspect "$(jq -cr '.target."static-builder".tags | first' <<< "${METADATA}")"
         env:
-          METADATA: ${{ needs.prepare.outputs.metadata }}  
-      -
-        name: Copy binary
+          METADATA: ${{ needs.prepare.outputs.metadata }}
+      - name: Copy binary
         run: |
           tag=$(jq -cr '.target."static-builder".tags | first' <<< "${METADATA}")
           docker cp "$(docker create --platform=linux/amd64 --name static-builder "${tag}"):/go/src/app/dist/frankenphp-linux-x86_64" frankenphp-linux-x86_64 ; docker rm static-builder
           docker cp "$(docker create --platform=linux/arm64 --name static-builder "${tag}"):/go/src/app/dist/frankenphp-linux-aarch64" frankenphp-linux-aarch64 ; docker rm static-builder
         env:
           METADATA: ${{ needs.prepare.outputs.metadata }}
-      -
-        name: Upload asset
+      - name: Upload asset
         if: needs.prepare.outputs.ref || github.ref_type == 'tag'
         run: gh release upload "${{ (github.ref_type == 'tag' && github.ref_name) || needs.prepare.outputs.ref }}" frankenphp-linux-x86_64 frankenphp-linux-aarch64 --repo dunglas/frankenphp --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      -
-        if: needs.prepare.outputs.ref || github.ref_type == 'tag'
+      - if: needs.prepare.outputs.ref || github.ref_type == 'tag'
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: ${{ github.workspace }}/frankenphp-linux-*
@@ -258,26 +231,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ['arm64', 'x86_64']
+        platform: ["arm64", "x86_64"]
     name: Build macOS ${{ matrix.platform }} binaries
     runs-on: ${{ matrix.platform == 'arm64' && 'macos-14' || 'macos-13' }}
-    needs: [ prepare ]
+    needs: [prepare]
     env:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
-      -
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.prepare.outputs.ref }}
-      -
-        uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: "1.22"
           cache-dependency-path: |
             go.sum 
             caddy/go.sum
-      -
-        name: Set FRANKENPHP_VERSION
+      - name: Set FRANKENPHP_VERSION
         run: |
           if [ "${GITHUB_REF_TYPE}" == "tag" ]; then
             export FRANKENPHP_VERSION=${GITHUB_REF_NAME:1}
@@ -288,20 +258,17 @@ jobs:
           fi
 
           echo "FRANKENPHP_VERSION=${FRANKENPHP_VERSION}" >> "${GITHUB_ENV}"
-      -
-        name: Build FrankenPHP
+      - name: Build FrankenPHP
         run: ./build-static.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE: ${{ (needs.prepare.outputs.ref || github.ref_type == 'tag') && '1' || '' }}
           NO_COMPRESS: ${{ github.event_name == 'pull_request' && '1' || '' }}
-      -
-        if: needs.prepare.outputs.ref || github.ref_type == 'tag'
+      - if: needs.prepare.outputs.ref || github.ref_type == 'tag'
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: ${{ github.workspace }}/dist/frankenphp-mac-*
-      -
-        name: Upload artifact
+      - name: Upload artifact
         if: github.ref_type == 'branch'
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,12 +5,12 @@ on:
     branches:
       - main
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
   push:
     branches:
       - main
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
 permissions:
   contents: read
 jobs:
@@ -19,23 +19,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3', '8.4']
+        php-versions: ["8.2", "8.3", "8.4"]
     env:
       GOEXPERIMENT: cgocheck2
       GOMAXPROCS: 10
       LIBRARY_PATH: ${{ github.workspace }}/watcher/target/lib
     steps:
-      -
-        uses: actions/checkout@v4
-      -
-        uses: actions/setup-go@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: "1.22"
           cache-dependency-path: |
             go.sum 
             caddy/go.sum
-      -
-        uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
           ini-file: development
@@ -44,43 +41,32 @@ jobs:
         env:
           phpts: ts
           debug: true
-      -
-        name: Install e-dant/watcher
+      - name: Install e-dant/watcher
         uses: ./.github/actions/watcher
-      -
-        name: Set Set CGO flags
+      - name: Set Set CGO flags
         run: echo "CGO_CFLAGS=-I${PWD}/watcher/target/include $(php-config --includes)" >> "${GITHUB_ENV}"
-      -
-        name: Build
-        run: go build          
-      -
-        name: Build testcli binary
+      - name: Build
+        run: go build
+      - name: Build testcli binary
         working-directory: internal/testcli/
         run: go build
-      -
-        name: Run library tests
+      - name: Run library tests
         run: go test -race -v ./...
-      -
-        name: Run Caddy module tests
+      - name: Run Caddy module tests
         working-directory: caddy/
         run: go test -tags nobadger,nomysql,nopgx -race -v ./...
-      -
-        name: Run Fuzzing Tests
+      - name: Run Fuzzing Tests
         working-directory: caddy/
         run: go test -fuzz FuzzRequest -fuzztime 20s
-      -
-        name: Build the server
+      - name: Build the server
         working-directory: caddy/frankenphp/
         run: go build
-      -
-        name: Start the server
+      - name: Start the server
         working-directory: testdata/
         run: sudo ../caddy/frankenphp/frankenphp start
-      -
-        name: Run integrations tests
+      - name: Run integrations tests
         run: ./reload_test.sh
-      -
-        name: Lint Go code
+      - name: Lint Go code
         uses: golangci/golangci-lint-action@v6
         if: matrix.php-versions == '8.4'
         with:


### PR DESCRIPTION
Solves #1249.

**Important**
- Most of the changes are related to the termination of the `YAML_PRETTIER` step (example [here](https://github.com/dunglas/frankenphp/actions/runs/12352069658/job/34468307603)).
- `VALIDATE_MARKDOWN_PRETTIER` has been deactivated for the same reasons as we encountered in [api-platform/docs](https://github.com/api-platform/docs/pull/2035#issuecomment-2403326603).
- `GITHUB_ACTIONS` step reports deprecations in artifacts actions that will be solved in #1255.
