### PR TITLE
perf: rejects closed connections right away

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -341,7 +341,7 @@ func Init(options ...Option) error {
 		return err
 	}
 
-	regularRequestChan = make(chan *http.Request, totalThreadCount-workerThreadCount)
+	regularRequestChan = make(chan *http.Request)
 	regularThreads = make([]*phpThread, 0, totalThreadCount-workerThreadCount)
 	for i := 0; i < totalThreadCount-workerThreadCount; i++ {
 		thread := getInactivePHPThread()

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -458,6 +458,9 @@ func TestConnectionAbort_worker(t *testing.T) {
 	testConnectionAbort(t, &testOptions{workerScript: "connectionStatusLog.php"})
 }
 func testConnectionAbort(t *testing.T, opts *testOptions) {
+	// Set parallel requests to 1 so the request will not get stalled and rejected immediately
+	opts.nbParallelRequests = 1
+
 	testFinish := func(finish string) {
 		t.Run(fmt.Sprintf("finish=%s", finish), func(t *testing.T) {
 			logger, logs := observer.New(zapcore.InfoLevel)

--- a/threadregular.go
+++ b/threadregular.go
@@ -117,6 +117,10 @@ func handleRequestWithRegularPHPThreads(r *http.Request, fc *FrankenPHPContext) 
 			return
 		case scaleChan <- fc:
 			// the request has triggered scaling, continue to wait for a thread
+			continue
+		case <-r.Context().Done():
+			// the request has been canceled by the client
+			return
 		}
 	}
 }

--- a/worker.go
+++ b/worker.go
@@ -187,6 +187,10 @@ func (worker *worker) handleRequest(r *http.Request, fc *FrankenPHPContext) {
 			return
 		case scaleChan <- fc:
 			// the request has triggered scaling, continue to wait for a thread
+			continue
+		case <-r.Context().Done():
+			// the request has been canceled by the client
+			return
 		}
 	}
 }


### PR DESCRIPTION
This PR should improve recovery in the case where the server is overwhelmed by rejecting all closed and stalled connections right away. This makes it so these connections don't even reach PHP.

Doing this requires removing the buffer from the regular request chan, but comes at no notable performance cost otherwise.