### PR TITLE
docs: add instructions to run Caddyfile from static binary

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -2,8 +2,7 @@
 
 FrankenPHP, Caddy as well as the Mercure and Vulcain modules can be configured using [the formats supported by Caddy](https://caddyserver.com/docs/getting-started#your-first-config).
 
-In [the Docker images](docker.md), the `Caddyfile` is located at `/etc/caddy/Caddyfile`.
-The static binary will look for the `Caddyfile` in the directory in which it is started.
+In [the Docker images](docker.md), the `Caddyfile` is located at `/etc/caddy/Caddyfile`. The static binary will look for the `Caddyfile` in the directory where the `frankenphp run` command is executed. You can specify a custom path with the `-c` or `--config` option.
 
 PHP itself can be configured [using a `php.ini` file](https://www.php.net/manual/en/configuration.file.php).
 


### PR DESCRIPTION
This PR adds a mention about how to run a `Caddyfile` from static binary in config section of documentation