### PR TITLE
Fix: only flush temporary unreferenced streams

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -113,7 +113,7 @@ static void frankenphp_destroy_super_globals() {
  * streams are globally registered in EG(regular_list), see zend_list.c
  * this fixes a leak when reading the body of a request
  */
-static void frankenphp_release_temporary_streams(){
+static void frankenphp_release_temporary_streams() {
   zend_resource *val;
   int stream_type = php_file_le_stream();
   ZEND_HASH_FOREACH_PTR(&EG(regular_list), val) {
@@ -121,7 +121,8 @@ static void frankenphp_release_temporary_streams(){
     if (val->type == stream_type) {
       php_stream *stream = (php_stream *)val->ptr;
       if (stream != NULL && stream->ops == &php_stream_temp_ops &&
-          !stream->is_persistent && stream->__exposed == 0 && GC_REFCOUNT(val) == 1) {
+          !stream->is_persistent && stream->__exposed == 0 &&
+          GC_REFCOUNT(val) == 1) {
         zend_list_close(val);
         zend_list_delete(val);
       }

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -137,7 +137,7 @@ static void frankenphp_worker_request_shutdown() {
   zend_set_memory_limit(PG(memory_limit));
 
   /*
-   * free any php_stream resources that are not php source files
+   * free php_stream resources that are temporary (php_stream_temp_ops)
    * all resources are stored in EG(regular_list), see zend_list.c
    */
   zend_resource *val;
@@ -145,7 +145,7 @@ static void frankenphp_worker_request_shutdown() {
     /* verify the resource is a stream */
     if (val->type == php_file_le_stream()) {
       php_stream *stream = (php_stream *)val->ptr;
-      if (stream != NULL && stream->ops != &php_stream_stdio_ops &&
+      if (stream != NULL && stream->ops == &php_stream_temp_ops &&
           !stream->is_persistent && GC_REFCOUNT(val) == 1) {
         zend_list_delete(val);
       }


### PR DESCRIPTION
This PR refines the fix in #1350.

I'll do some more testing, but explicitly checking if the stream is referenced as a zval will prevent issues with curl/openssl on a Laravel application I've been testing with.