### PR TITLE
Fixes build-static script

### DIFF
--- a/build-static.sh
+++ b/build-static.sh
@@ -150,7 +150,7 @@ else
 		fi
 	fi
 
-	if [ "${SPC_REL_TYPE}" = "binary" && "${arch}" != "arm64" ]; then
+	if [ "${SPC_REL_TYPE}" = "binary" ] && [[ ! "${arch}" =~ arm ]]; then
 		mkdir -p static-php-cli/
 		cd static-php-cli/
 		curl -o spc -fsSL "https://dl.static-php.dev/static-php-cli/spc-bin/nightly/spc-linux-${arch}"

--- a/static-builder-gnu.Dockerfile
+++ b/static-builder-gnu.Dockerfile
@@ -117,7 +117,6 @@ ENV SPC_REL_TYPE='binary'
 
 # not sure if this is needed
 ENV COMPOSER_ALLOW_SUPERUSER=1
-COPY --from=composer/composer:2-bin /composer /usr/bin/composer
 
 WORKDIR /go/src/app
 COPY go.mod go.sum ./


### PR DESCRIPTION
Some small fixes for the build-static script (mostly issues when running the script multiple times)

* If `libphp` is already built, `spcCommand` is not set and causes error when used
* Don't error when trying to create `static-php-cli` directory if it already exists
* spc-bin doesn't have an arm binary. If `SPC_REL_TYPE` is set to `binary` but the arch is arm64, don't download the binary and use source instead