### PR TITLE
fix: log worker failures

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -466,8 +466,12 @@ func addHeader(fc *frankenPHPContext, cString *C.char, length C.int) {
 func go_write_headers(threadIndex C.uintptr_t, status C.int, headers *C.zend_llist) C.bool {
 	fc := phpThreads[threadIndex].getRequestContext()
 
-	if fc.isDone || fc.responseWriter == nil {
+	if fc.isDone {
 		return C.bool(false)
+	}
+
+	if fc.responseWriter == nil {
+		return C.bool(true)
 	}
 
 	current := headers.head


### PR DESCRIPTION
This PR fixes 2 small issues that also came up in #1421.

I've noticed before that any error that is thrown during a worker start is not actually logged anywhere. While php in dev mode will log any fatal errors to stderr, in the `dunglas/frankenphp` image this is actually not the case.

There exists logic for `logger.Info()` to output everything during worker startup, but that logic never gets triggered since PHP will not attempt to call `ub_write` if sending headers fails. This PR fixes that by 'faking' a successful sending of headers.

This PR also makes workers fail everytime if `frankenphp_handle_request `has not been reached.