### PR TITLE
fix(doc): missing export for tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,7 @@ If your Docker version is lower than 23.0, the build will fail due to dockerigno
 ## Running the test suite
 
 ```console
+export CGO_CFLAGS=$(php-config --includes) CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)"
 go test -tags watcher -race -v ./...
 ```
 


### PR DESCRIPTION
Documentation misses an export we can find in [this comment](https://github.com/php/frankenphp/issues/1758#issuecomment-3092470632)