### PR TITLE
fix: SIGSEGV with env vars

### DIFF
--- a/phpmainthread.go
+++ b/phpmainthread.go
@@ -30,14 +30,14 @@ func initPHPThreads(numThreads int) error {
 	}
 	phpThreads = make([]*phpThread, numThreads)
 
-	if err := mainThread.start(); err != nil {
-		return err
-	}
-
 	// initialize all threads as inactive
 	for i := 0; i < numThreads; i++ {
 		phpThreads[i] = newPHPThread(i)
 		convertToInactiveThread(phpThreads[i])
+	}
+
+	if err := mainThread.start(); err != nil {
+		return err
 	}
 
 	// start the underlying C threads

--- a/phpmainthread.go
+++ b/phpmainthread.go
@@ -31,6 +31,8 @@ func initPHPThreads(numThreads int) error {
 	phpThreads = make([]*phpThread, numThreads)
 
 	// initialize all threads as inactive
+	// this needs to happen before starting the main thread
+	// since some extensions access environment variables on startup
 	for i := 0; i < numThreads; i++ {
 		phpThreads[i] = newPHPThread(i)
 		convertToInactiveThread(phpThreads[i])

--- a/phpthread.go
+++ b/phpthread.go
@@ -73,11 +73,10 @@ func (thread *phpThread) getActiveRequest() *http.Request {
 // Pin a string that is not null-terminated
 // PHP's zend_string may contain null-bytes
 func (thread *phpThread) pinString(s string) *C.char {
-	if s == "" {
+	sData := unsafe.StringData(s)
+	if sData == nil {
 		return nil
 	}
-
-	sData := unsafe.StringData(s)
 	thread.Pin(sData)
 
 	return (*C.char)(unsafe.Pointer(sData))


### PR DESCRIPTION
This is another attempt at fixing #1269
I still couldn't reproduce the issue, but here is my best guess:

Some PHP extensions probably access environment variables when starting the main thread. In a past PR, we changed it so all environment is accessed via go 
https://github.com/dunglas/frankenphp/blob/0fc6ccc5ceaee0855f2a5c24e7b064d25d589d3f/frankenphp.c#L777

So we need to make sure the `phpThreads` slice is initialized before starting the main thread, so it can pin to the first phpThread (threadIndex on the main thread defaults to 0)