### PR TITLE
fix: added missing decrement for the "ready" WaitGroup counter

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -149,6 +149,7 @@ func drainWorkerThreads() []*phpThread {
 		ready.Add(len(worker.threads))
 		for _, thread := range worker.threads {
 			if !thread.state.requestSafeStateChange(stateRestarting) {
+				ready.Done()
 				// no state change allowed == thread is shutting down
 				// we'll proceed to restart all other threads anyways
 				continue


### PR DESCRIPTION
missing `ready.Done()` decrement before `continue` statement in the `for` loop prevents `ready.Wait()` to release and leads to a deadlock