### PR TITLE
 Required Caddy directories when running FrankenPHP inside Docker

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -95,7 +95,8 @@ And ensure the root directory exists in the image:
 ```
 RUN mkdir -p /srv/app/public
 ```
-This prevents Docker from overwriting internal Caddy directories and guarantees stable behavior during development.
+This prevents the bind-mount from overwriting internal Caddy directories and guarantees stable behavior during development.
+This setup matches the directory structure used in many production deployments and avoids subtle issues with Caddy startup sequencing.
 
 ## How to Install More PHP Extensions
 


### PR DESCRIPTION
This PR adds missing documentation about two Caddy directories required when running FrankenPHP inside Docker:

- `/data/caddy`
- `/config/caddy` (used to store autosave.json)

These directories are not created by the official image. When  `/config/caddy`` is absent or not writable, Caddy cannot autosave its adapted configuration and silently falls back to “serving initial configuration”, even with a valid Caddyfile.

## What this PR adds

- A Dockerfile snippet to create the required directories with proper permissions.
- A note for Docker Compose users explaining why mounting the application over
- `/app` can overwrite internal Caddy files.
- A recommended alternative layout using `/srv/app` when bind-mounting the code.

This should make the Docker setup more reliable for developers using FrankenPHP.