### PR TITLE
update certmagic to match caddy

### DIFF
--- a/caddy/go.mod
+++ b/caddy/go.mod
@@ -10,7 +10,7 @@ retract v1.0.0-rc.1 // Human error
 
 require (
 	github.com/caddyserver/caddy/v2 v2.9.1
-	github.com/caddyserver/certmagic v0.22.1
+	github.com/caddyserver/certmagic v0.22.3-0.20250407182622-b9399eadfbe7
 	github.com/dunglas/caddy-cbrotli v1.0.0
 	github.com/dunglas/frankenphp v1.5.0
 	github.com/dunglas/mercure/caddy v0.18.4

--- a/caddy/go.mod
+++ b/caddy/go.mod
@@ -10,7 +10,7 @@ retract v1.0.0-rc.1 // Human error
 
 require (
 	github.com/caddyserver/caddy/v2 v2.9.1
-	github.com/caddyserver/certmagic v0.22.3-0.20250407182622-b9399eadfbe7
+	github.com/caddyserver/certmagic v0.22.1
 	github.com/dunglas/caddy-cbrotli v1.0.0
 	github.com/dunglas/frankenphp v1.5.0
 	github.com/dunglas/mercure/caddy v0.18.4

--- a/caddy/go.mod
+++ b/caddy/go.mod
@@ -10,7 +10,7 @@ retract v1.0.0-rc.1 // Human error
 
 require (
 	github.com/caddyserver/caddy/v2 v2.9.1
-	github.com/caddyserver/certmagic v0.22.0
+	github.com/caddyserver/certmagic v0.22.3-0.20250407182622-b9399eadfbe7
 	github.com/dunglas/caddy-cbrotli v1.0.0
 	github.com/dunglas/frankenphp v1.5.0
 	github.com/dunglas/mercure/caddy v0.18.4


### PR DESCRIPTION
certmagic 0.22.0 fails to build, using the certmagic version in the caddy repo works for me (ubuntu amd64)