### PR TITLE
docs: Document gettext incompatibility

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -8,6 +8,7 @@ The following extensions are known not to be compatible with FrankenPHP:
 | ----------------------------------------------------------------------------------------------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------- |
 | [imap](https://www.php.net/manual/en/imap.installation.php)                                                 | Not thread-safe | [javanile/php-imap2](https://github.com/javanile/php-imap2), [webklex/php-imap](https://github.com/Webklex/php-imap) |
 | [newrelic](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/introduction-new-relic-php/) | Not thread-safe | -                                                                                                                    |
+| [gettext](https://www.php.net/manual/en/gettext.installation.php)                                           | Not thread-safe | [gettext/gettext](https://github.com/php-gettext/Gettext)                                                            |
 
 ## Buggy PHP Extensions
 


### PR DESCRIPTION
[gettext](https://www.php.net/manual/en/gettext.installation.php) is not thread safe and can only load a single locale per process, this causes a mix and match of languages to be returned from translations.

https://stackoverflow.com/a/1646343