### PR TITLE
Docs: Added hide for *.php files to file_server directives.

### DIFF
--- a/docs/cn/config.md
+++ b/docs/cn/config.md
@@ -114,7 +114,9 @@ route {
 	# FrankenPHP!
 	@phpFiles path *.php
 	php @phpFiles
-	file_server
+	file_server {
+		hide *.php
+	}
 }
 ```
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -123,7 +123,9 @@ route {
 	# FrankenPHP!
 	@phpFiles path *.php
 	php @phpFiles
-	file_server
+	file_server {
+		hide *.php
+	}
 }
 ```
 

--- a/docs/fr/config.md
+++ b/docs/fr/config.md
@@ -117,7 +117,9 @@ route {
  # FrankenPHP!
  @phpFiles path *.php
  php @phpFiles
- file_server
+ file_server {
+  hide *.php
+ }
 }
 ```
 

--- a/docs/ru/config.md
+++ b/docs/ru/config.md
@@ -119,7 +119,9 @@ route {
 	# FrankenPHP!
 	@phpFiles path *.php
 	php @phpFiles
-	file_server
+	file_server {
+		hide *.php
+	}
 }
 ```
 

--- a/docs/tr/config.md
+++ b/docs/tr/config.md
@@ -118,7 +118,9 @@ route {
 	# FrankenPHP!
 	@phpFiles path *.php
 	php @phpFiles
-	file_server
+	file_server {
+		hide *.php
+	}
 }
 ```
 

--- a/testdata/Caddyfile
+++ b/testdata/Caddyfile
@@ -28,7 +28,9 @@ http:// {
 		# FrankenPHP!
 		@phpFiles path *.php
 		php @phpFiles
-		file_server
+		file_server {
+			hide *.php
+		}
 
 		respond 404
 	}


### PR DESCRIPTION
This has always spooked me with FrankenPHP.

Thought I'd make a quick documentation PR to help prevent accidental exposure of downloading raw `.php` files when using `file_server`. It's a possible security nightmare if we had an issue with unwanted PHP code downloads, particularly with projects that mix assets with code.

Adds a layer of security in case FrankenPHP has a Caddyfile misconfiguration or issue/crash or encounters any scenario where Caddy might send PHP requests to `file_server`.
