### PR TITLE
fix: flag parsing conflicts

### DIFF
--- a/caddy/php-cli.go
+++ b/caddy/php-cli.go
@@ -19,7 +19,7 @@ func init() {
 		Long: `
 Executes a PHP script similarly to the CLI SAPI.`,
 		CobraFunc: func(cmd *cobra.Command) {
-			cmd.Flags().StringP("code", "r", "", "Execute PHP code directly without <?php ... ?> tags")
+			cmd.DisableFlagParsing = true
 			cmd.RunE = caddycmd.WrapCommandFuncForCobra(cmdPHPCLI)
 		},
 	})
@@ -38,8 +38,8 @@ func cmdPHPCLI(fs caddycmd.Flags) (int, error) {
 	}
 
 	var status int
-	if evalCode := fs.String("code"); evalCode != "" {
-		status = frankenphp.ExecutePHPCode(evalCode)
+	if len(args) == 2 && args[0] == "-r" {
+		status = frankenphp.ExecutePHPCode(args[1])
 	} else {
 		status = frankenphp.ExecuteScriptCLI(args[0], args)
 	}

--- a/caddy/php-cli.go
+++ b/caddy/php-cli.go
@@ -38,7 +38,7 @@ func cmdPHPCLI(fs caddycmd.Flags) (int, error) {
 	}
 
 	var status int
-	if len(args) == 2 && args[0] == "-r" {
+	if len(args) >= 2 && args[0] == "-r" {
 		status = frankenphp.ExecutePHPCode(args[1])
 	} else {
 		status = frankenphp.ExecuteScriptCLI(args[0], args)


### PR DESCRIPTION
Should fix #1557. 

Looks like cobra's flag parsing prevents forwarding flags to PHP.

In the long run it would be nice to just forward this to php-cli