### PR TITLE
fix: check command go and xcaddy in build-static.sh

### DIFF
--- a/build-static.sh
+++ b/build-static.sh
@@ -137,8 +137,27 @@ else
 	${spcCommand} build --debug --enable-zts --build-embed ${extraOpts} "${PHP_EXTENSIONS}" --with-libs="${PHP_EXTENSION_LIBS}"
 fi
 
+if ! type "go" >/dev/null 2>&1; then
+	echo "The \"go\" command must be installed. We strongly recommended installed Homebrew for automatically install Golang"
+     	exit 1
+fi
+
 if ! type "xcaddy" >/dev/null 2>&1; then
 	go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+fi
+
+if ! type "xcaddy" >/dev/null 2>&1; then
+	echo "Something went wrong after running \"go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest\"."
+
+	PATH_USER_DOWNLOAD_GO="$(go env GOPATH)/bin"
+
+	# Default shell support
+	if [ -z "$PATH_USER_DOWNLOAD_GO" ]; then
+		echo "We cannot detection location user-downloads package in Go"
+		exit 1
+	fi
+
+	echo "Your user-downloads package in Go = ${PATH_USER_DOWNLOAD_GO}"
 fi
 
 curlGitHubHeaders=(--header "X-GitHub-Api-Version: 2022-11-28")

--- a/build-static.sh
+++ b/build-static.sh
@@ -138,7 +138,7 @@ else
 fi
 
 if ! type "go" >/dev/null 2>&1; then
-	echo "The \"go\" command must be installed. We strongly recommended installed Homebrew for automatically install Golang"
+	echo "The \"go\" command must be installed."
      	exit 1
 fi
 

--- a/build-static.sh
+++ b/build-static.sh
@@ -142,23 +142,10 @@ if ! type "go" >/dev/null 2>&1; then
      	exit 1
 fi
 
-if ! type "xcaddy" >/dev/null 2>&1; then
+XCADDY_COMMAND="$(go env GOPATH)/bin/xcaddy"
+
+if ! type "$XCADDY_COMMAND" >/dev/null 2>&1; then
 	go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
-fi
-
-if ! type "xcaddy" >/dev/null 2>&1; then
-	echo "Something went wrong after running \"go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest\"."
-
-	PATH_USER_DOWNLOAD_GO="$(go env GOPATH)/bin"
-
-	# Default shell support
-	if [ -z "$PATH_USER_DOWNLOAD_GO" ]; then
-		echo "We cannot detection location user-downloads package in Go"
-		exit 1
-	fi
-
-	echo "Your user-downloads package in Go = ${PATH_USER_DOWNLOAD_GO}"
-	exit 1
 fi
 
 curlGitHubHeaders=(--header "X-GitHub-Api-Version: 2022-11-28")
@@ -316,7 +303,7 @@ cd caddy/
 CGO_ENABLED=1 \
 	XCADDY_GO_BUILD_FLAGS="-buildmode=pie -tags cgo,netgo,osusergo,static_build,nobadger,nomysql,nopgx -ldflags \"-linkmode=external -extldflags '-static-pie ${extraExtldflags}' ${extraLdflags} -X 'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP ${FRANKENPHP_VERSION} PHP ${LIBPHP_VERSION} Caddy'\"" \
 	XCADDY_DEBUG="${XCADDY_DEBUG}" \
-	xcaddy build \
+	${XCADDY_COMMAND} build \
 	--output "../dist/${bin}" \
 	${XCADDY_ARGS} \
 	--with github.com/dunglas/frankenphp=.. \

--- a/build-static.sh
+++ b/build-static.sh
@@ -158,6 +158,7 @@ if ! type "xcaddy" >/dev/null 2>&1; then
 	fi
 
 	echo "Your user-downloads package in Go = ${PATH_USER_DOWNLOAD_GO}"
+	exit 1
 fi
 
 curlGitHubHeaders=(--header "X-GitHub-Api-Version: 2022-11-28")

--- a/build-static.sh
+++ b/build-static.sh
@@ -139,13 +139,13 @@ fi
 
 if ! type "go" >/dev/null 2>&1; then
 	echo "The \"go\" command must be installed."
-     	exit 1
+	exit 1
 fi
 
-XCADDY_COMMAND="$(go env GOPATH)/bin/xcaddy"
-
+XCADDY_COMMAND="xcaddy"
 if ! type "$XCADDY_COMMAND" >/dev/null 2>&1; then
 	go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+	XCADDY_COMMAND="$(go env GOPATH)/bin/xcaddy"
 fi
 
 curlGitHubHeaders=(--header "X-GitHub-Api-Version: 2022-11-28")


### PR DESCRIPTION
Checking command `go`:
```bash
+ type go
+ echo 'The "go" command must be installed. We strongly recommended installed Homebrew for automatically install Golang'
The "go" command must be installed. We strongly recommended installed Homebrew for automatically install Golang
+ exit 1
```
Checking command `xcaddy`:
```bash
+ type xcaddy
+ echo 'Something went wrong after running "go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest".'
Something went wrong after running "go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest".
++ go env GOPATH
+ PATH_USER_DOWNLOAD_GO=/root/go/bin
+ '[' -z /root/go/bin ']'
+ echo 'Your user-downloads package in Go = /root/go/bin'
Your user-downloads package in Go = /root/go/bin
```