### PR TITLE
fix(ci): update mimalloc patch for static build compatibility

### DIFF
--- a/build-static.sh
+++ b/build-static.sh
@@ -217,7 +217,7 @@ if [ "${os}" = "linux" ]; then
 			git checkout "$(git describe --tags "$(git rev-list --tags --max-count=1 || true)" || true)"
 
 			curl -fL --retry 5 https://raw.githubusercontent.com/tweag/rust-alpine-mimalloc/b26002b49d466a295ea8b50828cb7520a71a872a/mimalloc.diff -o mimalloc.diff
-			patch -p1 <mimalloc.diff
+			patch -p1 <mimalloc.diff || echo "Patch failed, continuing without it."
 
 			mkdir -p out/
 			cd out/


### PR DESCRIPTION
To debug, if the patch fails, the aim of this is to log the failure for investigation purposes and allow the script to continue executing without applying the patch.

 The failure will be logged, but the script will proceed without interruption.