### PR TITLE
feat(types): expose `IsPacked` to help dealing with hashmaps and lists in Go code

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -212,7 +212,7 @@ func process_data_packed(arr *C.zend_array) unsafe.Pointer {
 - `frankenphp.GoAssociativeArray(arr unsafe.Pointer, ordered bool) frankenphp.AssociativeArray` - Convert a PHP array to an ordered Go `AssociativeArray` (map with order)
 - `frankenphp.GoMap(arr unsafe.Pointer) map[string]any` - Convert a PHP array to an unordered Go map
 - `frankenphp.GoPackedArray(arr unsafe.Pointer) []any` - Convert a PHP array to a Go slice
-- `frankenphp.IsPacked(zval unsafe.Pointer) bool` - Check if a PHP array is packed (indexed only) or associative (key-value pairs)
+- `frankenphp.IsPacked(zval *C.zend_array) bool` - Check if a PHP array is packed (indexed only) or associative (key-value pairs)
 
 ### Working with Callables
 

--- a/docs/fr/extensions.md
+++ b/docs/fr/extensions.md
@@ -209,6 +209,7 @@ func process_data_packed(arr *C.zval) unsafe.Pointer {
 - `frankenphp.GoAssociativeArray(arr unsafe.Pointer, ordered bool) frankenphp.AssociativeArray` - Convertir un tableau PHP vers un `AssociativeArray` Go ordonné (map avec ordre)
 - `frankenphp.GoMap(arr unsafe.Pointer) map[string]any` - Convertir un tableau PHP vers une map Go non ordonnée
 - `frankenphp.GoPackedArray(arr unsafe.Pointer) []any` - Convertir un tableau PHP vers un slice Go
+- `frankenphp.IsPacked(zval *C.zend_array) bool` - Vérifie si le tableau PHP est une liste ou un tableau associatif
 
 ### Travailler avec des Callables
 

--- a/types.go
+++ b/types.go
@@ -416,24 +416,14 @@ func createNewArray(size uint32) *C.zend_array {
 	return (*C.zend_array)(unsafe.Pointer(arr))
 }
 
-// IsPacked determines if the given zval pointer represents a packed array (list).
-// Returns false if the zval is nil, not an array, or not packed.
-func IsPacked(zval unsafe.Pointer) bool {
-	if zval == nil {
+// IsPacked determines if the given zend_array is a packed array (list).
+// Returns false if the array is nil or not packed.
+func IsPacked(arr unsafe.Pointer) bool {
+	if arr == nil {
 		return false
 	}
 
-	v, err := extractZvalValue((*C.zval)(zval), C.IS_ARRAY)
-	if err != nil {
-		return false
-	}
-
-	ht := (*C.HashTable)(v)
-	if ht == nil {
-		return false
-	}
-
-	return htIsPacked(ht)
+	return htIsPacked((*C.zend_array)(arr))
 }
 
 // htIsPacked checks if a zend_array is a list (packed) or hashmap (not packed).


### PR DESCRIPTION
Because the API is different depending on if you deal with hash maps or lists, it would be nice to expose a method that returns whether the hashtable is packed.

My use case: I'm getting back to callable support and while writing a custom `array_map()`, I want to keep indexes if it's not a list. I have to check whether the provided hash table is packed or not.