### PR TITLE
fix(extgen): use `REGISTER(_NS)_BOOL_CONSTANT`

### DIFF
--- a/internal/extgen/cfile_namespace_test.go
+++ b/internal/extgen/cfile_namespace_test.go
@@ -174,7 +174,7 @@ func TestCFileGenerationWithNamespacedConstants(t *testing.T) {
 				{Name: "TEST_BOOL", Value: "true", PhpType: phpBool},
 			},
 			contains: []string{
-				`REGISTER_NS_LONG_CONSTANT("Go\\Extension", "TEST_BOOL", 1, CONST_CS | CONST_PERSISTENT);`,
+				`REGISTER_NS_BOOL_CONSTANT("Go\\Extension", "TEST_BOOL", true, CONST_CS | CONST_PERSISTENT);`,
 			},
 		},
 		{
@@ -286,7 +286,7 @@ func TestCFileGenerationWithoutNamespacedConstants(t *testing.T) {
 				{Name: "GLOBAL_BOOL", Value: "false", PhpType: phpBool},
 			},
 			contains: []string{
-				`REGISTER_LONG_CONSTANT("GLOBAL_BOOL", 0, CONST_CS | CONST_PERSISTENT);`,
+				`REGISTER_BOOL_CONSTANT("GLOBAL_BOOL", false, CONST_CS | CONST_PERSISTENT);`,
 			},
 		},
 		{

--- a/internal/extgen/templates/extension.c.tpl
+++ b/internal/extgen/templates/extension.c.tpl
@@ -162,14 +162,14 @@ PHP_MINIT_FUNCTION({{.BaseName}}) {
     {{- if $.Namespace}}
         {{if .IsIota}}REGISTER_NS_LONG_CONSTANT("{{cString $.Namespace}}", "{{.Name}}", {{.Name}}, CONST_CS | CONST_PERSISTENT);
         {{else if eq .PhpType "string"}}REGISTER_NS_STRING_CONSTANT("{{cString $.Namespace}}", "{{.Name}}", {{.CValue}}, CONST_CS | CONST_PERSISTENT);
-        {{else if eq .PhpType "bool"}}REGISTER_NS_LONG_CONSTANT("{{cString $.Namespace}}", "{{.Name}}", {{if eq .Value "true"}}1{{else}}0{{end}}, CONST_CS | CONST_PERSISTENT);
+        {{else if eq .PhpType "bool"}}REGISTER_NS_BOOL_CONSTANT("{{cString $.Namespace}}", "{{.Name}}", {{if eq .Value "true"}}true{{else}}false{{end}}, CONST_CS | CONST_PERSISTENT);
         {{else if eq .PhpType "float"}}REGISTER_NS_DOUBLE_CONSTANT("{{cString $.Namespace}}", "{{.Name}}", {{.CValue}}, CONST_CS | CONST_PERSISTENT);
         {{else}}REGISTER_NS_LONG_CONSTANT("{{cString $.Namespace}}", "{{.Name}}", {{.CValue}}, CONST_CS | CONST_PERSISTENT);
         {{- end}}
     {{- else}}
     {{if .IsIota}}REGISTER_LONG_CONSTANT("{{.Name}}", {{.Name}}, CONST_CS | CONST_PERSISTENT);
     {{else if eq .PhpType "string"}}REGISTER_STRING_CONSTANT("{{.Name}}", {{.CValue}}, CONST_CS | CONST_PERSISTENT);
-    {{else if eq .PhpType "bool"}}REGISTER_LONG_CONSTANT("{{.Name}}", {{if eq .Value "true"}}1{{else}}0{{end}}, CONST_CS | CONST_PERSISTENT);
+    {{else if eq .PhpType "bool"}}REGISTER_BOOL_CONSTANT("{{.Name}}", {{if eq .Value "true"}}true{{else}}false{{end}}, CONST_CS | CONST_PERSISTENT);
     {{else if eq .PhpType "float"}}REGISTER_DOUBLE_CONSTANT("{{.Name}}", {{.CValue}}, CONST_CS | CONST_PERSISTENT);
     {{else}}REGISTER_LONG_CONSTANT("{{.Name}}", {{.CValue}}, CONST_CS | CONST_PERSISTENT);
     {{- end}}


### PR DESCRIPTION
Spotted in #1984, this is the right macros to declare boolean constants