### PR TITLE
feat: set a custom Server header

### DIFF
--- a/caddy/module.go
+++ b/caddy/module.go
@@ -22,6 +22,8 @@ import (
 	"github.com/dunglas/frankenphp/internal/fastabs"
 )
 
+var serverHeader = []string{"FrankenPHP Caddy"}
+
 // FrankenPHPModule represents the "php_server" and "php" directives in the Caddyfile
 // they are responsible for forwarding requests to FrankenPHP via "ServeHTTP"
 //
@@ -197,6 +199,8 @@ func (f *FrankenPHPModule) ServeHTTP(w http.ResponseWriter, r *http.Request, _ c
 		return caddyhttp.Error(http.StatusInternalServerError, err)
 	}
 
+	// TODO: set caddyhttp.ServerHeader when https://github.com/caddyserver/caddy/pull/7338 will be released
+	w.Header()["Server"] = serverHeader
 	if err = frankenphp.ServeHTTP(w, fr); err != nil && !errors.As(err, &frankenphp.ErrRejected{}) {
 		return caddyhttp.Error(http.StatusInternalServerError, err)
 	}

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -41,8 +41,6 @@ import (
 
 type contextKeyStruct struct{}
 
-var contextKey = contextKeyStruct{}
-
 var (
 	ErrInvalidRequest         = errors.New("not a FrankenPHP request")
 	ErrAlreadyStarted         = errors.New("FrankenPHP is already started")
@@ -55,6 +53,9 @@ var (
 	ErrInvalidRequestPath         = ErrRejected{"invalid request path", http.StatusBadRequest}
 	ErrInvalidContentLengthHeader = ErrRejected{"invalid Content-Length header", http.StatusBadRequest}
 	ErrMaxWaitTimeExceeded        = ErrRejected{"maximum request handling time exceeded", http.StatusServiceUnavailable}
+
+	contextKey   = contextKeyStruct{}
+	serverHeader = []string{"FrankenPHP"}
 
 	isRunning        bool
 	onServerShutdown []func()
@@ -333,6 +334,11 @@ func Shutdown() {
 
 // ServeHTTP executes a PHP script according to the given context.
 func ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) error {
+	h := responseWriter.Header()
+	if h["Server"] == nil {
+		h["Server"] = serverHeader
+	}
+
 	if !isRunning {
 		return ErrNotRunning
 	}


### PR DESCRIPTION
Will allow to track FrankenPHP usage in the wild (currently, it is identified as Caddy).

cc @mholt 