### PR TITLE
docs: update embed path to absolute due to build-static.sh changes

### DIFF
--- a/docs/cn/embed.md
+++ b/docs/cn/embed.md
@@ -63,7 +63,7 @@ composer dump-env prod
 
    # 构建静态二进制文件
    WORKDIR /go/src/app/
-   RUN EMBED=dist/app/ ./build-static.sh
+   RUN EMBED=/go/src/app/dist/app/ ./build-static.sh
    ```
 
    > [!CAUTION]

--- a/docs/cn/laravel.md
+++ b/docs/cn/laravel.md
@@ -111,7 +111,7 @@ php artisan octane:frankenphp
 
    # 构建静态二进制文件
    WORKDIR /go/src/app/
-   RUN EMBED=dist/app/ ./build-static.sh
+   RUN EMBED=/go/src/app/dist/app/ ./build-static.sh
    ```
 
    > [!CAUTION]

--- a/docs/embed.md
+++ b/docs/embed.md
@@ -63,7 +63,7 @@ The easiest way to create a Linux binary is to use the Docker-based builder we p
 
    # Build the static binary
    WORKDIR /go/src/app/
-   RUN EMBED=dist/app/ ./build-static.sh
+   RUN EMBED=/go/src/app/dist/app/ ./build-static.sh
    ```
 
    > [!CAUTION]

--- a/docs/fr/embed.md
+++ b/docs/fr/embed.md
@@ -64,7 +64,7 @@ La manière la plus simple de créer un binaire Linux est d'utiliser le builder 
    COPY . .
 
    WORKDIR /go/src/app/
-   RUN EMBED=dist/app/ ./build-static.sh
+   RUN EMBED=/go/src/app/dist/app/ ./build-static.sh
    ```
 
    > [!CAUTION]

--- a/docs/fr/laravel.md
+++ b/docs/fr/laravel.md
@@ -111,7 +111,7 @@ Suivez ces étapes pour empaqueter votre application Laravel en tant que binaire
 
    # Construire le binaire statique
    WORKDIR /go/src/app/
-   RUN EMBED=dist/app/ ./build-static.sh
+   RUN EMBED=/go/src/app/dist/app/ ./build-static.sh
    ```
 
    > [!CAUTION]

--- a/docs/ja/embed.md
+++ b/docs/ja/embed.md
@@ -63,7 +63,7 @@ Linux用バイナリを作成する最も簡単な方法は、提供されてい
 
    # 静的バイナリをビルド
    WORKDIR /go/src/app/
-   RUN EMBED=dist/app/ ./build-static.sh
+   RUN EMBED=/go/src/app/dist/app/ ./build-static.sh
    ```
 
    > [!CAUTION]

--- a/docs/ja/laravel.md
+++ b/docs/ja/laravel.md
@@ -111,7 +111,7 @@ LaravelアプリをLinux用のスタンドアロンバイナリとしてパッ�
 
    # 静的バイナリをビルド
    WORKDIR /go/src/app/
-   RUN EMBED=dist/app/ ./build-static.sh
+   RUN EMBED=/go/src/app/dist/app/ ./build-static.sh
    ```
 
    > [!CAUTION]

--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -113,7 +113,7 @@ Follow these steps to package your Laravel app as a standalone binary for Linux:
 
    # Build the static binary
    WORKDIR /go/src/app/
-   RUN EMBED=dist/app/ ./build-static.sh
+   RUN EMBED=/go/src/app/dist/app/ ./build-static.sh
    ```
 
    > [!CAUTION]

--- a/docs/pt-br/embed.md
+++ b/docs/pt-br/embed.md
@@ -75,7 +75,7 @@ Docker que fornecemos.
 
    # Compila o binário estático
    WORKDIR /go/src/app/
-   RUN EMBED=dist/app/ ./build-static.sh
+   RUN EMBED=/go/src/app/dist/app/ ./build-static.sh
    ```
 
    > [!CAUTION]

--- a/docs/pt-br/laravel.md
+++ b/docs/pt-br/laravel.md
@@ -131,7 +131,7 @@ independente para Linux:
 
    # Compila o binário estático
    WORKDIR /go/src/app/
-   RUN EMBED=dist/app/ ./build-static.sh
+   RUN EMBED=/go/src/app/dist/app/ ./build-static.sh
    ```
 
    > [!CAUTION]

--- a/docs/ru/embed.md
+++ b/docs/ru/embed.md
@@ -61,7 +61,7 @@ composer dump-env prod
 
    # Сборка статического бинарного файла
    WORKDIR /go/src/app/
-   RUN EMBED=dist/app/ ./build-static.sh
+   RUN EMBED=/go/src/app/dist/app/ ./build-static.sh
    ```
 
    > [!CAUTION]

--- a/docs/ru/laravel.md
+++ b/docs/ru/laravel.md
@@ -108,7 +108,7 @@ php artisan octane:frankenphp
 
    # Соберите статический бинарный файл
    WORKDIR /go/src/app/
-   RUN EMBED=dist/app/ ./build-static.sh
+   RUN EMBED=/go/src/app/dist/app/ ./build-static.sh
    ```
 
    > [!CAUTION]

--- a/docs/tr/embed.md
+++ b/docs/tr/embed.md
@@ -55,7 +55,7 @@ Bir Linux binary çıktısı almanın en kolay yolu, sağladığımız Docker ta
 
    # Statik binary dosyasını oluşturun, yalnızca istediğiniz PHP eklentilerini seçtiğinizden emin olun
    WORKDIR /go/src/app/
-   RUN EMBED=dist/app/ \
+   RUN EMBED=/go/src/app/dist/app/ \
        ./build-static.sh
    ```
 

--- a/docs/tr/laravel.md
+++ b/docs/tr/laravel.md
@@ -111,7 +111,7 @@ Linux için Laravel uygulamanızı bağımsız bir çalıştırılabilir olarak 
 
    # Statik ikiliyi derleyin
    WORKDIR /go/src/app/
-   RUN EMBED=dist/app/ ./build-static.sh
+   RUN EMBED=/go/src/app/dist/app/ ./build-static.sh
    ```
 
    > [!CAUTION]


### PR DESCRIPTION
The docs still show relative paths for `embed=`. However, since the changes in `build-static.sh`, relative paths may not work reliably.

I hit this issue while following the docs, so this PR updates the examples to use absolute paths.