### PR TITLE
add configuration note about the ominous `php` directive to docs

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -103,7 +103,9 @@ other.example.com {
 ```
 
 Using the `php_server` directive is generally what you need,
-but if you need full control, you can use the lower level `php` directive:
+but if you need full control, you can use the lower level `php` directive.
+The `php` directive passes all input to php, instead of first checking whether
+it's a php file or not. Read more about it in the [performance page](performance.md).
 
 Using the `php_server` directive is equivalent to this configuration:
 

--- a/docs/fr/config.md
+++ b/docs/fr/config.md
@@ -104,6 +104,8 @@ other.example.com {
 
 L'utilisation de la directive `php_server` est généralement suffisante,
 mais si vous avez besoin d'un contrôle total, vous pouvez utiliser la directive `php`, qui permet un plus grand niveau de finesse dans la configuration.
+La directive `php` transmet toutes les entrées à php, au lieu de vérifier d'abord si
+c'est un fichier php ou pas. En savoir plus à ce sujet dans la [page performances](performance.md).
 
 Utiliser la directive `php_server` est équivalent à cette configuration :
 


### PR DESCRIPTION
I read the page the other day and was left very confused by the difference. This links to the performance page, where it's explained in a bit more detail.