### PR TITLE
docs: add alternative solution for TLS/SSL issues using symbolic link

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -141,3 +141,13 @@ It's also possible to use the `SSL_CERT_FILE` and `SSL_CERT_DIR` to hint OpenSSL
 export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 export SSL_CERT_DIR=/etc/ssl/certs
 ```
+
+### Alternative Solution
+
+You can also resolve this issue by creating a shortcut from the `/etc/ssl` folder to the root directory using the following command:
+
+```bash
+sudo ln -s /etc/ssl /
+```
+
+This approach simplifies the configuration by allowing OpenSSL to locate the necessary certificates without additional setup.


### PR DESCRIPTION
This pull request updates the documentation to include an alternative solution for resolving TLS/SSL issues with static binaries. The added method involves creating a symbolic link from `/etc/ssl` to the root directory, which simplifies the process of pointing OpenSSL to the required certificates.

I have successfully tested this approach and found it to be the easiest and most straightforward method compared to the other solutions described in the documentation.
