### PR TITLE
fix missing metrics

### DIFF
--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -57,7 +57,7 @@ type FrankenPHPApp struct {
 	// Workers configures the worker scripts to start.
 	Workers []workerConfig `json:"workers,omitempty"`
 
-	metrics *frankenphp.PrometheusMetrics
+	metrics frankenphp.Metrics
 }
 
 // CaddyModule returns the Caddy module information.

--- a/caddy/caddy_test.go
+++ b/caddy/caddy_test.go
@@ -11,10 +11,10 @@ import (
 	"testing"
 
 	"github.com/dunglas/frankenphp"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
+	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddytest"
 )
 
@@ -374,7 +374,9 @@ func TestMetrics(t *testing.T) {
 	frankenphp_busy_threads 0
 	`
 
-	require.NoError(t, testutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(expectedMetrics), "frankenphp_total_threads", "frankenphp_busy_threads"))
+	ctx := caddy.ActiveContext()
+
+	require.NoError(t, testutil.GatherAndCompare(ctx.GetMetricsRegistry(), strings.NewReader(expectedMetrics), "frankenphp_total_threads", "frankenphp_busy_threads"))
 }
 
 func TestWorkerMetrics(t *testing.T) {
@@ -462,9 +464,10 @@ func TestWorkerMetrics(t *testing.T) {
 	frankenphp_testdata_index_php_worker_restarts 0
 	`
 
+	ctx := caddy.ActiveContext()
 	require.NoError(t,
 		testutil.GatherAndCompare(
-			prometheus.DefaultGatherer,
+			ctx.GetMetricsRegistry(),
 			strings.NewReader(expectedMetrics),
 			"frankenphp_total_threads",
 			"frankenphp_busy_threads",
@@ -563,9 +566,10 @@ func TestAutoWorkerConfig(t *testing.T) {
 	frankenphp_testdata_index_php_worker_restarts 0
 	`
 
+	ctx := caddy.ActiveContext()
 	require.NoError(t,
 		testutil.GatherAndCompare(
-			prometheus.DefaultGatherer,
+			ctx.GetMetricsRegistry(),
 			strings.NewReader(expectedMetrics),
 			"frankenphp_total_threads",
 			"frankenphp_busy_threads",


### PR DESCRIPTION
closes #1365 

update Caddy metrics registry
as of Caddy v2.9 (https://github.com/caddyserver/caddy/commit/41f5dd56e1b93ec815daa98dd1f1caa7f2087312) it changed the flow to get the metrics registry