### PR TITLE
fix(extgen): replace `any` by `interface{}` in the generated go file when dealing with handles

### DIFF
--- a/internal/extgen/templates/extension.go.tpl
+++ b/internal/extgen/templates/extension.go.tpl
@@ -43,13 +43,13 @@ type {{.GoStruct}} struct {
 {{- end}}
 {{- if .Classes}}
 //export registerGoObject
-func registerGoObject(obj any) C.uintptr_t {
+func registerGoObject(obj interface{}) C.uintptr_t {
 	handle := cgo.NewHandle(obj)
 	return C.uintptr_t(handle)
 }
 
 //export getGoObject
-func getGoObject(handle C.uintptr_t) any {
+func getGoObject(handle C.uintptr_t) interface{} {
 	h := cgo.Handle(handle)
 	return h.Value()
 }


### PR DESCRIPTION
Necessary for a successful build.