### PR TITLE
docs: add link to skeleton Magento 2 (#1246)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,4 @@ frankenphp php-cli /path/to/your/script.php
 * [Drupal](https://github.com/dunglas/frankenphp-drupal)
 * [Joomla](https://github.com/alexandreelise/frankenphp-joomla)
 * [TYPO3](https://github.com/ochorocho/franken-typo3)
+* [Magento2](https://github.com/ekino/frankenphp-magento2)


### PR DESCRIPTION
Add link in Readme to a Magento 2 skeleton with FrankenPHP