### PR TITLE
docs: explicitly explain how to use without worker mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ frankenphp php-cli /path/to/your/script.php
 
 ## Docs
 
-* [The worker mode](https://frankenphp.dev/docs/worker/)
+* [Classic mode](https://frankenphp.dev/docs/classic/)
+* [Worker mode](https://frankenphp.dev/docs/worker/)
 * [Early Hints support (103 HTTP status code)](https://frankenphp.dev/docs/early-hints/)
 * [Real-time](https://frankenphp.dev/docs/mercure/)
 * [Configuration](https://frankenphp.dev/docs/config/)

--- a/docs/classic.md
+++ b/docs/classic.md
@@ -1,0 +1,7 @@
+# Using Classic Mode
+
+Without any additional configuration, FrankenPHP operates in classic mode. In this mode, FrankenPHP functions like a traditional PHP server, directly serving PHP files. This makes it a seamless drop-in replacement for PHP-FPM or Apache with mod_php.
+
+Similar to Caddy, FrankenPHP accepts an unlimited number of connections and uses a [fixed number of threads](config.md#caddyfile-config) to serve them. The number of accepted and queued connections is limited only by the available system resources. The PHP thread pool operates with a fixed number of threads initialized at startup, comparable to the static mode of PHP-FPM.
+
+Queued connections will wait indefinitely until a PHP thread is available to serve them. To prevent that, set a reasonable [write timeout in Caddy](https://caddyserver.com/docs/caddyfile/options#timeouts).

--- a/docs/classic.md
+++ b/docs/classic.md
@@ -5,3 +5,5 @@ Without any additional configuration, FrankenPHP operates in classic mode. In th
 Similar to Caddy, FrankenPHP accepts an unlimited number of connections and uses a [fixed number of threads](config.md#caddyfile-config) to serve them. The number of accepted and queued connections is limited only by the available system resources. The PHP thread pool operates with a fixed number of threads initialized at startup, comparable to the static mode of PHP-FPM.
 
 Queued connections will wait indefinitely until a PHP thread is available to serve them. To prevent that, set a reasonable [write timeout in Caddy](https://caddyserver.com/docs/caddyfile/options#timeouts).
+
+Each Caddy instance will only spin up one FrankenPHP thread pool, which will be shared across all `php_server` blocks.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -8,7 +8,7 @@ However, it is possible to substantially improve performance using an appropriat
 By default, FrankenPHP starts 2 times more threads and workers (in worker mode) than the available numbers of CPU.
 
 The appropriate values depend heavily on how your application is written, what it does and your hardware.
-We strongly recommend changing these values.
+We strongly recommend changing these values. For best system stability, it is recommended to have `num_threads` x `memory_limit` < `available_memory`.
 
 To find the right values, it's best to run load tests simulating real traffic.
 [k6](https://k6.io) and [Gatling](https://gatling.io) are good tools for this.


### PR DESCRIPTION
This is a proposal to improve documentation on how FrankenPHP operates without using worker mode, clarifying the internals based on my take-aways from the discussion https://github.com/dunglas/frankenphp/discussions/1241.

Feel free to provide feedback or correct me if I'm wrong.

I don't know how you handle translations for documentation changes, thus I only changed the English version.

Furthermore, especially after reading my own documentation, I believe there should be a configurable connection limit to avoid overloading the queue with too many requests, as well as a wait timeout, after which the request should return a 503 status code. Whether this should be implemented in Caddy or FrankenPHP is up for discussion which should take place in a new issue.