### PR TITLE
fix: only drain workers on graceful shutdown.

### DIFF
--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -113,7 +113,7 @@ func (f *FrankenPHPApp) Stop() error {
 	// note: Exiting() is currently marked as 'experimental'
 	// https://github.com/caddyserver/caddy/blob/e76405d55058b0a3e5ba222b44b5ef00516116aa/caddy.go#L810
 	if caddy.Exiting() {
-		frankenphp.Shutdown()
+		frankenphp.DrainWorkers()
 	}
 
 	// reset configuration so it doesn't bleed into later tests

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -372,7 +372,7 @@ func Shutdown() {
 		return
 	}
 
-	drainWorkers()
+	drainWatcher()
 	drainAutoScaling()
 	drainPHPThreads()
 

--- a/metrics.go
+++ b/metrics.go
@@ -380,9 +380,9 @@ func (m *PrometheusMetrics) Shutdown() {
 	}
 
 	if err := m.registry.Register(m.queueDepth); err != nil &&
-        !errors.As(err, &prometheus.AlreadyRegisteredError{}) {
-        panic(err)
-    }
+		!errors.As(err, &prometheus.AlreadyRegisteredError{}) {
+		panic(err)
+	}
 }
 
 func getWorkerNameForMetrics(name string) string {
@@ -432,9 +432,9 @@ func NewPrometheusMetrics(registry prometheus.Registerer) *PrometheusMetrics {
 	}
 
 	if err := m.registry.Register(m.queueDepth); err != nil &&
-        !errors.As(err, &prometheus.AlreadyRegisteredError{}) {
-        panic(err)
-    }
+		!errors.As(err, &prometheus.AlreadyRegisteredError{}) {
+		panic(err)
+	}
 
 	return m
 }

--- a/worker.go
+++ b/worker.go
@@ -86,7 +86,7 @@ func newWorker(o workerOpt) (*worker, error) {
 	return w, nil
 }
 
-// DrainWorkers finishes all worker scripts before a graceful shutdown
+// EXPERIMENTAL: DrainWorkers finishes all worker scripts before a graceful shutdown
 func DrainWorkers() {
 	_ = drainWorkerThreads()
 }


### PR DESCRIPTION
Should fix #1296

This PR changes the graceful shutdown to just drain all running worker scripts. It's faster and easier to just let the OS clean up all the remaining memory.