### PR TITLE
fix: removed redundant ext-json for embedded apps

### DIFF
--- a/build-static.sh
+++ b/build-static.sh
@@ -38,7 +38,10 @@ fi
 if [ -z "${PHP_EXTENSIONS}" ]; then
 	if [ -n "${EMBED}" ] && [ -f "${EMBED}/composer.json" ]; then
 		cd "${EMBED}"
-		PHP_EXTENSIONS="$(composer check-platform-reqs --no-dev 2>/dev/null | grep ^ext | sed -e 's/^ext-//' -e 's/ .*//' | xargs | tr ' ' ',')"
+		# read the composer.json file and extract the required php extensions
+		# note that the ext-json extension will be removed as it is a built-in extension since php 8.x and thus always
+		# available
+		PHP_EXTENSIONS="$(composer check-platform-reqs --no-dev 2>/dev/null | grep ^ext | sed -e 's/^ext-json//' | sed -e 's/^ext-//' -e 's/ .*//' | xargs | tr ' ' ',')"
 		export PHP_EXTENSIONS
 		cd -
 	else

--- a/build-static.sh
+++ b/build-static.sh
@@ -38,10 +38,9 @@ fi
 if [ -z "${PHP_EXTENSIONS}" ]; then
 	if [ -n "${EMBED}" ] && [ -f "${EMBED}/composer.json" ]; then
 		cd "${EMBED}"
-		# read the composer.json file and extract the required php extensions
-		# note that the ext-json extension will be removed as it is a built-in extension since php 8.x and thus always
-		# available
-		PHP_EXTENSIONS="$(composer check-platform-reqs --no-dev 2>/dev/null | grep ^ext | sed -e 's/^ext-json//' | sed -e 's/^ext-//' -e 's/ .*//' | xargs | tr ' ' ',')"
+		# read the composer.json file and extract the required PHP extensions
+		# remove internal extensions from the list: https://github.com/crazywhalecc/static-php-cli/blob/4b16631d45a57370b4747df15c8f105130e96d03/src/globals/defines.php#L26-L34
+		PHP_EXTENSIONS="$(composer check-platform-reqs --no-dev 2>/dev/null | grep ^ext | sed -e 's/^ext-core//' -e 's/^ext-hash//'  -e 's/^ext-json//'  -e 's/^ext-pcre//'  -e 's/^ext-reflection//'  -e 's/^ext-spl//'  -e 's/^ext-standard//' -e 's/^ext-//' -e 's/ .*//' | xargs | tr ' ' ',')"
 		export PHP_EXTENSIONS
 		cd -
 	else


### PR DESCRIPTION
I'm getting errors when I run `build-static` on my embedded app that requires ext-json indirectly from the following packages I'm requiring.

```bash
# composer why ext-json
Package "ext-json *" found in version "8.3.15".
beberlei/assert    v3.3.3  requires ext-json (*) 
guzzlehttp/guzzle  7.9.2   requires ext-json (*) 
knplabs/github-api v3.16.0 requires ext-json (*)
```

Build error:

```bash
2025/01/03 09:51:01 [INFO] exec (timeout=0s): /opt/homebrew/bin/go build -o /Users/jaap/Code/frankenphp/dist/frankenphp-mac-arm64 -buildmode=pie -tags cgo,netgo,osusergo,static_build,nobadger,nomysql,nopgx -ldflags -linkmode=external -extldflags '-static-pie ' -w -s -X 'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP 1.3.4 PHP 8.3.15 Caddy' 
# runtime/cgo
clang: error: no such file or directory: '<U+001B>[93m[09:50:43]'
clang: error: no such file or directory: '[WARN]'
clang: error: no such file or directory: 'Extension'
clang: error: no such file or directory: '[json]'
clang: error: no such file or directory: 'is'
clang: error: no such file or directory: 'an'
clang: error: no such file or directory: 'builtin'
clang: error: no such file or directory: 'extension,'
clang: error: no such file or directory: 'it'
clang: error: no such file or directory: 'will'
clang: error: no such file or directory: 'be'
clang: error: no such file or directory: 'ignored.<U+001B>[0m'
clang: error: no such file or directory: '<U+001B>[93m[09:50:43]'
clang: error: no such file or directory: '[WARN]'
clang: error: no such file or directory: 'Extension'
clang: error: no such file or directory: '[json]'
clang: error: no such file or directory: 'is'
clang: error: no such file or directory: 'an'
clang: error: no such file or directory: 'builtin'
clang: error: no such file or directory: 'extension,'
clang: error: no such file or directory: 'it'
clang: error: no such file or directory: 'will'
clang: error: no such file or directory: 'be'
clang: error: no such file or directory: 'ignored.<U+001B>[0m'
2025/01/03 09:51:04 [INFO] Cleaning up temporary folder: /Users/jaap/Code/frankenphp/caddy/buildenv_2025-01-03-0950.1409326622
2025/01/03 09:51:04 [FATAL] exit status 1
```

Looks like this was introduces in FrankenPHP 1.3.4. Building the embedded app with FrankenPHP 1.3.3 is working as expected.

If I'm not mistaken FrankenPHP supports PHP 8.2 and onwards so if that is the case we can safely remove the ext-json extension if it is required.

Or can I somehow remove this via the `composer.json` file?