### PR TITLE
docs: wrong config path for autoloaded .caddyfile

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -29,7 +29,7 @@ Depending on your installation method, FrankenPHP and the PHP interpreter will l
 FrankenPHP:
 
 - `/etc/frankenphp/Caddyfile`: the main configuration file
-- `/etc/frankenphp/caddy.d/*.caddy`: additional configuration files that are loaded automatically
+- `/etc/frankenphp/Caddyfile.d/*.caddyfile`: additional configuration files that are loaded automatically
 
 PHP:
 


### PR DESCRIPTION
Hi !

I am playing with FrankenPHP, and frankly new to the thing so I may be wrong.

The [current documentation](https://frankenphp.dev/docs/config/#docker) mention that : 

> /etc/frankenphp/caddy.d/*.caddy: additional configuration files that are loaded automatically

But in the main Caddyfile ([here on GitHub](https://github.com/php/frankenphp/blob/main/caddy/frankenphp/Caddyfile#L59)) imports differently:

```ini
import Caddyfile.d/*.caddyfile
```

This PR aims to correct this :)

Thank you for your time !