### PR TITLE
give /var/lib/frankenphp sys_rw_content_t permissions for mercure.db files

### DIFF
--- a/package/rhel/postinstall.sh
+++ b/package/rhel/postinstall.sh
@@ -15,7 +15,8 @@ if [ -x /usr/sbin/semanage ] && [ -x /usr/sbin/restorecon ]; then
 	semanage fcontext --add --type httpd_exec_t '/usr/bin/frankenphp' 2>/dev/null || :
 	semanage fcontext --add --type httpd_sys_content_t '/usr/share/frankenphp(/.*)?' 2>/dev/null || :
 	semanage fcontext --add --type httpd_config_t '/etc/frankenphp(/.*)?' 2>/dev/null || :
-	semanage fcontext --add --type httpd_sys_rw_content_t '/var/lib/frankenphp(/.*)?' 2>/dev/null || :
+	semanage fcontext --add --type httpd_var_lib_t '/var/lib/frankenphp(/.*)?' 2>/dev/null || :
+	semanage fcontext --add --type httpd_sys_rw_content_t "/var/lib/frankenphp(/.*\.db)" 2>/dev/null || :
 	restorecon -r /usr/bin/frankenphp /usr/share/frankenphp /etc/frankenphp /var/lib/frankenphp || :
 fi
 

--- a/package/rhel/postuninstall.sh
+++ b/package/rhel/postuninstall.sh
@@ -15,7 +15,8 @@ if [ "$1" -eq 0 ]; then
 		semanage fcontext --delete --type httpd_exec_t '/usr/bin/frankenphp' 2>/dev/null || :
 		semanage fcontext --delete --type httpd_sys_content_t '/usr/share/frankenphp(/.*)?' 2>/dev/null || :
 		semanage fcontext --delete --type httpd_config_t '/etc/frankenphp(/.*)?' 2>/dev/null || :
-		semanage fcontext --delete --type httpd_sys_rw_content_t '/var/lib/frankenphp(/.*)?' 2>/dev/null || :
+		semanage fcontext --delete --type httpd_var_lib_t '/var/lib/frankenphp(/.*)?' 2>/dev/null || :
+		semanage fcontext --delete --type httpd_sys_rw_content_t '/var/lib/frankenphp(/.*\.db)' 2>/dev/null || :
 		# QUIC
 		semanage port --delete --type http_port_t --proto udp 80 2>/dev/null || :
 		semanage port --delete --type http_port_t --proto udp 443 2>/dev/null || :


### PR DESCRIPTION
The current configuration is not able to start FrankenPHP when mercure and SELinux are used with a Caddyfile like this:

```Caddyfile
mercure {
    transport bolt {
        path mercure.db
    }
}
```

closes https://github.com/php/frankenphp/issues/2035

Exact error:
```
SELinux is preventing /usr/bin/frankenphp from map access on the file /var/lib/frankenphp/mercure.db.

*****  Plugin catchall_boolean (89.3 confidence) suggests   ******************

If you want to allow domain to can mmap files
Then you must tell SELinux about this by enabling the 'domain_can_mmap_files' boolean.

Do
setsebool -P domain_can_mmap_files 1

*****  Plugin catchall (11.6 confidence) suggests   **************************

If you believe that frankenphp should be allowed map access on the mercure.db file by default.
Then you should report this as a bug.
You can generate a local policy module to allow this access.
Do
allow this access for now by executing:
# ausearch -c 'frankenphp' --raw | audit2allow -M my-frankenphp
# semodule -X 300 -i my-frankenphp.pp


Additional Information:
Source Context                system_u:system_r:httpd_t:s0
Target Context                system_u:object_r:httpd_var_lib_t:s0
Target Objects                /var/lib/frankenphp/mercure.db [ file ]
Source                        frankenphp
Source Path                   /usr/bin/frankenphp
Port                          <Unknown>
Host                          localhost
Source RPM Packages           frankenphp-1.10.0_84-1.x86_64
Target RPM Packages
SELinux Policy RPM            selinux-policy-targeted-3.14.3-139.el8_10.1.noarch
Local Policy RPM              selinux-policy-targeted-3.14.3-139.el8_10.1.noarch
Selinux Enabled               True
Policy Type                   targeted
Enforcing Mode                Enforcing
Host Name                     localhost
Platform                      Linux localhost
                              4.18.0-553.81.1.el8_10.x86_64 #1 SMP Mon Oct 27
                              11:29:19 EDT 2025 x86_64 x86_64
Alert Count                   12
First Seen                    2025-10-29 17:25:26 CET
Last Seen                     2025-11-25 17:18:19 CET
Local ID                      c4e79504-117e-4e9f-ad8c-f0bcc4856697

Raw Audit Messages
type=AVC msg=audit(1764087499.320:475517): avc:  denied  { map } for  pid=322613 comm="frankenphp" path="/var/lib/frankenphp/mercure.db" dev="md3" ino=93716492 scontext=system_u:system_r:httpd_t:s0 tcontext=system_u:object_r:httpd_var_lib_t:s0 tclass=file permissive=0


type=SYSCALL msg=audit(1764087499.320:475517): arch=x86_64 syscall=mmap success=no exit=EACCES a0=0 a1=8000 a2=1 a3=1 items=0 ppid=1 pid=322613 auid=4294967295 uid=991 gid=988 euid=991 suid=991 fsuid=991 egid=988 sgid=988 fsgid=988 tty=(none) ses=4294967295 comm=frankenphp exe=/usr/bin/frankenphp subj=system_u:system_r:httpd_t:s0 key=(null)

Hash: frankenphp,httpd_t,httpd_var_lib_t,file,map
```