### PR TITLE
docs: remove wildcard matcher from root directive

### DIFF
--- a/caddy/caddy_test.go
+++ b/caddy/caddy_test.go
@@ -280,7 +280,7 @@ func TestPHPServerDirective(t *testing.T) {
 		}
 
 		localhost:`+testPort+` {
-			root * ../testdata
+			root ../testdata
 			php_server
 		}
 		`, "caddyfile")
@@ -304,7 +304,7 @@ func TestPHPServerDirectiveDisableFileServer(t *testing.T) {
 		}
 
 		localhost:`+testPort+` {
-			root * ../testdata
+			root ../testdata
 			php_server {
 				file_server off
 			}

--- a/docs/cn/config.md
+++ b/docs/cn/config.md
@@ -81,12 +81,12 @@ localhost {
 }
 
 app.example.com {
-	root * /path/to/app/public
+	root /path/to/app/public
 	php_server
 }
 
 other.example.com {
-	root * /path/to/other/public
+	root /path/to/other/public
 	php_server
 }
 # ...

--- a/docs/cn/laravel.md
+++ b/docs/cn/laravel.md
@@ -27,7 +27,7 @@ docker run -p 80:80 -p 443:443 -p 443:443/udp -v $PWD:/app dunglas/frankenphp
     # 服务器的域名
     localhost {
     	# 将 webroot 设置为 public/ 目录
-    	root * public/
+    	root public/
     	# 启用压缩(可选)
     	encode zstd br gzip
     	# 执行当前目录中的 PHP 文件并提供资产

--- a/docs/config.md
+++ b/docs/config.md
@@ -89,12 +89,12 @@ You can also define multiple workers if you serve multiple apps on the same serv
 }
 
 app.example.com {
-	root * /path/to/app/public
+	root /path/to/app/public
 	php_server
 }
 
 other.example.com {
-	root * /path/to/other/public
+	root /path/to/other/public
 	php_server
 }
 

--- a/docs/fr/config.md
+++ b/docs/fr/config.md
@@ -53,7 +53,7 @@ En option, le nombre de threads à créer et les [workers](worker.md) à démarr
         num_threads <num_threads> # Définit le nombre de threads PHP à démarrer. Par défaut : 2x le nombre de CPUs disponibles.
         max_threads <num_threads> # Limite le nombre de threads PHP supplémentaires qui peuvent être démarrés au moment de l'exécution. Valeur par défaut : num_threads. Peut être mis à 'auto'.
 		max_wait_time <duration> # Définit le temps maximum pendant lequel une requête peut attendre un thread PHP libre avant d'être interrompue. Valeur par défaut : désactivé.
-        php_ini <key> <value> Définit une directive php.ini. Peut être utilisé plusieurs fois pour définir plusieurs directives.   
+        php_ini <key> <value> Définit une directive php.ini. Peut être utilisé plusieurs fois pour définir plusieurs directives.
         worker {
             file <path> # Définit le chemin vers le script worker.
             num <num> # Définit le nombre de threads PHP à démarrer, par défaut 2x le nombre de CPUs disponibles.
@@ -90,12 +90,12 @@ Vous pouvez aussi définir plusieurs workers si vous servez plusieurs applicatio
 }
 
 app.example.com {
-    root * /path/to/app/public
+    root /path/to/app/public
     php_server
 }
 
 other.example.com {
-    root * /path/to/other/public
+    root /path/to/other/public
     php_server
 }
 

--- a/docs/fr/laravel.md
+++ b/docs/fr/laravel.md
@@ -27,7 +27,7 @@ Vous pouvez également exécuter vos projets Laravel avec FrankenPHP depuis votr
     # Le nom de domaine de votre serveur
     localhost {
     	# Définir le répertoire racine sur le dossier public/
-    	root * public/
+    	root public/
     	# Autoriser la compression (optionnel)
     	encode zstd br gzip
     	# Exécuter les scripts PHP du dossier public/ et servir les assets
@@ -108,7 +108,7 @@ Suivez ces étapes pour empaqueter votre application Laravel en tant que binaire
     # Installez les dépendances
     RUN composer install --ignore-platform-reqs --no-dev -a
 
-    # Construire le binaire statique 
+    # Construire le binaire statique
     WORKDIR /go/src/app/
     RUN EMBED=dist/app/ ./build-static.sh
     ```

--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -27,7 +27,7 @@ Alternatively, you can run your Laravel projects with FrankenPHP from your local
     # The domain name of your server
     localhost {
     	# Set the webroot to the public/ directory
-    	root * public/
+    	root public/
     	# Enable compression (optional)
     	encode zstd br gzip
     	# Execute PHP files from the public/ directory and serve assets

--- a/docs/ru/config.md
+++ b/docs/ru/config.md
@@ -2,7 +2,7 @@
 
 FrankenPHP, Caddy, а также модули Mercure и Vulcain могут быть настроены с использованием [конфигурационных форматов, поддерживаемых Caddy](https://caddyserver.com/docs/getting-started#your-first-config).
 
-В [Docker-образах](docker.md) файл `Caddyfile` находится по пути `/etc/caddy/Caddyfile`.  
+В [Docker-образах](docker.md) файл `Caddyfile` находится по пути `/etc/caddy/Caddyfile`.
 Статический бинарный файл будет искать `Caddyfile` в директории запуска.
 
 PHP можно настроить [с помощью файла `php.ini`](https://www.php.net/manual/en/configuration.file.php).
@@ -86,12 +86,12 @@ localhost {
 }
 
 app.example.com {
-	root * /path/to/app/public
+	root /path/to/app/public
 	php_server
 }
 
 other.example.com {
-	root * /path/to/other/public
+	root /path/to/other/public
 	php_server
 }
 
@@ -152,7 +152,7 @@ php_server [<matcher>] {
 }
 ```
 
-Если директория для `watch` не указана, по умолчанию будет использоваться путь `./**/*.{php,yaml,yml,twig,env}`,  
+Если директория для `watch` не указана, по умолчанию будет использоваться путь `./**/*.{php,yaml,yml,twig,env}`,
 который отслеживает все файлы с расширениями `.php`, `.yaml`, `.yml`, `.twig` и `.env` в директории, где был запущен процесс FrankenPHP, и во всех её поддиректориях. Вы также можете указать одну или несколько директорий с использованием [шаблона имён файлов](https://pkg.go.dev/path/filepath#Match):
 
 ```caddyfile
@@ -169,12 +169,12 @@ php_server [<matcher>] {
 }
 ```
 
-* Шаблон `**` указывает на рекурсивное отслеживание.  
-* Директории могут быть указаны относительно директории запуска FrankenPHP.  
-* Если у вас определено несколько workers, все они будут перезапущены при изменении файлов.  
+* Шаблон `**` указывает на рекурсивное отслеживание.
+* Директории могут быть указаны относительно директории запуска FrankenPHP.
+* Если у вас определено несколько workers, все они будут перезапущены при изменении файлов.
 * Избегайте отслеживания файлов, создаваемых во время выполнения (например, логов), так как это может вызвать нежелательные перезапуски.
 
-Механизм отслеживания файлов основан на [e-dant/watcher](https://github.com/e-dant/watcher).  
+Механизм отслеживания файлов основан на [e-dant/watcher](https://github.com/e-dant/watcher).
 
 ### Полный дуплекс (HTTP/1)
 
@@ -192,7 +192,7 @@ php_server [<matcher>] {
 
 > [!CAUTION]
 >
-> Включение этой опции может привести к зависанию устаревших HTTP/1.x клиентов, которые не поддерживают полный дуплекс.  
+> Включение этой опции может привести к зависанию устаревших HTTP/1.x клиентов, которые не поддерживают полный дуплекс.
 > Настройка также доступна через переменную окружения `CADDY_GLOBAL_OPTIONS`:
 
 ```sh
@@ -207,8 +207,8 @@ CADDY_GLOBAL_OPTIONS="servers {
 
 Следующие переменные окружения могут быть использованы для добавления директив в `Caddyfile` без его изменения:
 
-* `SERVER_NAME`: изменение [адресов для прослушивания](https://caddyserver.com/docs/caddyfile/concepts#addresses); предоставленные хостнеймы также будут использованы для генерации TLS-сертификата.  
-* `CADDY_GLOBAL_OPTIONS`: добавление [глобальных опций](https://caddyserver.com/docs/caddyfile/options).  
+* `SERVER_NAME`: изменение [адресов для прослушивания](https://caddyserver.com/docs/caddyfile/concepts#addresses); предоставленные хостнеймы также будут использованы для генерации TLS-сертификата.
+* `CADDY_GLOBAL_OPTIONS`: добавление [глобальных опций](https://caddyserver.com/docs/caddyfile/options).
 * `FRANKENPHP_CONFIG`: добавление конфигурации в директиву `frankenphp`.
 
 Как и для FPM и CLI SAPIs, переменные окружения по умолчанию доступны в суперглобальной переменной `$_SERVER`.
@@ -217,7 +217,7 @@ CADDY_GLOBAL_OPTIONS="servers {
 
 ## Конфигурация PHP
 
-Для загрузки [дополнительных конфигурационных файлов PHP](https://www.php.net/manual/en/configuration.file.php#configuration.file.scan) можно использовать переменную окружения `PHP_INI_SCAN_DIR`.  
+Для загрузки [дополнительных конфигурационных файлов PHP](https://www.php.net/manual/en/configuration.file.php#configuration.file.scan) можно использовать переменную окружения `PHP_INI_SCAN_DIR`.
 Если она установлена, PHP загрузит все файлы с расширением `.ini`, находящиеся в указанных директориях.
 
 ## Включение режима отладки

--- a/docs/ru/laravel.md
+++ b/docs/ru/laravel.md
@@ -27,7 +27,7 @@ docker run -p 80:80 -p 443:443 -p 443:443/udp -v $PWD:/app dunglas/frankenphp
     # Доменное имя вашего сервера
     localhost {
     	# Укажите веб-корень как директорию public/
-    	root * public/
+    	root public/
     	# Включите сжатие (опционально)
     	encode zstd br gzip
     	# Выполняйте PHP-файлы из директории public/ и обслуживайте статические файлы

--- a/docs/tr/config.md
+++ b/docs/tr/config.md
@@ -84,12 +84,12 @@ Aynı sunucuda birden fazla uygulamaya hizmet veriyorsanız birden fazla işçi 
 }
 
 app.example.com {
-	root * /path/to/app/public
+	root /path/to/app/public
 	php_server
 }
 
 other.example.com {
-	root * /path/to/other/public
+	root /path/to/other/public
 	php_server
 }
 

--- a/docs/tr/laravel.md
+++ b/docs/tr/laravel.md
@@ -27,7 +27,7 @@ Alternatif olarak, Laravel projelerinizi FrankenPHP ile yerel makinenizden çal�
     # Sunucunuzun alan adı
     localhost {
     	# Webroot'u public/ dizinine ayarlayın
-    	root * public/
+    	root public/
     	# Sıkıştırmayı etkinleştir (isteğe bağlı)
     	encode zstd br gzip
     	# PHP dosyalarını public/ dizininden çalıştırın ve varlıkları sunun

--- a/testdata/Caddyfile
+++ b/testdata/Caddyfile
@@ -8,7 +8,7 @@
 http:// {
 	log
 	route {
-		root * .
+		root .
 		# Add trailing slash for directory requests
 		@canonicalPath {
 			file {path}/index.php

--- a/testdata/benchmark.Caddyfile
+++ b/testdata/benchmark.Caddyfile
@@ -4,7 +4,7 @@
 
 http:// {
 	route {
-		root * .
+		root .
 
 		encode zstd br gzip
 


### PR DESCRIPTION
from Caddy docs: https://caddyserver.com/docs/caddyfile/directives/root#examples

> Note that prior to v2.8.0, a [wildcard matcher](https://caddyserver.com/docs/caddyfile/matchers#wildcard-matchers) was required here because the first argument is ambiguous with a [path matcher](https://caddyserver.com/docs/caddyfile/matchers#path-matchers), i.e. `root * /srv`, but it can now be simplified to `root /srv`.
