### PR TITLE
fix(extgen): don't remove everything in the build directory now that there's no build subdir

### DIFF
--- a/internal/extgen/generator.go
+++ b/internal/extgen/generator.go
@@ -50,10 +50,6 @@ func (g *Generator) Generate() error {
 }
 
 func (g *Generator) setupBuildDirectory() error {
-	if err := os.RemoveAll(g.BuildDir); err != nil {
-		return fmt.Errorf("removing build directory: %w", err)
-	}
-
 	return os.MkdirAll(g.BuildDir, 0755)
 }
 

--- a/internal/extgen/gofile.go
+++ b/internal/extgen/gofile.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
+	"os"
 	"path/filepath"
 	"text/template"
 
@@ -30,6 +31,16 @@ type goTemplateData struct {
 
 func (gg *GoFileGenerator) generate() error {
 	filename := filepath.Join(gg.generator.BuildDir, gg.generator.BaseName+".go")
+
+	if _, err := os.Stat(filename); err == nil {
+		backupFilename := filename + ".bak"
+		if err := os.Rename(filename, backupFilename); err != nil {
+			return fmt.Errorf("backing up existing Go file: %w", err)
+		}
+
+		gg.generator.SourceFile = backupFilename
+	}
+
 	content, err := gg.buildContent()
 	if err != nil {
 		return fmt.Errorf("building Go file content: %w", err)


### PR DESCRIPTION
Now that there's no more build subdirectory, we shouldn't try to clean things up, as it removes everything in the extension directory. Instead, I propose to rename the original source file to <filename>.go.src to keep track of it, before generating the actual extension file with the original name.