### PR TITLE
ci: always login to the Docker Hub to mitigate rate limiting issues

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -133,7 +133,6 @@ jobs:
         with:
           platforms: ${{ matrix.platform }}
       - name: Login to DockerHub
-        if: fromJson(needs.prepare.outputs.push)
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.REGISTRY_USERNAME }}

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -100,7 +100,6 @@ jobs:
         with:
           platforms: ${{ matrix.platform }}
       - name: Login to DockerHub
-        if: ${{ fromJson(needs.prepare.outputs.push) && !matrix.debug && !matrix.mimalloc }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -204,7 +203,6 @@ jobs:
         with:
           platforms: ${{ matrix.platform }}
       - name: Login to DockerHub
-        if: ${{ fromJson(needs.prepare.outputs.push) }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.REGISTRY_USERNAME }}


### PR DESCRIPTION
This should increase the limit: https://docs.docker.com/docker-hub/usage/#how-can-i-check-my-current-rate