### PR TITLE
ci: fix failed to call GitHub Status API

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,14 +7,15 @@ on:
   push:
     branches:
       - main
-permissions:
-  contents: read
-  packages: read
-  statuses: write  
+permissions: {}
 jobs:
   build:
     name: Lint Code Base
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      statuses: write
     steps:
       -
         name: Checkout Code


### PR DESCRIPTION
To fix theses `Failed to call GitHub Status API: curl: (22) The requested URL returned error: 403`

![image](https://github.com/user-attachments/assets/801237ba-f5ac-4969-90da-87e49b664491)
