### PR TITLE
Release but don't free CLI streams when executing cli scripts

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -1041,8 +1041,7 @@ static char **cli_argv;
  * <johannes@php.net> Parts based on CGI SAPI Module by Rasmus Lerdorf, Stig
  * Bakken and Zeev Suraski
  */
-static void cli_register_file_handles(void)
-{
+static void cli_register_file_handles(void) {
   php_stream *s_in, *s_out, *s_err;
   php_stream_context *sc_in = NULL, *sc_out = NULL, *sc_err = NULL;
   zend_constant ic, oc, ec;
@@ -1055,9 +1054,12 @@ static void cli_register_file_handles(void)
    * extensions which write to stderr or company during mshutdown/gshutdown
    * won't have the expected functionality.
    */
-  if (s_in) s_in->flags |= PHP_STREAM_FLAG_NO_RSCR_DTOR_CLOSE;
-  if (s_out) s_out->flags |= PHP_STREAM_FLAG_NO_RSCR_DTOR_CLOSE;
-  if (s_err) s_err->flags |= PHP_STREAM_FLAG_NO_RSCR_DTOR_CLOSE;
+  if (s_in)
+    s_in->flags |= PHP_STREAM_FLAG_NO_RSCR_DTOR_CLOSE;
+  if (s_out)
+    s_out->flags |= PHP_STREAM_FLAG_NO_RSCR_DTOR_CLOSE;
+  if (s_err)
+    s_err->flags |= PHP_STREAM_FLAG_NO_RSCR_DTOR_CLOSE;
 
   if (s_in == NULL || s_out == NULL || s_err == NULL) {
     if (s_in)


### PR DESCRIPTION
I think this closes out https://github.com/php/frankenphp/issues/590 if I'm not mistaken.

Here's the diff:
```
package main

import (
	"fmt"

	"github.com/dunglas/frankenphp"
)

func main() {
	fmt.Println("starting...")

	phpScript := "file_put_contents('test.log', 'SUCCESS\n', FILE_APPEND | LOCK_EX); echo 'Hello, World!';"
	sc1 := frankenphp.ExecutePHPCode(phpScript)
	fmt.Printf("script 1 finished with status code: %d\n", sc1)
	sc2 := frankenphp.ExecutePHPCode(phpScript)
	fmt.Printf("script 2 finished with status code: %d\n", sc2)
	fmt.Println("finished!")
}
```

When run on main gets me...
```
# ./main 
starting...
Hello, World!
```

which looks like it exited early (but it didn't)

When run on my branch gets me...
```
./main 
starting...
Hello, World!script 1 finished with status code: 0
Hello, World!script 2 finished with status code: 0
finished!
```

But, in both cases they successfully log to test.log with:
```
SUCCESS
SUCCESS
```

I'm still getting my test env setup enough to write a unit test, but I'm relatively confident this fixes the problem, I'm just not sure if this change has any undesirable side effects.