### PR TITLE
fix: Updated patch from rust-alpine-mimalloc for mimalloc >= 2.1.8

### DIFF
--- a/build-static.sh
+++ b/build-static.sh
@@ -216,7 +216,7 @@ if [ "${os}" = "linux" ]; then
 
 			git checkout "$(git describe --tags "$(git rev-list --tags --max-count=1 || true)" || true)"
 
-			curl -fL --retry 5 https://raw.githubusercontent.com/tweag/rust-alpine-mimalloc/b26002b49d466a295ea8b50828cb7520a71a872a/mimalloc.diff -o mimalloc.diff
+			curl -fL --retry 5 https://raw.githubusercontent.com/tweag/rust-alpine-mimalloc/1a756444a5c1484d26af9cd39187752728416ba8/mimalloc.diff -o mimalloc.diff
 			patch -p1 <mimalloc.diff
 
 			mkdir -p out/


### PR DESCRIPTION
A recent fix in mimalloc for Musl (https://github.com/microsoft/mimalloc/commit/f38816d4ed3fb4af588c6addf8ec11ec47b79c55) made obsolete the patch applied from rust-alpine-mimalloc.

This PR apply the update from rust-alpine-mimalloc (https://github.com/tweag/rust-alpine-mimalloc/commit/1a756444a5c1484d26af9cd39187752728416ba8).