### PR TITLE
fix: watcher - handles associated events.

### DIFF
--- a/.github/actions/watcher/action.yaml
+++ b/.github/actions/watcher/action.yaml
@@ -19,7 +19,7 @@ runs:
       name: Compile e-dant/watcher
       run: |
         mkdir watcher
-        gh release download --repo e-dant/watcher -A tar.gz -O - | tar -xz -C watcher --strip-components 1
+        gh release download 0.13.2 --repo e-dant/watcher -A tar.gz -O - | tar -xz -C watcher --strip-components 1
         cd watcher
         cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
         cmake --build build

--- a/internal/watcher/watch_pattern_test.go
+++ b/internal/watcher/watch_pattern_test.go
@@ -155,7 +155,6 @@ func TestAnAssociatedEventTriggersTheWatcher(t *testing.T) {
 
 	select {
 	case <-watchPattern.trigger:
-		assert.True(t, true)
 	case <-time.After(2 * time.Second):
 		assert.Fail(t, "associated watchPattern did not trigger after 2s")
 	}

--- a/internal/watcher/watcher.c
+++ b/internal/watcher/watcher.c
@@ -5,8 +5,9 @@
 #include "wtr/watcher-c.h"
 
 void handle_event(struct wtr_watcher_event event, void *data) {
-  go_handle_file_watcher_event((char *)event.path_name, event.effect_type,
-                               event.path_type, (uintptr_t)data);
+  go_handle_file_watcher_event(
+      (char *)event.path_name, (char *)event.associated_path_name,
+      event.effect_type, event.path_type, (uintptr_t)data);
 }
 
 uintptr_t start_new_watcher(char const *const path, uintptr_t data) {

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -171,7 +171,7 @@ func handleWatcherEvent(watchPattern *watchPattern, path string, associatedPath 
 	}
 
 	// some editors create temporary files and never actually modify the original file
-	// so we need to also check if the associated path of an event
+	// so we need to also check the associated path of an event
 	// see https://github.com/dunglas/frankenphp/issues/1375
 	if associatedPath != "" && watchPattern.allowReload(associatedPath, eventType, pathType) {
 		watchPattern.trigger <- struct{}{}

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -82,6 +82,7 @@ func retryWatching(watchPattern *watchPattern) {
 	failureMu.Lock()
 	defer failureMu.Unlock()
 	if watchPattern.failureCount >= maxFailureCount {
+		logger.Warn("gave up watching", zap.String("dir", watchPattern.dir))
 		return
 	}
 	logger.Info("watcher was closed prematurely, retrying...", zap.String("dir", watchPattern.dir))
@@ -152,17 +153,28 @@ func stopSession(session C.uintptr_t) {
 }
 
 //export go_handle_file_watcher_event
-func go_handle_file_watcher_event(path *C.char, eventType C.int, pathType C.int, handle C.uintptr_t) {
+func go_handle_file_watcher_event(path *C.char, associatedPath *C.char, eventType C.int, pathType C.int, handle C.uintptr_t) {
 	watchPattern := cgo.Handle(handle).Value().(*watchPattern)
-	goPath := C.GoString(path)
+	handleWatcherEvent(watchPattern, C.GoString(path), C.GoString(associatedPath), int(eventType), int(pathType))
+}
 
-	if watchPattern.allowReload(goPath, int(eventType), int(pathType)) {
-		watchPattern.trigger <- struct{}{}
+func handleWatcherEvent(watchPattern *watchPattern, path string, associatedPath string, eventType int, pathType int) {
+	// If the watcher prematurely sends the die@ event, retry watching
+	if pathType == 4 && strings.HasPrefix(path, "e/self/die@") && watcherIsActive.Load() {
+		retryWatching(watchPattern)
+		return
 	}
 
-	// If the watcher prematurely sends the die@ event, retry watching
-	if pathType == 4 && strings.HasPrefix(goPath, "e/self/die@") && watcherIsActive.Load() {
-		retryWatching(watchPattern)
+	if watchPattern.allowReload(path, eventType, pathType) {
+		watchPattern.trigger <- struct{}{}
+		return
+	}
+
+	// some editors create temporary files and never actually modify the original file
+	// so we need to also check if the associated path of an event
+	// see https://github.com/dunglas/frankenphp/issues/1375
+	if associatedPath != "" && watchPattern.allowReload(associatedPath, eventType, pathType) {
+		watchPattern.trigger <- struct{}{}
 	}
 }
 


### PR DESCRIPTION
This changes the watcher to also check file patterns of associated events (fixes #1375).

Some editors will just create temporary files and never directly modify the original PHP file.