### PR TITLE
fix: makes response writer error a debug message.

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -533,7 +533,7 @@ func go_sapi_flush(threadIndex C.uintptr_t) bool {
 	}
 
 	if err := http.NewResponseController(fc.responseWriter).Flush(); err != nil {
-		logger.LogAttrs(context.Background(), slog.LevelDebug, "the current responseWriter is not a flusher", slog.Any("error", err))
+		logger.LogAttrs(context.Background(), slog.LevelWarn, "the current responseWriter is not a flusher", slog.Any("error", err))
 	}
 
 	return false

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -533,7 +533,7 @@ func go_sapi_flush(threadIndex C.uintptr_t) bool {
 	}
 
 	if err := http.NewResponseController(fc.responseWriter).Flush(); err != nil {
-		logger.LogAttrs(context.Background(), slog.LevelWarn, "the current responseWriter is not a flusher", slog.Any("error", err))
+		logger.LogAttrs(context.Background(), slog.LevelWarn, "the current responseWriter is not a flusher, if you are not using a custom build, please report this issue", slog.Any("error", err))
 	}
 
 	return false

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -533,7 +533,7 @@ func go_sapi_flush(threadIndex C.uintptr_t) bool {
 	}
 
 	if err := http.NewResponseController(fc.responseWriter).Flush(); err != nil {
-		logger.LogAttrs(context.Background(), slog.LevelError, "the current responseWriter is not a flusher", slog.Any("error", err))
+		logger.LogAttrs(context.Background(), slog.LevelDebug, "the current responseWriter is not a flusher", slog.Any("error", err))
 	}
 
 	return false


### PR DESCRIPTION
Apparently in some circumstances Caddy will pass a response-writer that is not a flusher. One such instance is the one described in #1543, where the Accel-Redirect request flow results in a response-writer without flusher under HTTP2.

Since this is still a legitimate request flow, the error message should probably be turned into a debug one.