### PR TITLE
Fix invalid example for CADDY_GLOBAL_OPTIONS

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -202,7 +202,9 @@ This is an opt-in configuration that needs to be added to the global options in 
 > This can also be configured using the `CADDY_GLOBAL_OPTIONS` environment config:
 
 ```sh
-CADDY_GLOBAL_OPTIONS="servers { enable_full_duplex }"
+CADDY_GLOBAL_OPTIONS="servers {
+  enable_full_duplex
+}"
 ```
 
 You can find more information about this setting in the [Caddy documentation](https://caddyserver.com/docs/caddyfile/options#enable-full-duplex).


### PR DESCRIPTION
Fix example that doesn't work with the currently used Caddy version. New lines must be used.

This fixes #1088 