### PR TITLE
Fix typo in method name in example usage

### DIFF
--- a/docs/mercure.md
+++ b/docs/mercure.md
@@ -64,7 +64,7 @@ To dispatch an update to connected subscribers, send an authenticated POST reque
 
 const JWT = 'eyJhbGciOiJIUzI1NiJ9.eyJtZXJjdXJlIjp7InB1Ymxpc2giOlsiKiJdfX0.PXwpfIGng6KObfZlcOXvcnWCJOWTFLtswGI5DZuWSK4';
 
-$updateID = file_get_contents('https://localhost/.well-known/mercure', context: stream_context_create(['http' => [
+$updateID = file_put_contents('https://localhost/.well-known/mercure', context: stream_context_create(['http' => [
     'method'  => 'POST',
     'header'  => "Content-type: application/x-www-form-urlencoded\r\nAuthorization: Bearer " . JWT,
     'content' => http_build_query([


### PR DESCRIPTION
The heading mentions `file_put_contents()` but the example mentioned `file_get_contents()`.