### PR TITLE
chore: bump `actions/download-artifact`

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -223,7 +223,7 @@ jobs:
         target: ["builder", "runner"]
     steps:
       - name: Download metadata
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: metadata-${{ matrix.target }}-${{ matrix.variant }}-*
           path: /tmp/metadata

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -307,13 +307,13 @@ jobs:
     if: fromJson(needs.prepare.outputs.push)
     steps:
       - name: Download metadata
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: metadata-static-builder-musl-*
           path: /tmp/metadata
           merge-multiple: true
       - name: Download GNU metadata
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: metadata-static-builder-gnu-*
           path: /tmp/metadata-gnu


### PR DESCRIPTION
Meant to replace https://github.com/php/frankenphp/pull/1803. Let's start by bumping `actions/download-artifact` only. Superlinter is handled in #1813 