### PR TITLE
feat: track request cpu and peak memory usage and expose in caddy replacer vars

### DIFF
--- a/cgi.go
+++ b/cgi.go
@@ -311,6 +311,8 @@ func go_update_request_info(threadIndex C.uintptr_t, info *C.sapi_request_info) 
 	info.request_uri = thread.pinCString(request.URL.RequestURI())
 
 	info.proto_num = C.int(request.ProtoMajor*1000 + request.ProtoMinor)
+
+	C.clock_gettime(C.CLOCK_THREAD_CPUTIME_ID, &thread.cpuRequestStartTime)
 }
 
 // SanitizedPathJoin performs filepath.Join(root, reqPath) that

--- a/context.go
+++ b/context.go
@@ -38,6 +38,16 @@ type frankenPHPContext struct {
 
 	done      chan any
 	startedAt time.Time
+
+	memoryUsage uint64
+	cpuUsage    time.Duration
+}
+
+type Stats struct {
+	MemoryUsage    uint64
+	CpuUsage       time.Duration
+	Script         string
+	ScriptFilename string
 }
 
 type contextHolder struct {

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -456,6 +456,9 @@ PHP_FUNCTION(frankenphp_handle_request) {
   fci.params = result.r1;
   fci.param_count = result.r1 == NULL ? 0 : 1;
 
+  // Reset memory peak usage at the start of the request
+  zend_memory_reset_peak_usage();
+
   if (zend_call_function(&fci, &fcc) == SUCCESS && Z_TYPE(retval) != IS_UNDEF) {
     callback_ret = &retval;
   }
@@ -609,6 +612,8 @@ static zend_module_entry frankenphp_module = {
     STANDARD_MODULE_PROPERTIES};
 
 static void frankenphp_request_shutdown() {
+  go_frankenphp_set_memory_peak_usage(thread_index, zend_memory_peak_usage(1));
+
   frankenphp_free_request_context();
   php_request_shutdown((void *)0);
 }

--- a/frankenphp.go
+++ b/frankenphp.go
@@ -382,6 +382,29 @@ func Shutdown() {
 	resetGlobals()
 }
 
+// Stats returns FrankenPHP-specific execution stats from the given context.
+func StatusFromContext(ctx context.Context) (Stats, bool) {
+	fc, ok := fromContext(ctx)
+	if !ok {
+		return Stats{}, false
+	}
+	if fc.worker != nil {
+		return Stats{
+			CpuUsage:       fc.cpuUsage,
+			MemoryUsage:    fc.memoryUsage,
+			Script:         fc.worker.fileName,
+			ScriptFilename: fc.worker.fileName,
+		}, true
+	} else {
+		return Stats{
+			CpuUsage:       fc.cpuUsage,
+			MemoryUsage:    fc.memoryUsage,
+			Script:         fc.scriptName,
+			ScriptFilename: fc.scriptFilename,
+		}, true
+	}
+}
+
 // ServeHTTP executes a PHP script according to the given context.
 func ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) error {
 	h := responseWriter.Header()

--- a/threadregular.go
+++ b/threadregular.go
@@ -100,6 +100,8 @@ func (handler *regularThread) waitForRequest() string {
 }
 
 func (handler *regularThread) afterRequest() {
+	handler.contextHolder.frankenPHPContext.cpuUsage = handler.thread.lastRequestCpuUsage
+	handler.contextHolder.frankenPHPContext.memoryUsage = handler.thread.lastRequestMemoryUsage
 	handler.contextHolder.frankenPHPContext.closeContext()
 	handler.contextHolder.frankenPHPContext = nil
 	handler.ctx = nil

--- a/threadworker.go
+++ b/threadworker.go
@@ -285,6 +285,12 @@ func go_frankenphp_finish_worker_request(threadIndex C.uintptr_t, retval *C.zval
 	ctx := thread.context()
 	fc := ctx.Value(contextKey).(*frankenPHPContext)
 
+	// Stats
+	thread.lastRequestCpuUsage = thread.requestCpuUsage()
+	thread.lastRequestMemoryUsage = uint64(C.zend_memory_peak_usage(C.bool(true)))
+	fc.cpuUsage = thread.lastRequestCpuUsage
+	fc.memoryUsage = thread.lastRequestMemoryUsage
+
 	if retval != nil {
 		r, err := GoValue[any](unsafe.Pointer(retval))
 		if err != nil && globalLogger.Enabled(ctx, slog.LevelError) {


### PR DESCRIPTION
 This captures request cpu (user+system) and peak memory usage similar to FPM and Apache2 SAPIs.
 
To propagate this back to Go we store it in FrankenPHP context first, before retrieving it in embedder / runtime (e.g. Caddy) from context.

For better compatibility with FPM logging we expose script and script filename vars as well.

 - CPU usage is nanoseconds user space and system space thread runtime (only works on POSIX that supports clock_gettime(CLOCK_THREAD_CPUTIME_ID)).
 - Memory usage is retrieved at the end of every request. In worker mode we reset peak memory usage before every request.

Using in Caddy:
```
  log_append cpu_usage_human {http.frankenphp.cpu_usage_human}
  log_append cpu_usage {http.frankenphp.cpu_usage}
  log_append memory_usage {http.frankenphp.memory_usage}
  log_append memory_usage_human {http.frankenphp.memory_usage_human}
  log_append script {http.frankenphp.script}
  log_append script_filename {http.frankenphp.script_filename}
```