### PR TITLE
perf: avoid redundant work in frankenphp_release_temporary_streams()

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -121,9 +121,9 @@ static void frankenphp_release_temporary_streams() {
     if (val->type == stream_type) {
       php_stream *stream = (php_stream *)val->ptr;
       if (stream != NULL && stream->ops == &php_stream_temp_ops &&
-          !stream->is_persistent && stream->__exposed == 0 &&
+          stream->__exposed == 0 &&
           GC_REFCOUNT(val) == 1) {
-        zend_list_close(val);
+        ZEND_ASSERT(!stream->is_persistent);
         zend_list_delete(val);
       }
     }


### PR DESCRIPTION
Persistent streams are of type le_pstream, not le_stream. Therefore, the persistent check will always be false. We can thus replace that check with an assertion.

`zend_list_delete` removes the entry from the regular_list table, and calls `zend_resource_dtor` via the table destructor. When the refcount is 1, `zend_list_close` calls `zend_resource_dtor`, but keeps the entry in the table.
Multiple calls to `zend_resource_dtor` have no effect: the destructor is only called once.
Therefore, the `zend_list_close` operation is redundant because it is fully included in the work done by `zend_list_delete`.