### PR TITLE
docs: document the extensionworkers api

### DIFF
--- a/docs/extension-workers.md
+++ b/docs/extension-workers.md
@@ -1,6 +1,6 @@
 # Extension Workers
 
-Extension Workers enable your [FrankenPHP extension](https://frankenphp.dev/docs/extensions/) to manage a dedicated pool of PHP threads for executing background tasks, handling asynchronous events, or implementing custom protocols. Usefull for queue systems, event listeners, schedulers, etc.
+Extension Workers enable your [FrankenPHP extension](https://frankenphp.dev/docs/extensions/) to manage a dedicated pool of PHP threads for executing background tasks, handling asynchronous events, or implementing custom protocols. Useful for queue systems, event listeners, schedulers, etc.
 
 ## Registering the Worker
 


### PR DESCRIPTION
Solve https://github.com/php/frankenphp/issues/1967
I propose this documentation for the ExtensionWorkers API. I have included it in the Extensions section but as the page is becoming quite large (over 1000 lines), would it be better to create a dedicated section for it?