### PR TITLE
chore: bump `super-linter/super-linter/slim` to 8.0.0

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7.4.0
+        uses: super-linter/super-linter/slim@v8.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: /

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ The image contains the usual development tools (Go, GDB, Valgrind, Neovim...) an
 - additional configuration files: `/etc/frankenphp/php.d/*.ini`
 - php extensions: `/usr/lib/frankenphp/modules/`
 
-If your docker version is lower than 23.0, the build will fail due to dockerignore [pattern issue](https://github.com/moby/moby/pull/42676). Add directories to `.dockerignore`.
+If your Docker version is lower than 23.0, the build will fail due to dockerignore [pattern issue](https://github.com/moby/moby/pull/42676). Add directories to `.dockerignore`.
 
 ```patch
  !testdata/*.php
@@ -195,7 +195,7 @@ docker buildx bake -f docker-bake.hcl --pull --no-cache --push
 ## Docker-Related Resources
 
 - [Bake file definition](https://docs.docker.com/build/customize/bake/file-definition/)
-- [docker buildx build](https://docs.docker.com/engine/reference/commandline/buildx_build/)
+- [`docker buildx build`](https://docs.docker.com/engine/reference/commandline/buildx_build/)
 
 ## Useful Command
 

--- a/docs/cn/CONTRIBUTING.md
+++ b/docs/cn/CONTRIBUTING.md
@@ -17,7 +17,7 @@ docker run --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -p 8080:8080 -
 - 附加配置文件: `/etc/frankenphp/php.d/*.ini`
 - php 扩展: `/usr/lib/frankenphp/modules/`
 
-如果你的 docker 版本低于 23.0，则会因为 dockerignore [pattern issue](https://github.com/moby/moby/pull/42676) 而导致构建失败。将目录添加到 `.dockerignore`。
+如果你的 Docker 版本低于 23.0，则会因为 dockerignore [pattern issue](https://github.com/moby/moby/pull/42676) 而导致构建失败。将目录添加到 `.dockerignore`。
 
 ```patch
  !testdata/*.php
@@ -195,7 +195,7 @@ docker buildx bake -f docker-bake.hcl --pull --no-cache --push
 ## Docker 相关资源
 
 - [Bake 文件定义](https://docs.docker.com/build/customize/bake/file-definition/)
-- [docker buildx 构建](https://docs.docker.com/engine/reference/commandline/buildx_build/)
+- [`docker buildx build`](https://docs.docker.com/engine/reference/commandline/buildx_build/)
 
 ## 有用的命令
 

--- a/docs/cn/github-actions.md
+++ b/docs/cn/github-actions.md
@@ -7,7 +7,7 @@
 
 在存储库设置中的 `secrets` 下，添加以下字段：
 
-- `REGISTRY_LOGIN_SERVER`: 要使用的 docker registry（如 `docker.io`）。
+- `REGISTRY_LOGIN_SERVER`: 要使用的 Docker registry（如 `docker.io`）。
 - `REGISTRY_USERNAME`: 用于登录 registry 的用户名（如 `dunglas`）。
 - `REGISTRY_PASSWORD`: 用于登录 registry 的密码（如 `access key`）。
 - `IMAGE_NAME`: 镜像的名称（如 `dunglas/frankenphp`）。

--- a/docs/cn/known-issues.md
+++ b/docs/cn/known-issues.md
@@ -23,7 +23,7 @@
 
 ## 独立的二进制和基于 Alpine 的 Docker 镜像
 
-独立的二进制文件和基于 Alpine 的 docker 镜像 (`dunglas/frankenphp:*-alpine`) 使用的是 [musl libc](https://musl.libc.org/) 而不是 [glibc and friends](https://www.etalabs.net/compare_libcs.html)，为的是保持较小的二进制大小。这可能会导致一些兼容性问题。特别是，glob 标志 `GLOB_BRACE` [不可用](https://www.php.net/manual/en/function.glob.php)。
+独立的二进制文件和基于 Alpine 的 Docker 镜像 (`dunglas/frankenphp:*-alpine`) 使用的是 [musl libc](https://musl.libc.org/) 而不是 [glibc and friends](https://www.etalabs.net/compare_libcs.html)，为的是保持较小的二进制大小。这可能会导致一些兼容性问题。特别是，glob 标志 `GLOB_BRACE` [不可用](https://www.php.net/manual/en/function.glob.php)。
 
 ## 在 Docker 中使用 `https://127.0.0.1`
 

--- a/docs/fr/CONTRIBUTING.md
+++ b/docs/fr/CONTRIBUTING.md
@@ -197,7 +197,7 @@ docker buildx bake -f docker-bake.hcl --pull --no-cache --push
 ## Ressources Liées à Docker
 
 - [Définition du fichier Bake](https://docs.docker.com/build/customize/bake/file-definition/)
-- [docker buildx build](https://docs.docker.com/engine/reference/commandline/buildx_build/)
+- [`docker buildx build`](https://docs.docker.com/engine/reference/commandline/buildx_build/)
 
 ## Commande utile
 

--- a/docs/fr/known-issues.md
+++ b/docs/fr/known-issues.md
@@ -23,7 +23,7 @@ La fonction [get_browser()](https://www.php.net/manual/fr/function.get-browser.p
 
 ## Binaire autonome et images Docker basées sur Alpine
 
-Le binaire autonome et les images docker basées sur Alpine (`dunglas/frankenphp:*-alpine`) utilisent [musl libc](https://musl.libc.org/) au lieu de [glibc et ses amis](https://www.etalabs.net/compare_libcs.html), pour garder une taille de binaire plus petite. Cela peut entraîner des problèmes de compatibilité. En particulier, le drapeau glob `GLOB_BRACE` n'est [pas disponible](https://www.php.net/manual/fr/function.glob.php).
+Le binaire autonome et les images Docker basées sur Alpine (`dunglas/frankenphp:*-alpine`) utilisent [musl libc](https://musl.libc.org/) au lieu de [glibc et ses amis](https://www.etalabs.net/compare_libcs.html), pour garder une taille de binaire plus petite. Cela peut entraîner des problèmes de compatibilité. En particulier, le drapeau glob `GLOB_BRACE` n'est [pas disponible](https://www.php.net/manual/fr/function.glob.php).
 
 ## Utilisation de `https://127.0.0.1` avec Docker
 
@@ -130,7 +130,7 @@ pour trouver l'endroit où les certificats CA doivent être installés et stocke
 > Les contextes Web et CLI peuvent avoir des paramètres différents.
 > Assurez-vous d'exécuter `openssl_get_cert_locations()` dans le bon contexte.
 
-[Les certificats CA extraits de Mozilla peuvent être téléchargés sur le site curl](https://curl.se/docs/caextract.html).
+[Les certificats CA extraits de Mozilla peuvent être téléchargés sur le site de cURL](https://curl.se/docs/caextract.html).
 
 Alternativement, de nombreuses distributions, y compris Debian, Ubuntu, et Alpine fournissent des paquets nommés `ca-certificates` qui contiennent ces certificats.
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -7,7 +7,7 @@ every approved pull request or on your own fork once setup.
 
 In the repository settings, under secrets, add the following secrets:
 
-- `REGISTRY_LOGIN_SERVER`: The docker registry to use (e.g. `docker.io`).
+- `REGISTRY_LOGIN_SERVER`: The Docker registry to use (e.g. `docker.io`).
 - `REGISTRY_USERNAME`: The username to use to log in to the registry (e.g. `dunglas`).
 - `REGISTRY_PASSWORD`: The password to use to log in to the registry (e.g. an access key).
 - `IMAGE_NAME`: The name of the image (e.g. `dunglas/frankenphp`).

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -23,7 +23,7 @@ The [get_browser()](https://www.php.net/manual/en/function.get-browser.php) func
 
 ## Standalone Binary and Alpine-based Docker Images
 
-The standalone binary and Alpine-based docker images (`dunglas/frankenphp:*-alpine`) use [musl libc](https://musl.libc.org/) instead of [glibc and friends](https://www.etalabs.net/compare_libcs.html), to keep a smaller binary size. This may lead to some compatibility issues. In particular, the glob flag `GLOB_BRACE` is [not available](https://www.php.net/manual/en/function.glob.php)
+The standalone binary and Alpine-based Docker images (`dunglas/frankenphp:*-alpine`) use [musl libc](https://musl.libc.org/) instead of [glibc and friends](https://www.etalabs.net/compare_libcs.html), to keep a smaller binary size. This may lead to some compatibility issues. In particular, the glob flag `GLOB_BRACE` is [not available](https://www.php.net/manual/en/function.glob.php)
 
 ## Using `https://127.0.0.1` with Docker
 
@@ -130,7 +130,7 @@ to find where CA certificates must be installed and store them at this location.
 > Web and CLI contexts may have different settings.
 > Be sure to run `openssl_get_cert_locations()` in the proper context.
 
-[CA certificates extracted from Mozilla can be downloaded on the curl site](https://curl.se/docs/caextract.html).
+[CA certificates extracted from Mozilla can be downloaded on the cURL site](https://curl.se/docs/caextract.html).
 
 Alternatively, many distributions, including Debian, Ubuntu, and Alpine provide packages named `ca-certificates` that contain these certificates.
 

--- a/docs/ru/known-issues.md
+++ b/docs/ru/known-issues.md
@@ -127,7 +127,7 @@ error:0A000086:SSL routines::certificate verify failed
 > Веб и CLI контексты могут иметь разные настройки.  
 > Запустите `openssl_get_cert_locations()` в нужном контексте.
 
-[Сертификаты CA, извлечённые из Mozilla, можно скачать с сайта curl](https://curl.se/docs/caextract.html).
+[Сертификаты CA, извлечённые из Mozilla, можно скачать с сайта cURL](https://curl.se/docs/caextract.html).
 
 Кроме того, многие дистрибутивы, такие как Debian, Ubuntu и Alpine, предоставляют пакеты `ca-certificates`, содержащие эти сертификаты.
 

--- a/docs/tr/CONTRIBUTING.md
+++ b/docs/tr/CONTRIBUTING.md
@@ -196,7 +196,7 @@ docker buildx bake -f docker-bake.hcl --pull --no-cache --push
 ## Docker ile İlgili Kaynaklar
 
 - [Pişirme (bake) dosya tanımı](https://docs.docker.com/build/customize/bake/file-definition/)
-- [docker buildx build](https://docs.docker.com/engine/reference/commandline/buildx_build/)
+- [`docker buildx build`](https://docs.docker.com/engine/reference/commandline/buildx_build/)
 
 ## Faydalı Komut
 

--- a/testdata/performance/performance-testing.md
+++ b/testdata/performance/performance-testing.md
@@ -7,7 +7,7 @@ Go the root of this repository and run:
 bash testdata/performance/perf-test.sh
 ```
 
-This will build the `frankenphp-dev` docker image and run it under the name 'load-test-container'
+This will build the `frankenphp-dev` Docker image and run it under the name 'load-test-container'
 in the background. Additionally, it will run the `grafana/k6` container, and you'll be able to choose
 the load test you want to run. A `flamegraph.svg` will be created in the `testdata/performance` directory.
 


### PR DESCRIPTION
The upgrade requires the following changes:
- `docker` => `Docker`
- `curl` => `cURL`