### PR TITLE
fix: crash when using the logger outside of the a request context v2

### DIFF
--- a/frankenphp.go
+++ b/frankenphp.go
@@ -660,10 +660,28 @@ func go_read_cookies(threadIndex C.uintptr_t) *C.char {
 	return C.CString(cookie)
 }
 
+func getLogger(threadIndex C.uintptr_t) (*slog.Logger, context.Context) {
+	ctxHolder := phpThreads[threadIndex]
+	if ctxHolder == nil {
+		return globalLogger, globalCtx
+	}
+
+	ctx := ctxHolder.context()
+	if ctxHolder.handler == nil {
+		return globalLogger, ctx
+	}
+
+	fCtx := ctxHolder.frankenPHPContext()
+	if fCtx == nil || fCtx.logger == nil {
+		return globalLogger, ctx
+	}
+
+	return fCtx.logger, ctx
+}
+
 //export go_log
 func go_log(threadIndex C.uintptr_t, message *C.char, level C.int) {
-	ctx := phpThreads[threadIndex].context()
-	logger := phpThreads[threadIndex].frankenPHPContext().logger
+	logger, ctx := getLogger(threadIndex)
 
 	m := C.GoString(message)
 	le := syslogLevelInfo
@@ -697,8 +715,7 @@ func go_log(threadIndex C.uintptr_t, message *C.char, level C.int) {
 
 //export go_log_attrs
 func go_log_attrs(threadIndex C.uintptr_t, message *C.zend_string, cLevel C.zend_long, cAttrs *C.zval) *C.char {
-	ctx := phpThreads[threadIndex].context()
-	logger := phpThreads[threadIndex].frankenPHPContext().logger
+	logger, ctx := getLogger(threadIndex)
 
 	level := slog.Level(cLevel)
 


### PR DESCRIPTION
Fixes: https://github.com/php/frankenphp/issues/2083

It has been attempted already in https://github.com/php/frankenphp/pull/2087, but it was not enough to avoid the panic.