### PR TITLE
ci: env test remediation

### DIFF
--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -672,10 +672,10 @@ func TestFailingWorker(t *testing.T) {
 }
 
 func TestEnv(t *testing.T) {
-	testEnv(t, &testOptions{})
+	testEnv(t, &testOptions{nbParallelRequests:1})
 }
 func TestEnvWorker(t *testing.T) {
-	testEnv(t, &testOptions{workerScript: "env/test-env.php"})
+	testEnv(t, &testOptions{nbParallelRequests:1, workerScript: "env/test-env.php"})
 }
 func testEnv(t *testing.T, opts *testOptions) {
 	assert.NoError(t, os.Setenv("EMPTY", ""))

--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -677,6 +677,7 @@ func TestEnv(t *testing.T) {
 func TestEnvWorker(t *testing.T) {
 	testEnv(t, &testOptions{nbParallelRequests:1, workerScript: "env/test-env.php"})
 }
+// testEnv cannot be run in parallel due to https://github.com/golang/go/issues/63567
 func testEnv(t *testing.T, opts *testOptions) {
 	assert.NoError(t, os.Setenv("EMPTY", ""))
 


### PR DESCRIPTION
It looks like the failing of the `Env Test` is related to a fundamental flaw in cgo/libc and probably can't be resolved before https://github.com/golang/go/issues/63567 is addressed.

#1409 has sped up the environment import and thereby probably made the race condition more likely. The only way to stop failure currently in tests is by not testing in parallell.