### PR TITLE
perf - removes pinning

### DIFF
--- a/cgi.go
+++ b/cgi.go
@@ -63,56 +63,56 @@ func addKnownVariablesToServer(thread *phpThread, request *http.Request, fc *Fra
 
 	ra, raOK := fc.env["REMOTE_ADDR\x00"]
 	if raOK {
-		registerTrustedVar(keys["REMOTE_ADDR\x00"], ra, trackVarsArray, thread)
+		registerTrustedVar(keys["REMOTE_ADDR\x00"], ra, trackVarsArray)
 	} else {
-		registerTrustedVar(keys["REMOTE_ADDR\x00"], ip, trackVarsArray, thread)
+		registerTrustedVar(keys["REMOTE_ADDR\x00"], ip, trackVarsArray)
 	}
 
 	if rh, ok := fc.env["REMOTE_HOST\x00"]; ok {
-		registerTrustedVar(keys["REMOTE_HOST\x00"], rh, trackVarsArray, thread) // For speed, remote host lookups disabled
+		registerTrustedVar(keys["REMOTE_HOST\x00"], rh, trackVarsArray) // For speed, remote host lookups disabled
 	} else {
 		if raOK {
-			registerTrustedVar(keys["REMOTE_HOST\x00"], ra, trackVarsArray, thread)
+			registerTrustedVar(keys["REMOTE_HOST\x00"], ra, trackVarsArray)
 		} else {
-			registerTrustedVar(keys["REMOTE_HOST\x00"], ip, trackVarsArray, thread)
+			registerTrustedVar(keys["REMOTE_HOST\x00"], ip, trackVarsArray)
 		}
 	}
 
-	registerTrustedVar(keys["REMOTE_PORT\x00"], port, trackVarsArray, thread)
-	registerTrustedVar(keys["DOCUMENT_ROOT\x00"], fc.documentRoot, trackVarsArray, thread)
-	registerTrustedVar(keys["PATH_INFO\x00"], fc.pathInfo, trackVarsArray, thread)
-	registerTrustedVar(keys["PHP_SELF\x00"], request.URL.Path, trackVarsArray, thread)
-	registerTrustedVar(keys["DOCUMENT_URI\x00"], fc.docURI, trackVarsArray, thread)
-	registerTrustedVar(keys["SCRIPT_FILENAME\x00"], fc.scriptFilename, trackVarsArray, thread)
-	registerTrustedVar(keys["SCRIPT_NAME\x00"], fc.scriptName, trackVarsArray, thread)
+	registerTrustedVar(keys["REMOTE_PORT\x00"], port, trackVarsArray)
+	registerTrustedVar(keys["DOCUMENT_ROOT\x00"], fc.documentRoot, trackVarsArray)
+	registerTrustedVar(keys["PATH_INFO\x00"], fc.pathInfo, trackVarsArray)
+	registerTrustedVar(keys["PHP_SELF\x00"], request.URL.Path, trackVarsArray)
+	registerTrustedVar(keys["DOCUMENT_URI\x00"], fc.docURI, trackVarsArray)
+	registerTrustedVar(keys["SCRIPT_FILENAME\x00"], fc.scriptFilename, trackVarsArray)
+	registerTrustedVar(keys["SCRIPT_NAME\x00"], fc.scriptName, trackVarsArray)
 
 	var rs string
 	if request.TLS == nil {
 		rs = "http"
-		registerTrustedVar(keys["HTTPS\x00"], "", trackVarsArray, thread)
-		registerTrustedVar(keys["SSL_PROTOCOL\x00"], "", trackVarsArray, thread)
+		registerTrustedVar(keys["HTTPS\x00"], "", trackVarsArray)
+		registerTrustedVar(keys["SSL_PROTOCOL\x00"], "", trackVarsArray)
 	} else {
 		rs = "https"
 		if h, ok := fc.env["HTTPS\x00"]; ok {
-			registerTrustedVar(keys["HTTPS\x00"], h, trackVarsArray, thread)
+			registerTrustedVar(keys["HTTPS\x00"], h, trackVarsArray)
 		} else {
-			registerTrustedVar(keys["HTTPS\x00"], "on", trackVarsArray, thread)
+			registerTrustedVar(keys["HTTPS\x00"], "on", trackVarsArray)
 		}
 
 		// and pass the protocol details in a manner compatible with apache's mod_ssl
 		// (which is why these have an SSL_ prefix and not TLS_).
 		if pr, ok := fc.env["SSL_PROTOCOL\x00"]; ok {
-			registerTrustedVar(keys["SSL_PROTOCOL\x00"], pr, trackVarsArray, thread)
+			registerTrustedVar(keys["SSL_PROTOCOL\x00"], pr, trackVarsArray)
 		} else {
 			if v, ok := tlsProtocolStrings[request.TLS.Version]; ok {
-				registerTrustedVar(keys["SSL_PROTOCOL\x00"], v, trackVarsArray, thread)
+				registerTrustedVar(keys["SSL_PROTOCOL\x00"], v, trackVarsArray)
 			} else {
-				registerTrustedVar(keys["SSL_PROTOCOL\x00"], "", trackVarsArray, thread)
+				registerTrustedVar(keys["SSL_PROTOCOL\x00"], "", trackVarsArray)
 			}
 		}
 	}
 
-	registerTrustedVar(keys["REQUEST_SCHEME\x00"], rs, trackVarsArray, thread)
+	registerTrustedVar(keys["REQUEST_SCHEME\x00"], rs, trackVarsArray)
 	reqHost, reqPort, _ := net.SplitHostPort(request.Host)
 
 	if reqHost == "" {
@@ -133,11 +133,11 @@ func addKnownVariablesToServer(thread *phpThread, request *http.Request, fc *Fra
 		}
 	}
 
-	registerTrustedVar(keys["SERVER_NAME\x00"], reqHost, trackVarsArray, thread)
+	registerTrustedVar(keys["SERVER_NAME\x00"], reqHost, trackVarsArray)
 	if reqPort != "" {
-		registerTrustedVar(keys["SERVER_PORT\x00"], reqPort, trackVarsArray, thread)
+		registerTrustedVar(keys["SERVER_PORT\x00"], reqPort, trackVarsArray)
 	} else {
-		registerTrustedVar(keys["SERVER_PORT\x00"], "", trackVarsArray, thread)
+		registerTrustedVar(keys["SERVER_PORT\x00"], "", trackVarsArray)
 	}
 
 	// Variables defined in CGI 1.1 spec
@@ -145,15 +145,15 @@ func addKnownVariablesToServer(thread *phpThread, request *http.Request, fc *Fra
 	// the parent environment from interfering.
 
 	// These values can not be overridden
-	registerTrustedVar(keys["CONTENT_LENGTH\x00"], request.Header.Get("Content-Length"), trackVarsArray, thread)
-	registerTrustedVar(keys["GATEWAY_INTERFACE\x00"], "CGI/1.1", trackVarsArray, thread)
-	registerTrustedVar(keys["SERVER_PROTOCOL\x00"], request.Proto, trackVarsArray, thread)
-	registerTrustedVar(keys["SERVER_SOFTWARE\x00"], "FrankenPHP", trackVarsArray, thread)
-	registerTrustedVar(keys["HTTP_HOST\x00"], request.Host, trackVarsArray, thread) // added here, since not always part of headers
+	registerTrustedVar(keys["CONTENT_LENGTH\x00"], request.Header.Get("Content-Length"), trackVarsArray)
+	registerTrustedVar(keys["GATEWAY_INTERFACE\x00"], "CGI/1.1", trackVarsArray)
+	registerTrustedVar(keys["SERVER_PROTOCOL\x00"], request.Proto, trackVarsArray)
+	registerTrustedVar(keys["SERVER_SOFTWARE\x00"], "FrankenPHP", trackVarsArray)
+	registerTrustedVar(keys["HTTP_HOST\x00"], request.Host, trackVarsArray) // added here, since not always part of headers
 
 	// These values are always empty but must be defined:
-	registerTrustedVar(keys["AUTH_TYPE\x00"], "", trackVarsArray, thread)
-	registerTrustedVar(keys["REMOTE_IDENT\x00"], "", trackVarsArray, thread)
+	registerTrustedVar(keys["AUTH_TYPE\x00"], "", trackVarsArray)
+	registerTrustedVar(keys["REMOTE_IDENT\x00"], "", trackVarsArray)
 
 	// These values are already present in the SG(request_info), so we'll register them from there
 	C.frankenphp_register_variables_from_request_info(
@@ -167,11 +167,11 @@ func addKnownVariablesToServer(thread *phpThread, request *http.Request, fc *Fra
 	)
 }
 
-func registerTrustedVar(key *C.zend_string, value string, trackVarsArray *C.zval, thread *phpThread) {
+func registerTrustedVar(key *C.zend_string, value string, trackVarsArray *C.zval) {
 	C.frankenphp_register_trusted_var(key, toUnsafeChar(value), C.int(len(value)), trackVarsArray)
 }
 
-func addHeadersToServer(thread *phpThread, request *http.Request, fc *FrankenPHPContext, trackVarsArray *C.zval) {
+func addHeadersToServer(request *http.Request, fc *FrankenPHPContext, trackVarsArray *C.zval) {
 	for field, val := range request.Header {
 		k, ok := headerKeyCache.Get(field)
 		if !ok {
@@ -188,7 +188,7 @@ func addHeadersToServer(thread *phpThread, request *http.Request, fc *FrankenPHP
 	}
 }
 
-func addPreparedEnvToServer(thread *phpThread, fc *FrankenPHPContext, trackVarsArray *C.zval) {
+func addPreparedEnvToServer(fc *FrankenPHPContext, trackVarsArray *C.zval) {
 	for k, v := range fc.env {
 		C.frankenphp_register_variable_safe(toUnsafeChar(k), toUnsafeChar(v), C.size_t(len(v)), trackVarsArray)
 	}
@@ -215,8 +215,8 @@ func go_register_variables(threadIndex C.uintptr_t, trackVarsArray *C.zval) {
 	fc := r.Context().Value(contextKey).(*FrankenPHPContext)
 
 	addKnownVariablesToServer(thread, r, fc, trackVarsArray)
-	addHeadersToServer(thread, r, fc, trackVarsArray)
-	addPreparedEnvToServer(thread, fc, trackVarsArray)
+	addHeadersToServer(r, fc, trackVarsArray)
+	addPreparedEnvToServer(fc, trackVarsArray)
 }
 
 //export go_frankenphp_release_known_variable_keys


### PR DESCRIPTION
I noticed that it's not necessary to pin a string if it's being used explicitly during a CGO function call (see also [this discussion in the google forums](https://groups.google.com/g/golang-nuts/c/cdWBSGXxh5A).

[zend_string_init](https://github.com/php/php-src/blob/665ebd7f48ee5e7e01e903f87f000aa345154f4b/Zend/zend_string.h#L200) will always copy the underlying string anyways so removing pinning for most globals is safe.

In the flamegraphs you can see that `Pinner.Pin` and `Pinner.Unpin` currently consume around 7% of the CPU profile for the optimized 'Hello World'. Without Pinning most of that time is gone.

With Pinner
![flame](https://github.com/user-attachments/assets/1617a790-c6fa-49f4-a8e2-6bf9c8d8d5bb)

Without Pinner
![flame](https://github.com/user-attachments/assets/4ed53622-0508-484b-9012-7419486b6c01)

The only way to optimize this even more would be by directly using the allocated go string as a zend_string (not sure if this is currently possible)
