### PR TITLE
support sapi options php_ini_ignore, php_ini_ignore_cwd

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -968,7 +968,8 @@ static void *php_main(void *arg) {
 #endif
 
   sapi_startup(&frankenphp_sapi_module);
-
+  frankenphp_sapi_module.php_ini_ignore = go_get_php_ini_ignore();
+  frankenphp_sapi_module.php_ini_ignore_cwd = go_get_php_ini_ignore_cwd();
 #ifndef ZEND_MAX_EXECUTION_TIMERS
 #if (PHP_VERSION_ID >= 80300)
   frankenphp_sapi_module.ini_entries = HARDCODED_INI;

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -333,7 +333,7 @@ func Init(options ...Option) error {
 	}
 
 	requestChan = make(chan *http.Request, opt.numThreads)
-	if err := initPHPThreads(totalThreadCount); err != nil {
+	if err := initPHPThreads(totalThreadCount, opt.phpIniIgnore, opt.phpIniIgnoreCwd); err != nil {
 		return err
 	}
 

--- a/options.go
+++ b/options.go
@@ -15,6 +15,9 @@ type opt struct {
 	workers    []workerOpt
 	logger     *zap.Logger
 	metrics    Metrics
+	// sapi options
+	phpIniIgnore    bool
+	phpIniIgnoreCwd bool
 }
 
 type workerOpt struct {
@@ -54,6 +57,24 @@ func WithWorkers(fileName string, num int, env map[string]string, watch []string
 func WithLogger(l *zap.Logger) Option {
 	return func(o *opt) error {
 		o.logger = l
+
+		return nil
+	}
+}
+
+// WithPHPIniIgnore don't look for php.ini
+func WithPHPIniIgnore(ignore bool) Option {
+	return func(o *opt) error {
+		o.phpIniIgnore = ignore
+
+		return nil
+	}
+}
+
+// WithPHPIniIgnoreCwd don't look for php.ini in the current directory
+func WithPHPIniIgnoreCwd(ignoreCwd bool) Option {
+	return func(o *opt) error {
+		o.phpIniIgnoreCwd = ignoreCwd
 
 		return nil
 	}

--- a/phpmainthread_test.go
+++ b/phpmainthread_test.go
@@ -18,8 +18,8 @@ import (
 var testDataPath, _ = filepath.Abs("./testdata")
 
 func TestStartAndStopTheMainThreadWithOneInactiveThread(t *testing.T) {
-	logger = zap.NewNop()                // the logger needs to not be nil
-	assert.NoError(t, initPHPThreads(1)) // reserve 1 thread
+	logger = zap.NewNop()                              // the logger needs to not be nil
+	assert.NoError(t, initPHPThreads(1, false, false)) // reserve 1 thread
 
 	assert.Len(t, phpThreads, 1)
 	assert.Equal(t, 0, phpThreads[0].threadIndex)
@@ -31,7 +31,7 @@ func TestStartAndStopTheMainThreadWithOneInactiveThread(t *testing.T) {
 
 func TestTransitionRegularThreadToWorkerThread(t *testing.T) {
 	logger = zap.NewNop()
-	assert.NoError(t, initPHPThreads(1))
+	assert.NoError(t, initPHPThreads(1, false, false))
 
 	// transition to regular thread
 	convertToRegularThread(phpThreads[0])
@@ -54,7 +54,7 @@ func TestTransitionRegularThreadToWorkerThread(t *testing.T) {
 
 func TestTransitionAThreadBetween2DifferentWorkers(t *testing.T) {
 	logger = zap.NewNop()
-	assert.NoError(t, initPHPThreads(1))
+	assert.NoError(t, initPHPThreads(1, false, false))
 	firstWorker := getDummyWorker("transition-worker-1.php")
 	secondWorker := getDummyWorker("transition-worker-2.php")
 

--- a/testdata/php_ini_loaded_file.php
+++ b/testdata/php_ini_loaded_file.php
@@ -1,0 +1,14 @@
+<?php
+
+require_once __DIR__ . '/_executor.php';
+
+return function () {
+    $ini = php_ini_loaded_file();
+    if ($ini === false) {
+        echo 'none';
+    } elseif (str_contains($ini, "testdata/php.ini")) {
+        echo 'cwd';
+    } else {
+        echo 'global';
+    }
+};


### PR DESCRIPTION
This PR adds support for php_ini_ignore and php_ini_ignore_cwd while maintaining the current behavior.

However, I suggest changing the default value of php_ini_ignore_cwd to true, similar to how FPM handles it ([reference](https://github.com/php/php-src/blob/3b23de31db969c3c12060ff7c5ba363f65de6669/sapi/fpm/fpm/fpm_main.c#L1595)).

This change would improve consistency with FPM and ensure that php.ini is not loaded based on the current working directory by default.