### PR TITLE
fix(extgen): use fast ZPP

### DIFF
--- a/internal/extgen/paramparser.go
+++ b/internal/extgen/paramparser.go
@@ -88,9 +88,7 @@ func (pp *ParameterParser) getDefaultValue(param phpParameter, fallback string) 
 
 func (pp *ParameterParser) generateParamParsing(params []phpParameter, requiredCount int) string {
 	if len(params) == 0 {
-		return `    if (zend_parse_parameters_none() == FAILURE) {
-        RETURN_THROWS();
-    }`
+		return `    ZEND_PARSE_PARAMETERS_NONE();`
 	}
 
 	var builder strings.Builder

--- a/internal/extgen/paramparser_test.go
+++ b/internal/extgen/paramparser_test.go
@@ -223,9 +223,7 @@ func TestParameterParser_GenerateParamParsing(t *testing.T) {
 			name:          "no parameters",
 			params:        []phpParameter{},
 			requiredCount: 0,
-			expected: `    if (zend_parse_parameters_none() == FAILURE) {
-        RETURN_THROWS();
-    }`,
+			expected:      `    ZEND_PARSE_PARAMETERS_NONE();`,
 		},
 		{
 			name: "single required string parameter",


### PR DESCRIPTION
Fast ZPP is being more and more widely used in php-src with PR such as https://github.com/php/php-src/pull/20441 or https://github.com/php/php-src/pull/20644, let's use it here as well.