### PR TITLE
fix(docker): prevent BC break with the new Caddyfile path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,14 @@ RUN set -eux; \
 		/app/public \
 		/config/caddy \
 		/data/caddy \
+		/etc/caddy; \
 		/etc/frankenphp; \
 	sed -i 's/php/frankenphp run/g' /usr/local/bin/docker-php-entrypoint; \
 	echo '<?php phpinfo();' > /app/public/index.php
 
-COPY --link caddy/frankenphp/Caddyfile /etc/frankenphp/Caddyfile
-RUN curl -sSLf \
+COPY --link caddy/frankenphp/Caddyfile /etc/caddy/Caddyfile
+RUN ln /etc/caddy/Caddyfile /etc/frankenphp/Caddyfile && \
+	curl -sSLf \
 		-o /usr/local/bin/install-php-extensions \
 		https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions && \
 	chmod +x /usr/local/bin/install-php-extensions

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -18,12 +18,15 @@ RUN set -eux; \
 		/app/public \
 		/config/caddy \
 		/data/caddy \
+		/etc/caddy \
 		/etc/frankenphp; \
 	sed -i 's/php/frankenphp run/g' /usr/local/bin/docker-php-entrypoint; \
 	echo '<?php phpinfo();' > /app/public/index.php
 
-COPY --link caddy/frankenphp/Caddyfile /etc/frankenphp/Caddyfile
-RUN curl -sSLf \
+COPY --link caddy/frankenphp/Caddyfile /etc/caddy/Caddyfile
+
+RUN ln /etc/caddy/Caddyfile /etc/frankenphp/Caddyfile && \
+	curl -sSLf \
 		-o /usr/local/bin/install-php-extensions \
 		https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions && \
 	chmod +x /usr/local/bin/install-php-extensions


### PR DESCRIPTION
Closes #1583.

Should fix a BC break introduced by the change of the `Caddyfile` path in https://github.com/dunglas/frankenphp/pull/1497.

cc @henderkes
