### PR TITLE
Add more example configs in docs

### DIFF
--- a/docs/classic.md
+++ b/docs/classic.md
@@ -8,4 +8,19 @@ The PHP thread pool operates with a fixed number of threads initialized at start
 Queued connections will wait indefinitely until a PHP thread is available to serve them. To prevent that, you can use the `max_wait_time` [configuration](config.md#caddyfile-config) to limit how long a request may wait for a free PHP thread before being rejected.
 Additionally, you can set a reasonable [write timeout in Caddy](https://caddyserver.com/docs/caddyfile/options#timeouts).
 
+Here is how to do it using environment variables:
+
+```
+FRANKENPHP_CONFIG="max_wait_time 2m"
+
+CADDY_GLOBAL_OPTIONS="servers {
+  timeouts {
+    read_body 30s
+    read_header 5s
+    write 30s
+    idle 30s
+  }
+}"
+```
+
 Each Caddy instance will only spin up one FrankenPHP thread pool, which will be shared across all `php_server` blocks.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -15,3 +15,11 @@ When [Caddy metrics](https://caddyserver.com/docs/metrics) are enabled, FrankenP
 - `frankenphp_worker_queue_depth{worker="[worker_name]"}`: The number of queued requests.
 
 For worker metrics, the `[worker_name]` placeholder is replaced by the worker name in the Caddyfile, otherwise absolute path of worker file will be used.
+
+Here is how to enable the metrics using environment variables:
+
+```
+CADDY_GLOBAL_OPTIONS="servers {                                                                                                                                                                                                                                                          read_body 30s                                                                                                                                                                       
+  metrics
+}
+```


### PR DESCRIPTION
1. Added example of setting timeouts to "Using Classic Mode" page.
2. Added example of enabling metrics to "Metrics" page.

Congrats on joining PHP :tada: 