### PR TITLE
fix(extgen): correctly handle const blocks to declare iota constants

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -406,11 +406,14 @@ const MAX_CONNECTIONS = 100
 const API_VERSION = "1.2.3"
 
 //export_php:const
-const STATUS_OK = iota
-
-//export_php:const
-const STATUS_ERROR = iota
+const (
+	STATUS_OK = iota
+	STATUS_ERROR
+)
 ```
+
+> [!NOTE]
+> PHP constants will take the name of the Go constant, thus using upper case letters is recommended.
 
 #### Class Constants
 
@@ -429,14 +432,15 @@ const STATUS_INACTIVE = 0
 const ROLE_ADMIN = "admin"
 
 //export_php:classconst Order
-const STATE_PENDING = iota
-
-//export_php:classconst Order
-const STATE_PROCESSING = iota
-
-//export_php:classconst Order
-const STATE_COMPLETED = iota
+const (
+	STATE_PENDING = iota
+	STATE_PROCESSING
+	STATE_COMPLETED
+)
 ```
+
+> [!NOTE]
+> Just like global constants, the class constants will take the name of the Go constant.
 
 Class constants are accessible using the class name scope in PHP:
 

--- a/docs/fr/extensions.md
+++ b/docs/fr/extensions.md
@@ -402,11 +402,14 @@ const MAX_CONNECTIONS = 100
 const API_VERSION = "1.2.3"
 
 //export_php:const
-const STATUS_OK = iota
-
-//export_php:const
-const STATUS_ERROR = iota
+const (
+	STATUS_OK = iota
+	STATUS_ERROR
+)
 ```
+
+> [!NOTE]
+> Les constantes PHP prennent le nom de la constante Go, d'où l'utilisation de majuscules pour les noms des constants en Go.
 
 #### Constantes de Classe
 
@@ -425,14 +428,15 @@ const STATUS_INACTIVE = 0
 const ROLE_ADMIN = "admin"
 
 //export_php:classconst Order
-const STATE_PENDING = iota
-
-//export_php:classconst Order
-const STATE_PROCESSING = iota
-
-//export_php:classconst Order
-const STATE_COMPLETED = iota
+const (
+	STATE_PENDING = iota
+	STATE_PROCESSING
+	STATE_COMPLETED
+)
 ```
+
+> [!NOTE]
+> Comme les constantes globales, les constantes de classe prennent le nom de la constante Go.
 
 Les constantes de classe sont accessibles en utilisant la portée du nom de classe en PHP :
 

--- a/internal/extgen/integration_test.go
+++ b/internal/extgen/integration_test.go
@@ -480,6 +480,7 @@ func TestConstants(t *testing.T) {
 		[]string{
 			"TEST_MAX_RETRIES", "TEST_API_VERSION", "TEST_ENABLED", "TEST_PI",
 			"STATUS_PENDING", "STATUS_PROCESSING", "STATUS_COMPLETED",
+			"ONE", "TWO",
 		},
 	)
 	require.NoError(t, err, "all constants, functions, and classes should be accessible from PHP")

--- a/testdata/integration/constants.go
+++ b/testdata/integration/constants.go
@@ -21,13 +21,18 @@ const TEST_ENABLED = true
 const TEST_PI = 3.14159
 
 // export_php:const
-const STATUS_PENDING = iota
+const (
+	STATUS_PENDING = iota
+	STATUS_PROCESSING
+	STATUS_COMPLETED
+)
 
-// export_php:const
-const STATUS_PROCESSING = iota
-
-// export_php:const
-const STATUS_COMPLETED = iota
+const (
+	// export_php:const
+	ONE = 1
+	// export_php:const
+	TWO = 2
+)
 
 // export_php:class Config
 type ConfigStruct struct {


### PR DESCRIPTION
While continuing the work on #2011, I realized that constant declarations have a problem when using `iota`. I mean, it technically works, but const *blocks* we not supported which means that setting all constants to `iota` as shown in the documentation was non-sensical, as `iota` resets every time outside of const blocks.

So, this is between the bug fix and the feature. To me, it's a bug fix as the behavior wasn't the one intended when creating extgen.