### PR TITLE
docs: default compile without watcher and brotli

### DIFF
--- a/docs/cn/compile.md
+++ b/docs/cn/compile.md
@@ -71,6 +71,11 @@ cd frankenphp-main/caddy/frankenphp
 CGO_CFLAGS=$(php-config --includes) CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" go build
 ```
 
+> [!TIP]
+>
+> 要成功编译，必须安装 brotli 和 watcher 依赖项。
+> 否则，如果不需要它们，请确保添加 `nobrotli,nowatcher` 标记。
+
 ### 使用 xcaddy
 
 你可以使用 [xcaddy](https://github.com/caddyserver/xcaddy) 来编译 [自定义 Caddy 模块](https://caddyserver.com/docs/modules/) 的 FrankenPHP：

--- a/docs/compile.md
+++ b/docs/compile.md
@@ -81,6 +81,11 @@ cd frankenphp-main/caddy/frankenphp
 CGO_CFLAGS=$(php-config --includes) CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" go build -tags=nobadger,nomysql,nopgx
 ```
 
+> [!TIP]
+>
+> The brotli and watcher dependencies need to be installed for compilation to succeed
+> Otherwise make sure to add the `nobrotli,nowatcher` tags if you do not need them.
+
 ### Using xcaddy
 
 Alternatively, use [xcaddy](https://github.com/caddyserver/xcaddy) to compile FrankenPHP with [custom Caddy modules](https://caddyserver.com/docs/modules/):
@@ -107,6 +112,3 @@ xcaddy build \
 > To do so, change the `XCADDY_GO_BUILD_FLAGS` environment variable to something like
 > `XCADDY_GO_BUILD_FLAGS=$'-ldflags "-w -s -extldflags \'-Wl,-z,stack-size=0x80000\'"'`
 > (change the stack size value according to your app needs).
-> 
-> The brotli and watcher dependencies need to be installed for compilation to succeed 
-> Otherwise make sure to add the `nobrotli,nowatcher` tags if you do not need them.

--- a/docs/compile.md
+++ b/docs/compile.md
@@ -78,7 +78,7 @@ You can now build the final binary:
 ```console
 curl -L https://github.com/dunglas/frankenphp/archive/refs/heads/main.tar.gz | tar xz
 cd frankenphp-main/caddy/frankenphp
-CGO_CFLAGS=$(php-config --includes) CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" go build -tags=nobadger,nomysql,nopgx
+CGO_CFLAGS=$(php-config --includes) CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" go build -tags=nobadger,nomysql,nopgx,nobrotli,nowatcher
 ```
 
 ### Using xcaddy
@@ -87,7 +87,7 @@ Alternatively, use [xcaddy](https://github.com/caddyserver/xcaddy) to compile Fr
 
 ```console
 CGO_ENABLED=1 \
-XCADDY_GO_BUILD_FLAGS="-ldflags='-w -s' -tags=nobadger,nomysql,nopgx" \
+XCADDY_GO_BUILD_FLAGS="-ldflags='-w -s' -tags=nobadger,nomysql,nopgx,nobrotli,nowatcher" \
 CGO_CFLAGS=$(php-config --includes) \
 CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" \
 xcaddy build \

--- a/docs/compile.md
+++ b/docs/compile.md
@@ -78,7 +78,7 @@ You can now build the final binary:
 ```console
 curl -L https://github.com/dunglas/frankenphp/archive/refs/heads/main.tar.gz | tar xz
 cd frankenphp-main/caddy/frankenphp
-CGO_CFLAGS=$(php-config --includes) CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" go build -tags=nobadger,nomysql,nopgx,nobrotli,nowatcher
+CGO_CFLAGS=$(php-config --includes) CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" go build -tags=nobadger,nomysql,nopgx
 ```
 
 ### Using xcaddy
@@ -87,7 +87,7 @@ Alternatively, use [xcaddy](https://github.com/caddyserver/xcaddy) to compile Fr
 
 ```console
 CGO_ENABLED=1 \
-XCADDY_GO_BUILD_FLAGS="-ldflags='-w -s' -tags=nobadger,nomysql,nopgx,nobrotli,nowatcher" \
+XCADDY_GO_BUILD_FLAGS="-ldflags='-w -s' -tags=nobadger,nomysql,nopgx" \
 CGO_CFLAGS=$(php-config --includes) \
 CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" \
 xcaddy build \

--- a/docs/compile.md
+++ b/docs/compile.md
@@ -107,3 +107,6 @@ xcaddy build \
 > To do so, change the `XCADDY_GO_BUILD_FLAGS` environment variable to something like
 > `XCADDY_GO_BUILD_FLAGS=$'-ldflags "-w -s -extldflags \'-Wl,-z,stack-size=0x80000\'"'`
 > (change the stack size value according to your app needs).
+> 
+> The brotli and watcher dependencies need to be installed for compilation to succeed 
+> Otherwise make sure to add the `nobrotli,nowatcher` tags if you do not need them.

--- a/docs/fr/compile.md
+++ b/docs/fr/compile.md
@@ -78,7 +78,7 @@ Vous pouvez maintenant compiler FrankenPHP :
 ```console
 curl -L https://github.com/dunglas/frankenphp/archive/refs/heads/main.tar.gz | tar xz
 cd frankenphp-main/caddy/frankenphp
-CGO_CFLAGS=$(php-config --includes) CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" go build -tags=nobadger,nomysql,nopgx,nobrotli,nowatcher
+CGO_CFLAGS=$(php-config --includes) CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" go build -tags=nobadger,nomysql,nopgx
 ```
 
 ### Utiliser xcaddy
@@ -87,7 +87,7 @@ Alternativement, vous pouvez utiliser [xcaddy](https://github.com/caddyserver/xc
 
 ```console
 CGO_ENABLED=1 \
-XCADDY_GO_BUILD_FLAGS="-ldflags='-w -s' -tags=nobadger,nomysql,nopgx,nobrotli,nowatcher" \
+XCADDY_GO_BUILD_FLAGS="-ldflags='-w -s' -tags=nobadger,nomysql,nopgx" \
 CGO_CFLAGS=$(php-config --includes) \
 CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" \
 xcaddy build \

--- a/docs/fr/compile.md
+++ b/docs/fr/compile.md
@@ -81,6 +81,11 @@ cd frankenphp-main/caddy/frankenphp
 CGO_CFLAGS=$(php-config --includes) CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" go build -tags=nobadger,nomysql,nopgx
 ```
 
+> [!TIP]
+>
+> Les dépendances brotli et watcher doivent être installées pour que la compilation réussisse.
+> Sinon, assurez-vous d'ajouter les balises `nobrotli,nowatcher` si vous n'en avez pas besoin.
+
 ### Utiliser xcaddy
 
 Alternativement, vous pouvez utiliser [xcaddy](https://github.com/caddyserver/xcaddy) pour compiler FrankenPHP avec [des modules Caddy additionnels](https://caddyserver.com/docs/modules/) :

--- a/docs/fr/compile.md
+++ b/docs/fr/compile.md
@@ -78,7 +78,7 @@ Vous pouvez maintenant compiler FrankenPHP :
 ```console
 curl -L https://github.com/dunglas/frankenphp/archive/refs/heads/main.tar.gz | tar xz
 cd frankenphp-main/caddy/frankenphp
-CGO_CFLAGS=$(php-config --includes) CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" go build -tags=nobadger,nomysql,nopgx
+CGO_CFLAGS=$(php-config --includes) CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" go build -tags=nobadger,nomysql,nopgx,nobrotli,nowatcher
 ```
 
 ### Utiliser xcaddy
@@ -87,7 +87,7 @@ Alternativement, vous pouvez utiliser [xcaddy](https://github.com/caddyserver/xc
 
 ```console
 CGO_ENABLED=1 \
-XCADDY_GO_BUILD_FLAGS="-ldflags='-w -s' -tags=nobadger,nomysql,nopgx" \
+XCADDY_GO_BUILD_FLAGS="-ldflags='-w -s' -tags=nobadger,nomysql,nopgx,nobrotli,nowatcher" \
 CGO_CFLAGS=$(php-config --includes) \
 CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" \
 xcaddy build \

--- a/docs/ru/compile.md
+++ b/docs/ru/compile.md
@@ -78,7 +78,7 @@ sudo make install
 ```console
 curl -L https://github.com/dunglas/frankenphp/archive/refs/heads/main.tar.gz | tar xz
 cd frankenphp-main/caddy/frankenphp
-CGO_CFLAGS=$(php-config --includes) CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" go build -tags=nobadger,nomysql,nopgx,nobrotli,nowatcher
+CGO_CFLAGS=$(php-config --includes) CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" go build -tags=nobadger,nomysql,nopgx
 ```
 
 ### Использование xcaddy
@@ -87,7 +87,7 @@ CGO_CFLAGS=$(php-config --includes) CGO_LDFLAGS="$(php-config --ldflags) $(php-c
 
 ```console
 CGO_ENABLED=1 \
-XCADDY_GO_BUILD_FLAGS="-ldflags='-w -s' -tags=nobadger,nomysql,nopgx,nobrotli,nowatcher" \
+XCADDY_GO_BUILD_FLAGS="-ldflags='-w -s' -tags=nobadger,nomysql,nopgx" \
 CGO_CFLAGS=$(php-config --includes) \
 CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" \
 xcaddy build \

--- a/docs/ru/compile.md
+++ b/docs/ru/compile.md
@@ -78,7 +78,7 @@ sudo make install
 ```console
 curl -L https://github.com/dunglas/frankenphp/archive/refs/heads/main.tar.gz | tar xz
 cd frankenphp-main/caddy/frankenphp
-CGO_CFLAGS=$(php-config --includes) CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" go build -tags=nobadger,nomysql,nopgx
+CGO_CFLAGS=$(php-config --includes) CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" go build -tags=nobadger,nomysql,nopgx,nobrotli,nowatcher
 ```
 
 ### Использование xcaddy
@@ -87,7 +87,7 @@ CGO_CFLAGS=$(php-config --includes) CGO_LDFLAGS="$(php-config --ldflags) $(php-c
 
 ```console
 CGO_ENABLED=1 \
-XCADDY_GO_BUILD_FLAGS="-ldflags='-w -s' -tags=nobadger,nomysql,nopgx" \
+XCADDY_GO_BUILD_FLAGS="-ldflags='-w -s' -tags=nobadger,nomysql,nopgx,nobrotli,nowatcher" \
 CGO_CFLAGS=$(php-config --includes) \
 CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" \
 xcaddy build \

--- a/docs/ru/compile.md
+++ b/docs/ru/compile.md
@@ -81,6 +81,11 @@ cd frankenphp-main/caddy/frankenphp
 CGO_CFLAGS=$(php-config --includes) CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" go build -tags=nobadger,nomysql,nopgx
 ```
 
+> [!TIP]
+>
+> Для успешной компиляции необходимо установить зависимости brotli и watcher.
+> В противном случае убедитесь, что добавили теги `nobrotli,nowatcher`, если они вам не нужны.
+
 ### Использование xcaddy
 
 Альтернативно, используйте [xcaddy](https://github.com/caddyserver/xcaddy) для компиляции FrankenPHP с [пользовательскими модулями Caddy](https://caddyserver.com/docs/modules/):

--- a/docs/tr/compile.md
+++ b/docs/tr/compile.md
@@ -73,6 +73,11 @@ cd frankenphp-main/caddy/frankenphp
 CGO_CFLAGS=$(php-config --includes) CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)" go build
 ```
 
+> [!TIP]
+>
+> Derlemenin başarılı olması için brotli ve watcher bağımlılıklarının kurulması gerekir.
+> Aksi takdirde, bunlara ihtiyacınız yoksa `nobrotli,nowatcher` etiketlerini eklediğinizden emin olun.
+
 ### Xcaddy kullanımı
 
 Alternatif olarak, FrankenPHP'yi [özel Caddy modülleri](https://caddyserver.com/docs/modules/) ile derlemek için [xcaddy](https://github.com/caddyserver/xcaddy) kullanın:


### PR DESCRIPTION
It probably makes sense to remove `brotli` and `watcher-c` from the default compile instructions in the docs, so they work 'out of the box'.

Might avoid issues like #1562 in the future when people are first trying to build with xcaddy.