### PR TITLE
fix segmentation fault when registering multiple extensions

### DIFF
--- a/ext.go
+++ b/ext.go
@@ -23,7 +23,7 @@ func registerExtensions() {
 	}
 
 	registerOnce.Do(func() {
-		C.register_extensions(extensions[0], C.int(len(extensions)))
+		C.register_extensions((**C.zend_module_entry)(unsafe.Pointer(&extensions[0])), C.int(len(extensions)))
 		extensions = nil
 	})
 }

--- a/frankenphp.c
+++ b/frankenphp.c
@@ -1262,7 +1262,7 @@ int frankenphp_reset_opcache(void) {
 
 int frankenphp_get_current_memory_limit() { return PG(memory_limit); }
 
-static zend_module_entry *modules = NULL;
+static zend_module_entry **modules = NULL;
 static int modules_len = 0;
 static int (*original_php_register_internal_extensions_func)(void) = NULL;
 
@@ -1273,7 +1273,7 @@ PHPAPI int register_internal_extensions(void) {
   }
 
   for (int i = 0; i < modules_len; i++) {
-    if (zend_register_internal_module(&modules[i]) == NULL) {
+    if (zend_register_internal_module(modules[i]) == NULL) {
       return FAILURE;
     }
   }
@@ -1284,7 +1284,7 @@ PHPAPI int register_internal_extensions(void) {
   return SUCCESS;
 }
 
-void register_extensions(zend_module_entry *m, int len) {
+void register_extensions(zend_module_entry **m, int len) {
   modules = m;
   modules_len = len;
 

--- a/frankenphp.h
+++ b/frankenphp.h
@@ -76,6 +76,6 @@ void frankenphp_register_bulk(
     ht_key_value_pair auth_type, ht_key_value_pair remote_ident,
     ht_key_value_pair request_uri, ht_key_value_pair ssl_cipher);
 
-void register_extensions(zend_module_entry *m, int len);
+void register_extensions(zend_module_entry **m, int len);
 
 #endif


### PR DESCRIPTION
This PR fixes a segmentation fault when using frankenphp.RegisterExtension with more than one extension.
The issue was a type mismatch between Go and C: Go passes a slice of pointers, but the C code was treating it as a contiguous array of structs. This caused invalid memory access when iterating past the first element.
I created a minimal reproduction repo here: [https://github.com/y-l-g/frankenphp-extensions-segfault-repro](https://www.google.com/url?sa=E&q=https%3A%2F%2Fgithub.com%2Fy-l-g%2Ffrankenphp-extensions-segfault-repro)