### PR TITLE
docs: link metrics docs to website

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ frankenphp php-cli /path/to/your/script.php
 * [Create **standalone**, self-executable PHP apps](https://frankenphp.dev/docs/embed/)
 * [Create static binaries](https://frankenphp.dev/docs/static/)
 * [Compile from sources](https://frankenphp.dev/docs/compile/)
+* [Monitoring FrankenPHP](https://frankenphp.dev/docs/metrics/)
 * [Laravel integration](https://frankenphp.dev/docs/laravel/)
 * [Known issues](https://frankenphp.dev/docs/known-issues/)
 * [Demo app (Symfony) and benchmarks](https://github.com/dunglas/frankenphp-demo)


### PR DESCRIPTION
documentation about metrics was there but it is not shown on the website