### PR TITLE
fix: prevents segfault on early shutdown.

### DIFF
--- a/phpmainthread.go
+++ b/phpmainthread.go
@@ -79,6 +79,9 @@ func initPHPThreads(numThreads int, numMaxThreads int, phpIni map[string]string)
 }
 
 func drainPHPThreads() {
+	if mainThread == nil {
+		return // mainThread was never initialized
+	}
 	doneWG := sync.WaitGroup{}
 	doneWG.Add(len(phpThreads))
 	mainThread.state.Set(state.ShuttingDown)

--- a/phpmainthread_test.go
+++ b/phpmainthread_test.go
@@ -96,7 +96,7 @@ func TestTransitionThreadsWhileDoingRequests(t *testing.T) {
 
 	var (
 		isDone atomic.Bool
-		wg sync.WaitGroup
+		wg     sync.WaitGroup
 	)
 
 	numThreads := 10

--- a/watcher.go
+++ b/watcher.go
@@ -10,7 +10,7 @@ import (
 )
 
 type hotReloadOpt struct {
-	hotReload   []*watcher.PatternGroup
+	hotReload []*watcher.PatternGroup
 }
 
 var restartWorkers atomic.Bool


### PR DESCRIPTION
Fixes #2114

This early [Shutdown](https://github.com/php/frankenphp/blob/11160fb7b31171d706cf9933abb9102dbb1cdb3c/frankenphp.go#L281) introduced in #2031 segfaults instead of returning an error since threads have not started yet.