### PR TITLE
provide main for brotli and non-brotli builds

### DIFF
--- a/caddy/frankenphp/main-br.go
+++ b/caddy/frankenphp/main-br.go
@@ -1,0 +1,18 @@
+//go:build !nobrotli
+
+package main
+
+import (
+	caddycmd "github.com/caddyserver/caddy/v2/cmd"
+
+	// plug in Caddy modules here.
+	_ "github.com/caddyserver/caddy/v2/modules/standard"
+	_ "github.com/dunglas/caddy-cbrotli"
+	_ "github.com/dunglas/frankenphp/caddy"
+	_ "github.com/dunglas/mercure/caddy"
+	_ "github.com/dunglas/vulcain/caddy"
+)
+
+func main() {
+	caddycmd.Main()
+}

--- a/caddy/frankenphp/main-no-br.go
+++ b/caddy/frankenphp/main-no-br.go
@@ -1,3 +1,5 @@
+//go:build nobrotli
+
 package main
 
 import (
@@ -5,7 +7,6 @@ import (
 
 	// plug in Caddy modules here.
 	_ "github.com/caddyserver/caddy/v2/modules/standard"
-	_ "github.com/dunglas/caddy-cbrotli"
 	_ "github.com/dunglas/frankenphp/caddy"
 	_ "github.com/dunglas/mercure/caddy"
 	_ "github.com/dunglas/vulcain/caddy"


### PR DESCRIPTION
Provides a brotli and non-brotli `main` file for caddy.

fixes #1377 