### PR TITLE
Fix: warn on wrong configuration

### DIFF
--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -198,12 +198,21 @@ func (f *FrankenPHPApp) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				}
 
 				if d.NextArg() {
-					v, err := strconv.Atoi(d.Val())
-					if err != nil {
-						return err
-					}
+					if d.Val() == "watch" {
+						wc.Watch = append(wc.Watch, "./**/*.{php,yaml,yml,twig,env}")
+					} else {
+						v, err := strconv.Atoi(d.Val())
+						if err != nil {
+							return err
+						}
 
-					wc.Num = v
+						wc.Num = v
+					}
+				}
+
+				if d.NextArg() {
+					// TODO: this should error in a V2
+					caddy.Log().Warn("Unknown worker argument: " + d.Val())
 				}
 
 				for d.NextBlock(1) {
@@ -241,6 +250,9 @@ func (f *FrankenPHPApp) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 						} else {
 							wc.Watch = append(wc.Watch, d.Val())
 						}
+					default:
+						// TODO: this should error in a V2
+						caddy.Log().Warn("FrankenPHP: Unknown worker configuration: " + d.Val())
 					}
 
 					if wc.FileName == "" {
@@ -253,6 +265,9 @@ func (f *FrankenPHPApp) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				}
 
 				f.Workers = append(f.Workers, wc)
+			default:
+				// TODO: this should error in a V2
+				caddy.Log().Warn("FrankenPHP: Unknown 'frankenphp' configuration: " + d.Val())
 			}
 		}
 	}
@@ -448,6 +463,9 @@ func (f *FrankenPHPModule) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				}
 
 				f.ResolveRootSymlink = &v
+			default:
+				// TODO: this should error in a V2
+				caddy.Log().Warn("FrankenPHP: Unknown 'php_server' or 'php' configuration: " + d.Val())
 			}
 		}
 	}


### PR DESCRIPTION
There have been multiple issues like #1419, #1423 or https://github.com/dunglas/frankenphp/issues/1356#issuecomment-2694913680 where people have unknowingly wrongly configured FrankenPHP.

Ideally, it should error on wrong configuration. This PR makes it so there's at least a warning to not break current Caddy configurations.

It also allows allows this shorthand worker configuration:

`ENV FRANKENPHP_CONFIG="worker ./public/index.php watch"`