### PR TITLE
Remove duplicate frankenphp_free_request_context()

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -1076,7 +1076,6 @@ int frankenphp_execute_script(char *file_name) {
 
   zend_destroy_file_handle(&file_handle);
 
-  frankenphp_free_request_context();
   frankenphp_request_shutdown();
 
   return status;


### PR DESCRIPTION
Removes an unnecessary call to frankenphp_free_request_context() since it is already invoked in frankenphp_request_shutdown().