### PR TITLE
perf: nocallback and noescape cgo flags

### DIFF
--- a/cgi.go
+++ b/cgi.go
@@ -1,5 +1,13 @@
 package frankenphp
 
+// #cgo nocallback frankenphp_register_bulk
+// #cgo nocallback frankenphp_register_variables_from_request_info
+// #cgo nocallback frankenphp_register_variable_safe
+// #cgo nocallback frankenphp_register_single
+// #cgo noescape frankenphp_register_bulk
+// #cgo noescape frankenphp_register_variables_from_request_info
+// #cgo noescape frankenphp_register_variable_safe
+// #cgo noescape frankenphp_register_single
 // #include <php_variables.h>
 // #include "frankenphp.h"
 import "C"

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -12,6 +12,8 @@ package frankenphp
 //
 // We also set these flags for hardening: https://github.com/docker-library/php/blob/master/8.2/bookworm/zts/Dockerfile#L57-L59
 
+// #cgo nocallback frankenphp_update_server_context
+// #cgo noescape frankenphp_update_server_context
 // #cgo darwin pkg-config: libxml-2.0
 // #cgo CFLAGS: -Wall -Werror
 // #cgo CFLAGS: -I/usr/local/include -I/usr/local/include/php -I/usr/local/include/php/main -I/usr/local/include/php/TSRM -I/usr/local/include/php/Zend -I/usr/local/include/php/ext -I/usr/local/include/php/ext/date/lib

--- a/phpmainthread.go
+++ b/phpmainthread.go
@@ -1,5 +1,10 @@
 package frankenphp
 
+// #cgo nocallback frankenphp_new_main_thread
+// #cgo nocallback frankenphp_init_persistent_string
+// #cgo noescape frankenphp_new_main_thread
+// #cgo noescape frankenphp_init_persistent_string
+// #include <php_variables.h>
 // #include "frankenphp.h"
 import "C"
 import (

--- a/phpthread.go
+++ b/phpthread.go
@@ -1,5 +1,6 @@
 package frankenphp
 
+// #cgo nocallback frankenphp_new_php_thread
 // #include "frankenphp.h"
 import "C"
 import (


### PR DESCRIPTION
go 1.24 has some new flags to optimize cgo calls: `nocallback `and `noescape`:
https://pkg.go.dev/cmd/cgo@master#hdr-Optimizing_calls_of_C_code

While the perfomance gain from adding these flags isn't immediately obvious in the flamegraphs, it's nice that both of these flags conform to how we are currently using `cgo`. 

`nocallback` will panic for any `go -> c -> go` call, which is also what we are currently avoiding since it breaks Fibers.