### PR TITLE
fix(extgen): constant should be declared under the namespace provided by `export_php:namespace`

### DIFF
--- a/internal/extgen/cfile.go
+++ b/internal/extgen/cfile.go
@@ -58,6 +58,7 @@ func (cg *cFileGenerator) buildContent() (string, error) {
 func (cg *cFileGenerator) getTemplateContent() (string, error) {
 	funcMap := sprig.FuncMap()
 	funcMap["namespacedClassName"] = NamespacedName
+	funcMap["cString"] = escapeCString
 
 	tmpl := template.Must(template.New("cfile").Funcs(funcMap).Parse(cFileContent))
 
@@ -73,4 +74,9 @@ func (cg *cFileGenerator) getTemplateContent() (string, error) {
 	}
 
 	return buf.String(), nil
+}
+
+// escapeCString escapes backslashes for C string literals
+func escapeCString(s string) string {
+	return strings.ReplaceAll(s, `\`, `\\`)
 }

--- a/internal/extgen/cfile_namespace_test.go
+++ b/internal/extgen/cfile_namespace_test.go
@@ -129,3 +129,212 @@ func TestCFileGenerationWithoutNamespace(t *testing.T) {
 	expectedCall := "register_class_MySuperClass()"
 	require.Contains(t, contentResult, expectedCall, "C file should not contain the standard function call")
 }
+
+func TestCFileGenerationWithNamespacedConstants(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		constants []phpConstant
+		contains  []string
+	}{
+		{
+			name:      "integer constant with namespace",
+			namespace: `Go\Extension`,
+			constants: []phpConstant{
+				{Name: "TEST_INT", Value: "42", PhpType: phpInt},
+			},
+			contains: []string{
+				`REGISTER_NS_LONG_CONSTANT("Go\\Extension", "TEST_INT", 42, CONST_CS | CONST_PERSISTENT);`,
+			},
+		},
+		{
+			name:      "string constant with namespace",
+			namespace: `Go\Extension`,
+			constants: []phpConstant{
+				{Name: "TEST_STRING", Value: `"hello"`, PhpType: phpString},
+			},
+			contains: []string{
+				`REGISTER_NS_STRING_CONSTANT("Go\\Extension", "TEST_STRING", "hello", CONST_CS | CONST_PERSISTENT);`,
+			},
+		},
+		{
+			name:      "float constant with namespace",
+			namespace: `Go\Extension`,
+			constants: []phpConstant{
+				{Name: "TEST_FLOAT", Value: "3.14", PhpType: phpFloat},
+			},
+			contains: []string{
+				`REGISTER_NS_DOUBLE_CONSTANT("Go\\Extension", "TEST_FLOAT", 3.14, CONST_CS | CONST_PERSISTENT);`,
+			},
+		},
+		{
+			name:      "bool constant with namespace",
+			namespace: `Go\Extension`,
+			constants: []phpConstant{
+				{Name: "TEST_BOOL", Value: "true", PhpType: phpBool},
+			},
+			contains: []string{
+				`REGISTER_NS_LONG_CONSTANT("Go\\Extension", "TEST_BOOL", 1, CONST_CS | CONST_PERSISTENT);`,
+			},
+		},
+		{
+			name:      "iota constant with namespace",
+			namespace: `Go\Extension`,
+			constants: []phpConstant{
+				{Name: "STATUS_OK", Value: "STATUS_OK", PhpType: phpInt, IsIota: true},
+			},
+			contains: []string{
+				`REGISTER_NS_LONG_CONSTANT("Go\\Extension", "STATUS_OK", STATUS_OK, CONST_CS | CONST_PERSISTENT);`,
+			},
+		},
+		{
+			name:      "multiple constants with deep namespace",
+			namespace: `My\Deep\Namespace`,
+			constants: []phpConstant{
+				{Name: "CONST_INT", Value: "100", PhpType: phpInt},
+				{Name: "CONST_STR", Value: `"value"`, PhpType: phpString},
+				{Name: "CONST_FLOAT", Value: "1.5", PhpType: phpFloat},
+			},
+			contains: []string{
+				`REGISTER_NS_LONG_CONSTANT("My\\Deep\\Namespace", "CONST_INT", 100, CONST_CS | CONST_PERSISTENT);`,
+				`REGISTER_NS_STRING_CONSTANT("My\\Deep\\Namespace", "CONST_STR", "value", CONST_CS | CONST_PERSISTENT);`,
+				`REGISTER_NS_DOUBLE_CONSTANT("My\\Deep\\Namespace", "CONST_FLOAT", 1.5, CONST_CS | CONST_PERSISTENT);`,
+			},
+		},
+		{
+			name:      "single level namespace",
+			namespace: `TestNamespace`,
+			constants: []phpConstant{
+				{Name: "MY_CONST", Value: "999", PhpType: phpInt},
+			},
+			contains: []string{
+				`REGISTER_NS_LONG_CONSTANT("TestNamespace", "MY_CONST", 999, CONST_CS | CONST_PERSISTENT);`,
+			},
+		},
+		{
+			name:      "namespace with trailing backslash",
+			namespace: `TestIntegration\Extension`,
+			constants: []phpConstant{
+				{Name: "VERSION", Value: `"1.0.0"`, PhpType: phpString},
+			},
+			contains: []string{
+				`REGISTER_NS_STRING_CONSTANT("TestIntegration\\Extension", "VERSION", "1.0.0", CONST_CS | CONST_PERSISTENT);`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			generator := &Generator{
+				BaseName:  "test_ext",
+				Namespace: tt.namespace,
+				Constants: tt.constants,
+			}
+
+			cGen := cFileGenerator{generator: generator}
+			content, err := cGen.buildContent()
+			require.NoError(t, err, "Failed to build C file content")
+
+			for _, expected := range tt.contains {
+				assert.Contains(t, content, expected, "Generated C content should contain '%s'", expected)
+			}
+		})
+	}
+}
+
+func TestCFileGenerationWithoutNamespacedConstants(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		constants []phpConstant
+		contains  []string
+	}{
+		{
+			name:      "integer constant without namespace",
+			namespace: "",
+			constants: []phpConstant{
+				{Name: "GLOBAL_INT", Value: "42", PhpType: phpInt},
+			},
+			contains: []string{
+				`REGISTER_LONG_CONSTANT("GLOBAL_INT", 42, CONST_CS | CONST_PERSISTENT);`,
+			},
+		},
+		{
+			name:      "string constant without namespace",
+			namespace: "",
+			constants: []phpConstant{
+				{Name: "GLOBAL_STRING", Value: `"test"`, PhpType: phpString},
+			},
+			contains: []string{
+				`REGISTER_STRING_CONSTANT("GLOBAL_STRING", "test", CONST_CS | CONST_PERSISTENT);`,
+			},
+		},
+		{
+			name:      "float constant without namespace",
+			namespace: "",
+			constants: []phpConstant{
+				{Name: "GLOBAL_FLOAT", Value: "2.71", PhpType: phpFloat},
+			},
+			contains: []string{
+				`REGISTER_DOUBLE_CONSTANT("GLOBAL_FLOAT", 2.71, CONST_CS | CONST_PERSISTENT);`,
+			},
+		},
+		{
+			name:      "bool constant without namespace",
+			namespace: "",
+			constants: []phpConstant{
+				{Name: "GLOBAL_BOOL", Value: "false", PhpType: phpBool},
+			},
+			contains: []string{
+				`REGISTER_LONG_CONSTANT("GLOBAL_BOOL", 0, CONST_CS | CONST_PERSISTENT);`,
+			},
+		},
+		{
+			name:      "iota constant without namespace",
+			namespace: "",
+			constants: []phpConstant{
+				{Name: "ERROR_CODE", Value: "ERROR_CODE", PhpType: phpInt, IsIota: true},
+			},
+			contains: []string{
+				`REGISTER_LONG_CONSTANT("ERROR_CODE", ERROR_CODE, CONST_CS | CONST_PERSISTENT);`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			generator := &Generator{
+				BaseName:  "test_ext",
+				Namespace: tt.namespace,
+				Constants: tt.constants,
+			}
+
+			cGen := cFileGenerator{generator: generator}
+			content, err := cGen.buildContent()
+			require.NoError(t, err, "Failed to build C file content")
+
+			for _, expected := range tt.contains {
+				assert.Contains(t, content, expected, "Generated C content should contain '%s'", expected)
+			}
+
+			assert.NotContains(t, content, "REGISTER_NS_", "Content should NOT contain namespaced constant macros when namespace is empty")
+		})
+	}
+}
+
+func TestCFileTemplateFunctionMapCString(t *testing.T) {
+	generator := &Generator{
+		BaseName:  "test_ext",
+		Namespace: `My\Namespace\Test`,
+		Constants: []phpConstant{
+			{Name: "MY_CONST", Value: "123", PhpType: phpInt},
+		},
+	}
+
+	cGen := cFileGenerator{generator: generator}
+	content, err := cGen.getTemplateContent()
+	require.NoError(t, err, "Failed to get template content")
+
+	assert.Contains(t, content, `"My\\Namespace\\Test"`, "Template should properly escape namespace backslashes using cString filter")
+	assert.NotContains(t, content, `"My\Namespace\Test"`, "Template should not contain unescaped namespace (single backslashes)")
+}

--- a/internal/extgen/cfile_test.go
+++ b/internal/extgen/cfile_test.go
@@ -459,3 +459,74 @@ func TestCFileTemplateErrorHandling(t *testing.T) {
 	_, err := cGen.getTemplateContent()
 	assert.NoError(t, err, "getTemplateContent() should not fail with valid template")
 }
+
+func TestEscapeCString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple namespace with single backslash",
+			input:    `Go\Extension`,
+			expected: `Go\\Extension`,
+		},
+		{
+			name:     "namespace with multiple backslashes",
+			input:    `My\Deep\Namespace`,
+			expected: `My\\Deep\\Namespace`,
+		},
+		{
+			name:     "complex nested namespace",
+			input:    `TestIntegration\Extension\Module`,
+			expected: `TestIntegration\\Extension\\Module`,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "single backslash",
+			input:    `\`,
+			expected: `\\`,
+		},
+		{
+			name:     "multiple consecutive backslashes",
+			input:    `\\\`,
+			expected: `\\\\\\`,
+		},
+		{
+			name:     "string without backslashes",
+			input:    "TestNamespace",
+			expected: "TestNamespace",
+		},
+		{
+			name:     "leading backslash",
+			input:    `\Leading`,
+			expected: `\\Leading`,
+		},
+		{
+			name:     "trailing backslash",
+			input:    `Trailing\`,
+			expected: `Trailing\\`,
+		},
+		{
+			name:     "mixed alphanumeric with backslashes",
+			input:    `Path123\To456\File789`,
+			expected: `Path123\\To456\\File789`,
+		},
+		{
+			name:     "unicode characters with backslashes",
+			input:    `Namespace\Über\Test`,
+			expected: `Namespace\\Über\\Test`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := escapeCString(tt.input)
+			assert.Equal(t, tt.expected, result, "escapeCString(%q) should return %q, got %q", tt.input, tt.expected, result)
+		})
+	}
+}

--- a/internal/extgen/templates/extension.c.tpl
+++ b/internal/extgen/templates/extension.c.tpl
@@ -159,11 +159,20 @@ PHP_MINIT_FUNCTION({{.BaseName}}) {
 
     {{- range .Constants}}
     {{- if eq .ClassName ""}}
+    {{- if $.Namespace}}
+        {{if .IsIota}}REGISTER_NS_LONG_CONSTANT("{{cString $.Namespace}}", "{{.Name}}", {{.Name}}, CONST_CS | CONST_PERSISTENT);
+        {{else if eq .PhpType "string"}}REGISTER_NS_STRING_CONSTANT("{{cString $.Namespace}}", "{{.Name}}", {{.CValue}}, CONST_CS | CONST_PERSISTENT);
+        {{else if eq .PhpType "bool"}}REGISTER_NS_LONG_CONSTANT("{{cString $.Namespace}}", "{{.Name}}", {{if eq .Value "true"}}1{{else}}0{{end}}, CONST_CS | CONST_PERSISTENT);
+        {{else if eq .PhpType "float"}}REGISTER_NS_DOUBLE_CONSTANT("{{cString $.Namespace}}", "{{.Name}}", {{.CValue}}, CONST_CS | CONST_PERSISTENT);
+        {{else}}REGISTER_NS_LONG_CONSTANT("{{cString $.Namespace}}", "{{.Name}}", {{.CValue}}, CONST_CS | CONST_PERSISTENT);
+        {{- end}}
+    {{- else}}
     {{if .IsIota}}REGISTER_LONG_CONSTANT("{{.Name}}", {{.Name}}, CONST_CS | CONST_PERSISTENT);
     {{else if eq .PhpType "string"}}REGISTER_STRING_CONSTANT("{{.Name}}", {{.CValue}}, CONST_CS | CONST_PERSISTENT);
     {{else if eq .PhpType "bool"}}REGISTER_LONG_CONSTANT("{{.Name}}", {{if eq .Value "true"}}1{{else}}0{{end}}, CONST_CS | CONST_PERSISTENT);
     {{else if eq .PhpType "float"}}REGISTER_DOUBLE_CONSTANT("{{.Name}}", {{.CValue}}, CONST_CS | CONST_PERSISTENT);
     {{else}}REGISTER_LONG_CONSTANT("{{.Name}}", {{.CValue}}, CONST_CS | CONST_PERSISTENT);
+    {{- end}}
     {{- end}}
     {{- end}}
     {{- end}}


### PR DESCRIPTION
Currently, constants are always declared in the global namespace, which is not the intended behavior — thus qualifying as bug fix.