### PR TITLE
fix: catches panic on invalid status code

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -480,7 +480,7 @@ func go_write_headers(threadIndex C.uintptr_t, status C.int, headers *C.zend_lli
 	// go panics on invalid status code
 	// https://github.com/golang/go/blob/9b8742f2e79438b9442afa4c0a0139d3937ea33f/src/net/http/server.go#L1162
 	if goStatus < 100 || goStatus > 999 {
-		logger.Error(fmt.Sprintf("Invalid response status code %v", goStatus))
+		logger.Warn(fmt.Sprintf("Invalid response status code %v", goStatus))
 		goStatus = 500
 	}
 


### PR DESCRIPTION
Fixes #1907 by avoiding [this panic](https://github.com/golang/go/blob/9b8742f2e79438b9442afa4c0a0139d3937ea33f/src/net/http/server.go#L1162).

I actually like that go panics here, but there might be edge cases where PHP legitimately sends a wrong status code.