### PR TITLE
Call opcache_reset PHP function directly

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -1162,7 +1162,8 @@ int frankenphp_execute_script_cli(char *script, int argc, char **argv) {
 }
 
 int frankenphp_reset_opcache(void) {
-  zend_function *opcache_reset = zend_hash_str_find_ptr(CG(function_table), ZEND_STRL("opcache_reset"));
+  zend_function *opcache_reset =
+      zend_hash_str_find_ptr(CG(function_table), ZEND_STRL("opcache_reset"));
   if (opcache_reset) {
     zend_call_known_function(opcache_reset, NULL, NULL, NULL, 0, NULL, NULL);
   }

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -1180,11 +1180,13 @@ int frankenphp_execute_php_function(const char *php_function) {
   return success;
 }
 
-void frankenphp_reset_opcache(void) {
+int frankenphp_reset_opcache(void) {
   zend_function *opcache_reset = zend_hash_str_find_ptr(CG(function_table), ZEND_STRL("opcache_reset"));
   if (opcache_reset) {
     zend_call_known_function(opcache_reset, NULL, NULL, NULL, 0, NULL, NULL);
   }
+
+  return 0;
 }
 
 int frankenphp_get_current_memory_limit() { return PG(memory_limit); }

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -1180,12 +1180,11 @@ int frankenphp_execute_php_function(const char *php_function) {
   return success;
 }
 
-int frankenphp_reset_opcache(void) {
-  if (zend_hash_str_exists(CG(function_table), "opcache_reset",
-                           sizeof("opcache_reset") - 1)) {
-    return frankenphp_execute_php_function("opcache_reset");
+void frankenphp_reset_opcache(void) {
+  zend_function *opcache_reset = zend_hash_str_find_ptr(CG(function_table), ZEND_STRL("opcache_reset"));
+  if (opcache_reset) {
+    zend_call_known_function(opcache_reset, NULL, NULL, NULL, 0, NULL, NULL);
   }
-  return 0;
 }
 
 int frankenphp_get_current_memory_limit() { return PG(memory_limit); }

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -1161,25 +1161,6 @@ int frankenphp_execute_script_cli(char *script, int argc, char **argv) {
   return (intptr_t)exit_status;
 }
 
-int frankenphp_execute_php_function(const char *php_function) {
-  zval retval = {0};
-  zend_fcall_info fci = {0};
-  zend_fcall_info_cache fci_cache = {0};
-  zend_string *func_name =
-      zend_string_init(php_function, strlen(php_function), 0);
-  ZVAL_STR(&fci.function_name, func_name);
-  fci.size = sizeof fci;
-  fci.retval = &retval;
-  int success = 0;
-
-  zend_try { success = zend_call_function(&fci, &fci_cache) == SUCCESS; }
-  zend_end_try();
-
-  zend_string_release(func_name);
-
-  return success;
-}
-
 int frankenphp_reset_opcache(void) {
   zend_function *opcache_reset = zend_hash_str_find_ptr(CG(function_table), ZEND_STRL("opcache_reset"));
   if (opcache_reset) {

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -653,13 +653,6 @@ func freeArgs(argv []*C.char) {
 	}
 }
 
-func executePHPFunction(functionName string) bool {
-	cFunctionName := C.CString(functionName)
-	defer C.free(unsafe.Pointer(cFunctionName))
-
-	return C.frankenphp_execute_php_function(cFunctionName) == 1
-}
-
 func timeoutChan(timeout time.Duration) <-chan time.Time {
 	if timeout == 0 {
 		return nil

--- a/frankenphp.h
+++ b/frankenphp.h
@@ -63,8 +63,6 @@ int frankenphp_execute_script(char *file_name);
 
 int frankenphp_execute_script_cli(char *script, int argc, char **argv);
 
-int frankenphp_execute_php_function(const char *php_function);
-
 void frankenphp_register_variables_from_request_info(
     zval *track_vars_array, zend_string *content_type,
     zend_string *path_translated, zend_string *query_string,

--- a/frankenphp.h
+++ b/frankenphp.h
@@ -74,7 +74,6 @@ void frankenphp_register_variable_safe(char *key, char *var, size_t val_len,
 zend_string *frankenphp_init_persistent_string(const char *string, size_t len);
 int frankenphp_reset_opcache(void);
 void frankenphp_release_zend_string(zend_string *z_string);
-void frankenphp_reset_opcache(void);
 int frankenphp_get_current_memory_limit();
 void frankenphp_add_assoc_str_ex(zval *track_vars_array, char *key,
                                  size_t keylen, zend_string *val);

--- a/frankenphp.h
+++ b/frankenphp.h
@@ -73,7 +73,6 @@ void frankenphp_register_variable_safe(char *key, char *var, size_t val_len,
                                        zval *track_vars_array);
 zend_string *frankenphp_init_persistent_string(const char *string, size_t len);
 int frankenphp_reset_opcache(void);
-void frankenphp_release_zend_string(zend_string *z_string);
 int frankenphp_get_current_memory_limit();
 void frankenphp_add_assoc_str_ex(zval *track_vars_array, char *key,
                                  size_t keylen, zend_string *val);

--- a/frankenphp.h
+++ b/frankenphp.h
@@ -73,6 +73,8 @@ void frankenphp_register_variable_safe(char *key, char *var, size_t val_len,
                                        zval *track_vars_array);
 zend_string *frankenphp_init_persistent_string(const char *string, size_t len);
 int frankenphp_reset_opcache(void);
+void frankenphp_release_zend_string(zend_string *z_string);
+void frankenphp_reset_opcache(void);
 int frankenphp_get_current_memory_limit();
 void frankenphp_add_assoc_str_ex(zval *track_vars_array, char *key,
                                  size_t keylen, zend_string *val);


### PR DESCRIPTION
Combined with #1398 this should allow the removal of `frankenphp_execute_php_function`