### PR TITLE
doc: fix -d / --wait arguments

### DIFF
--- a/docs/production.md
+++ b/docs/production.md
@@ -124,7 +124,7 @@ git clone git@github.com:<username>/<project-name>.git
 Go into the directory containing your project (`<project-name>`), and start the app in production mode:
 
 ```console
-docker compose up -d --wait
+docker compose up --wait
 ```
 
 Your server is up and running, and an HTTPS certificate has been automatically generated for you.


### PR DESCRIPTION
--wait includes -d in its behavior. The difference is that -d doesn't necessary wait for the container to be ready --wait does.