### PR TITLE
feat(watcher): allow omitting value with the `--watch` flag

### DIFF
--- a/caddy/php-server.go
+++ b/caddy/php-server.go
@@ -28,7 +28,7 @@ import (
 func init() {
 	caddycmd.RegisterCommand(caddycmd.Command{
 		Name:  "php-server",
-		Usage: "[--domain <example.com>] [--root <path>] [--listen <addr>] [--worker /path/to/worker.php<,nb-workers>] [--watch <paths...>] [--access-log] [--debug] [--no-compress] [--mercure]",
+		Usage: "[--domain <example.com>] [--root <path>] [--listen <addr>] [--worker /path/to/worker.php<,nb-workers>] [--watch[=<paths,...>]] [--access-log] [--debug] [--no-compress] [--mercure]",
 		Short: "Spins up a production-ready PHP server",
 		Long: `
 A simple but production-ready PHP server. Useful for quick deployments,
@@ -47,11 +47,14 @@ For more advanced use cases, see https://github.com/dunglas/frankenphp/blob/main
 			cmd.Flags().StringP("root", "r", "", "The path to the root of the site")
 			cmd.Flags().StringP("listen", "l", "", "The address to which to bind the listener")
 			cmd.Flags().StringArrayP("worker", "w", []string{}, "Worker script")
-			cmd.Flags().StringArrayP("watch", "", []string{}, "Directory to watch for file changes")
+			cmd.Flags().StringSlice("watch", []string{}, "Glob pattern of directories and files to watch for changes")
 			cmd.Flags().BoolP("access-log", "a", false, "Enable the access log")
 			cmd.Flags().BoolP("debug", "v", false, "Enable verbose debug logs")
 			cmd.Flags().BoolP("mercure", "m", false, "Enable the built-in Mercure.rocks hub")
-			cmd.Flags().BoolP("no-compress", "", false, "Disable Zstandard, Brotli and Gzip compression")
+			cmd.Flags().Bool("no-compress", false, "Disable Zstandard, Brotli and Gzip compression")
+
+			cmd.Flags().Lookup("watch").NoOptDefVal = "\"" + defaultWatchPattern + "\""
+
 			cmd.RunE = caddycmd.WrapCommandFuncForCobra(cmdPHPServer)
 		},
 	})
@@ -73,7 +76,7 @@ func cmdPHPServer(fs caddycmd.Flags) (int, error) {
 	if err != nil {
 		panic(err)
 	}
-	watch, err := fs.GetStringArray("watch")
+	watch, err := fs.GetStringSlice("watch")
 	if err != nil {
 		panic(err)
 	}

--- a/docs/fr/worker.md
+++ b/docs/fr/worker.md
@@ -32,7 +32,7 @@ Il est également possible de [redémarrer le worker en cas de changement de fic
 La commande suivante déclenchera un redémarrage si un fichier se terminant par `.php` dans le répertoire `/path/to/your/app/` ou ses sous-répertoires est modifié :
 
 ```console
-frankenphp php-server --worker /path/to/your/worker/script.php --watch "/path/to/your/app/**/*.php"
+frankenphp php-server --worker /path/to/your/worker/script.php --watch="/path/to/your/app/**/*.php"
 ```
 
 ## Runtime Symfony

--- a/docs/ru/worker.md
+++ b/docs/ru/worker.md
@@ -32,7 +32,7 @@ frankenphp php-server --worker /path/to/your/worker/script.php
 Следующая команда выполнит перезапуск, если будет изменён любой файл с расширением `.php` в директории `/path/to/your/app/` или её поддиректориях:
 
 ```console
-frankenphp php-server --worker /path/to/your/worker/script.php --watch "/path/to/your/app/**/*.php"
+frankenphp php-server --worker /path/to/your/worker/script.php --watch="/path/to/your/app/**/*.php"
 ```
 
 ## Symfony Runtime

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -32,7 +32,7 @@ It's also possible to [restart the worker on file changes](config.md#watching-fo
 The following command will trigger a restart if any file ending in `.php` in the `/path/to/your/app/` directory or subdirectories is modified:
 
 ```console
-frankenphp php-server --worker /path/to/your/worker/script.php --watch "/path/to/your/app/**/*.php"
+frankenphp php-server --worker /path/to/your/worker/script.php --watch="/path/to/your/app/**/*.php"
 ```
 
 ## Symfony Runtime


### PR DESCRIPTION
I suggest updating the `--watch` flag so it can be used without value, falling back on the default watch pattern `./**/*.{php,yaml,yml,twig,env}`.

Because of how pflags works, this change also implies that when passing a value to `--watch`, an equal sign must be added between the flag and its value, e.g. `--watch="custom-dir/*.php"`. This is a known "issue" as using `NoOptDefVal` on a flag makes it ambiguous to parse if `=` isn't provided (see https://github.com/spf13/cobra/issues/866#issuecomment-1585815287).

With this PR, the flag becomes a string slice instead of a string array, meaning each value must be separated by a coma. This "breaking change" seems worthy to me and looks fine as `--watch` should be mostly used in dev environment.