### PR TITLE
ci(superlinter): use `aligned` table style

### DIFF
--- a/.markdown-lint.yaml
+++ b/.markdown-lint.yaml
@@ -2,3 +2,5 @@
 no-hard-tabs: false
 MD013: false
 MD033: false
+MD060:
+  style: aligned


### PR DESCRIPTION
We use the `aligned` style everywhere in the docs and superlinter started to report that. I propose to update the configuration to use `aligned` style as IDE like Goland propose auto alignement of tables by default.

Documentation: https://github.com/DavidAnson/markdownlint/blob/main/doc/md060.md