### PR TITLE
chore: update static build cli PHP version to 8.4

### DIFF
--- a/build-static.sh
+++ b/build-static.sh
@@ -215,11 +215,11 @@ if [ "${os}" = "linux" ]; then
 		if [ ! -f "mimalloc/out/libmimalloc.a" ]; then
 			if [ -d "mimalloc" ]; then
 				cd mimalloc/
-				git reset --hard
+				git reset --hard v3.0.1
 				git clean -xdf
 				git fetch --tags
 			else
-				git clone https://github.com/microsoft/mimalloc.git
+				git clone -b v3.0.1 https://github.com/microsoft/mimalloc.git
 				cd mimalloc/
 			fi
 

--- a/build-static.sh
+++ b/build-static.sh
@@ -215,15 +215,16 @@ if [ "${os}" = "linux" ]; then
 		if [ ! -f "mimalloc/out/libmimalloc.a" ]; then
 			if [ -d "mimalloc" ]; then
 				cd mimalloc/
-				git reset --hard v3.0.1
+				git reset --hard
 				git clean -xdf
 				git fetch --tags
 			else
-				git clone -b v3.0.1 https://github.com/microsoft/mimalloc.git
+				git clone https://github.com/microsoft/mimalloc.git
 				cd mimalloc/
 			fi
 
-			git checkout "$(git describe --tags "$(git rev-list --tags --max-count=1 || true)" || true)"
+			# mimalloc version must be compatible with version used in tweag/rust-alpine-mimalloc
+			git checkout v3.0.1
 
 			curl -fL --retry 5 https://raw.githubusercontent.com/tweag/rust-alpine-mimalloc/1a756444a5c1484d26af9cd39187752728416ba8/mimalloc.diff -o mimalloc.diff
 			patch -p1 <mimalloc.diff

--- a/static-builder.Dockerfile
+++ b/static-builder.Dockerfile
@@ -54,25 +54,25 @@ RUN apk update; \
 		m4 \
 		make \
 		pkgconfig \
-		php83 \
-		php83-common \
-		php83-ctype \
-		php83-curl \
-		php83-dom \
-		php83-mbstring \
-		php83-openssl \
-		php83-pcntl \
-		php83-phar \
-		php83-posix \
-		php83-session \
-		php83-sodium \
-		php83-tokenizer \
-		php83-xml \
-		php83-xmlwriter \
+		php84 \
+		php84-common \
+		php84-ctype \
+		php84-curl \
+		php84-dom \
+		php84-mbstring \
+		php84-openssl \
+		php84-pcntl \
+		php84-phar \
+		php84-posix \
+		php84-session \
+		php84-sodium \
+		php84-tokenizer \
+		php84-xml \
+		php84-xmlwriter \
 		upx \
 		wget \
 		xz ; \
-	ln -sf /usr/bin/php83 /usr/bin/php && \
+	ln -sf /usr/bin/php84 /usr/bin/php && \
 	go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
 
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser


### PR DESCRIPTION
Using PHP 8.4 with static-php-cli should remove the deprecation notice that currently prevents the static build.