### PR TITLE
docs: add link to skeleton Magento 2 on fr/cn/tr Readme (#1246) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,4 @@ frankenphp php-cli /path/to/your/script.php
 * [Drupal](https://github.com/dunglas/frankenphp-drupal)
 * [Joomla](https://github.com/alexandreelise/frankenphp-joomla)
 * [TYPO3](https://github.com/ochorocho/franken-typo3)
+* [Magento2](https://github.com/ekino/frankenphp-magento2)

--- a/docs/cn/README.md
+++ b/docs/cn/README.md
@@ -75,3 +75,4 @@ docker run -v $PWD:/app/public \
 * [Drupal](https://github.com/dunglas/frankenphp-drupal)
 * [Joomla](https://github.com/alexandreelise/frankenphp-joomla)
 * [TYPO3](https://github.com/ochorocho/franken-typo3)
+* [Magento2](https://github.com/ekino/frankenphp-magento2)

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -85,3 +85,4 @@ frankenphp php-cli /path/to/your/script.php
 * [Drupal](https://github.com/dunglas/frankenphp-drupal)
 * [Joomla](https://github.com/alexandreelise/frankenphp-joomla)
 * [TYPO3](https://github.com/ochorocho/franken-typo3)
+* [Magento2](https://github.com/ekino/frankenphp-magento2)

--- a/docs/tr/README.md
+++ b/docs/tr/README.md
@@ -75,3 +75,4 @@ Ayrıca aşağıdaki tek komut satırı ile de çalıştırabilirsiniz:
 * [Drupal](https://github.com/dunglas/frankenphp-drupal)
 * [Joomla](https://github.com/alexandreelise/frankenphp-joomla)
 * [TYPO3](https://github.com/ochorocho/franken-typo3)
+* [Magento2](https://github.com/ekino/frankenphp-magento2)


### PR DESCRIPTION
docs: sync readme on FR/CN/TR with Magento 2 skeleton link