### PR TITLE
fix(extgen): only register `ext_functions` if functions are declared

### DIFF
--- a/internal/extgen/templates/extension.c.tpl
+++ b/internal/extgen/templates/extension.c.tpl
@@ -172,7 +172,7 @@ PHP_MINIT_FUNCTION({{.BaseName}}) {
 
 zend_module_entry {{.BaseName}}_module_entry = {STANDARD_MODULE_HEADER,
                                          "{{.BaseName}}",
-                                         ext_functions,             /* Functions */
+                                         {{if .Functions}}ext_functions{{else}}NULL{{end}},             /* Functions */
                                          PHP_MINIT({{.BaseName}}),  /* MINIT */
                                          NULL,                      /* MSHUTDOWN */
                                          NULL,                      /* RINIT */


### PR DESCRIPTION
For example, if only classes are declared and not functions, it will break as the `ext_functions` symbol won't be generated by the GEN_STUB script.