### PR TITLE
metrics/perf: register prometheus metrics only if enabled

### DIFF
--- a/caddy/caddy.go
+++ b/caddy/caddy.go
@@ -83,8 +83,18 @@ func (f FrankenPHPApp) CaddyModule() caddy.ModuleInfo {
 
 // Provision sets up the module.
 func (f *FrankenPHPApp) Provision(ctx caddy.Context) error {
-	f.metrics = frankenphp.NewPrometheusMetrics(ctx.GetMetricsRegistry())
 	f.logger = ctx.Logger()
+
+	httpApp, err := ctx.AppIfConfigured("http")
+	if err != nil {
+		// if the http module is not configured (this should never happen) then collect the metrics by default
+		f.metrics = frankenphp.NewPrometheusMetrics(ctx.GetMetricsRegistry())
+	} else {
+		http := httpApp.(*caddyhttp.App)
+		if http.Metrics != nil {
+			f.metrics = frankenphp.NewPrometheusMetrics(ctx.GetMetricsRegistry())
+		}
+	}
 
 	return nil
 }

--- a/testdata/performance/k6.Caddyfile
+++ b/testdata/performance/k6.Caddyfile
@@ -14,7 +14,6 @@
 		root /go/src/app/testdata
 		php {
 			root /go/src/app/testdata
-			enable_root_symlink false
 		}
 	}
 }

--- a/testdata/performance/perf-test.sh
+++ b/testdata/performance/perf-test.sh
@@ -27,7 +27,7 @@ select filename in ./testdata/performance/*.js; do
 
 	sleep 10
 
-	docker run --entrypoint "" -it -v .:/app -w /app \
+	docker run --entrypoint "" -it --rm -v .:/app -w /app \
 		--add-host "host.docker.internal:host-gateway" \
 		grafana/k6:latest \
 		k6 run -e "CADDY_HOSTNAME=$CADDY_HOSTNAME:8125" "./$filename"


### PR DESCRIPTION
based on this https://github.com/dunglas/frankenphp/pull/1450 PR, i noticed that we do register Prometheus collector even though the user does not define `metrics` directive in Caddyfile

this PR adds a check if `metrics` is configured then it will register the Prometheus collector