### PR TITLE
fix: log error if FrankenPHP is not properly started

### DIFF
--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -291,10 +291,6 @@ func needReplacement(s string) bool {
 // ServeHTTP implements caddyhttp.MiddlewareHandler.
 // TODO: Expose TLS versions as env vars, as Apache's mod_ssl: https://github.com/caddyserver/caddy/blob/master/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go#L298
 func (f FrankenPHPModule) ServeHTTP(w http.ResponseWriter, r *http.Request, _ caddyhttp.Handler) error {
-	if !frankenphp.IsRunning() {
-		return caddyhttp.Error(http.StatusBadGateway, frankenphp.NotRunningError)
-	}
-
 	origReq := r.Context().Value(caddyhttp.OriginalRequestCtxKey).(http.Request)
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
 
@@ -323,10 +319,14 @@ func (f FrankenPHPModule) ServeHTTP(w http.ResponseWriter, r *http.Request, _ ca
 	)
 
 	if err != nil {
-		return err
+		return caddyhttp.Error(http.StatusInternalServerError, err)
 	}
 
-	return frankenphp.ServeHTTP(w, fr)
+	if err = frankenphp.ServeHTTP(w, fr); err != nil {
+		return caddyhttp.Error(http.StatusInternalServerError, err)
+	}
+
+	return nil
 }
 
 // UnmarshalCaddyfile implements caddyfile.Unmarshaler.

--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -291,6 +291,10 @@ func needReplacement(s string) bool {
 // ServeHTTP implements caddyhttp.MiddlewareHandler.
 // TODO: Expose TLS versions as env vars, as Apache's mod_ssl: https://github.com/caddyserver/caddy/blob/master/modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go#L298
 func (f FrankenPHPModule) ServeHTTP(w http.ResponseWriter, r *http.Request, _ caddyhttp.Handler) error {
+	if !frankenphp.IsRunning() {
+		return caddyhttp.Error(http.StatusBadGateway, frankenphp.NotRunningError)
+	}
+
 	origReq := r.Context().Value(caddyhttp.OriginalRequestCtxKey).(http.Request)
 	repl := r.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
 

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -358,10 +358,6 @@ func Init(options ...Option) error {
 	return nil
 }
 
-func IsRunning() bool {
-	return isRunning
-}
-
 // Shutdown stops the workers and the PHP runtime.
 func Shutdown() {
 	if !isRunning {
@@ -458,6 +454,10 @@ func updateServerContext(thread *phpThread, request *http.Request, create bool, 
 
 // ServeHTTP executes a PHP script according to the given context.
 func ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) error {
+	if !isRunning {
+		return NotRunningError
+	}
+
 	if !requestIsValid(request, responseWriter) {
 		return nil
 	}

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -62,6 +62,7 @@ var (
 	MainThreadCreationError     = errors.New("error creating the main thread")
 	RequestContextCreationError = errors.New("error during request context creation")
 	ScriptExecutionError        = errors.New("error during PHP script execution")
+	NotRunningError             = errors.New("FrankenPHP is not running. For proper configuration visit: https://frankenphp.dev/docs/config/#caddyfile-config")
 
 	requestChan chan *http.Request
 	isRunning   bool
@@ -355,6 +356,10 @@ func Init(options ...Option) error {
 	}
 
 	return nil
+}
+
+func IsRunning() bool {
+	return isRunning
 }
 
 // Shutdown stops the workers and the PHP runtime.


### PR DESCRIPTION
This should prevent new issues like #1299 in the future. 

If FrankenPHP is not running, this PR changes it so a proper caddy.http error is created on ServeHTTP. Currently the server will just return an empty response and no error will be logged.

![image](https://github.com/user-attachments/assets/c1266160-1ef9-459e-8b2c-7d73022ea8b0)
