### PR TITLE
fix: ensure env is not in an invalid state on shutdown

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -405,11 +405,10 @@ PHP_FUNCTION(frankenphp_handle_request) {
   zend_unset_timeout();
 #endif
 
-  bool continue_handling_requests =
-      go_frankenphp_worker_handle_request_start(thread_index);
-  if (!continue_handling_requests ||
-      frankenphp_worker_request_startup() == FAILURE) {
-    /* Shutting down */
+  bool has_request = go_frankenphp_worker_handle_request_start(thread_index);
+  if (frankenphp_worker_request_startup() == FAILURE
+      /* Shutting down */
+      || !has_request) {
     RETURN_FALSE;
   }
 


### PR DESCRIPTION
Fixes #1441

The issue is: 
After releasing superglobals that have jit, they remain in an 'invalid state' as long as they are not reloaded (`$_SERVER`, `$_ENV`, `$_REQUEST`). Since `$_ENV` is not reloaded in worker mode, accessing the global directly will lead to a segfault.

Extensions like xdebug directly access the $_ENV global on shutdown.

This PR sets `$_ENV` to an empty array on worker script shutdown to fix the segfault. Ideally, `$_ENV` would not be released between requests, but I have not yet found a way to do so without causing a memory leak.