### PR TITLE
feat: add mongodb extension

### DIFF
--- a/build-static.sh
+++ b/build-static.sh
@@ -61,7 +61,7 @@ if [ -z "${PHP_VERSION}" ]; then
 	export PHP_VERSION="8.4"
 fi
 # default extension set
-defaultExtensions="apcu,bcmath,bz2,calendar,ctype,curl,dba,dom,exif,fileinfo,filter,ftp,gd,gmp,gettext,iconv,igbinary,imagick,intl,ldap,mbregex,mbstring,mysqli,mysqlnd,opcache,openssl,parallel,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,protobuf,readline,redis,session,shmop,simplexml,soap,sockets,sodium,sqlite3,ssh2,sysvmsg,sysvsem,sysvshm,tidy,tokenizer,xlswriter,xml,xmlreader,xmlwriter,zip,zlib,yaml,zstd"
+defaultExtensions="apcu,bcmath,bz2,calendar,ctype,curl,dba,dom,exif,fileinfo,filter,ftp,gd,gettext,gmp,iconv,igbinary,imagick,intl,ldap,mbregex,mbstring,mongodb,mysqli,mysqlnd,opcache,openssl,parallel,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,protobuf,readline,redis,session,shmop,simplexml,soap,sockets,sodium,sqlite3,ssh2,sysvmsg,sysvsem,sysvshm,tidy,tokenizer,xlswriter,xml,xmlreader,xmlwriter,yaml,zip,zlib,zstd"
 # if [ "${os}" != "linux" ] || [ "${SPC_LIBC}" = "glibc" ]; then
 # 	defaultExtensions="${defaultExtensions},ffi"
 # fi


### PR DESCRIPTION
Add mongodb to the default list of extensions.

Why? MongoDB is quite popular extension and it's a _pain_ to compile FrankenPHP manually. I've spent a few hours without success as documentation is simply outdated (see https://hub.docker.com/r/dunglas/frankenphp/tags tags are all gnu appended).

Thanks!