### PR TITLE
fix: SIGSEGV when an env var is empty

### DIFF
--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -649,6 +649,8 @@ func TestEnvWorker(t *testing.T) {
 	testEnv(t, &testOptions{workerScript: "test-env.php"})
 }
 func testEnv(t *testing.T, opts *testOptions) {
+	assert.NoError(t, os.Setenv("EMPTY", ""))
+
 	runTest(t, func(handler func(http.ResponseWriter, *http.Request), _ *httptest.Server, i int) {
 		req := httptest.NewRequest("GET", fmt.Sprintf("http://example.com/test-env.php?var=%d", i), nil)
 		w := httptest.NewRecorder()

--- a/phpthread.go
+++ b/phpthread.go
@@ -73,6 +73,10 @@ func (thread *phpThread) getActiveRequest() *http.Request {
 // Pin a string that is not null-terminated
 // PHP's zend_string may contain null-bytes
 func (thread *phpThread) pinString(s string) *C.char {
+	if s == "" {
+		return nil
+	}
+
 	sData := unsafe.StringData(s)
 	thread.Pin(sData)
 	return (*C.char)(unsafe.Pointer(sData))

--- a/phpthread.go
+++ b/phpthread.go
@@ -41,7 +41,7 @@ func newPHPThread(threadIndex int) *phpThread {
 }
 
 // change the thread handler safely
-// must be called from outside of the PHP thread
+// must be called from outside the PHP thread
 func (thread *phpThread) setHandler(handler threadHandler) {
 	logger.Debug("setHandler")
 	thread.handlerMu.Lock()
@@ -79,6 +79,7 @@ func (thread *phpThread) pinString(s string) *C.char {
 
 	sData := unsafe.StringData(s)
 	thread.Pin(sData)
+
 	return (*C.char)(unsafe.Pointer(sData))
 }
 

--- a/testdata/test-env.php
+++ b/testdata/test-env.php
@@ -47,4 +47,6 @@ return function() {
     } else {
         echo "Failed to unset NON_EXISTING_VAR.\n";
     }
+
+    getenv();
 };


### PR DESCRIPTION
Should fix https://github.com/dunglas/frankenphp/issues/1269.

The behavior of `unsafe.StringData()` is undefined when the string is empty.