### PR TITLE
fix: let PHP handle basic auth.

### DIFF
--- a/cgi.go
+++ b/cgi.go
@@ -277,23 +277,13 @@ func splitPos(path string, splitPath []string) int {
 // See: https://github.com/php/php-src/blob/345e04b619c3bc11ea17ee02cdecad6ae8ce5891/main/SAPI.h#L72
 //
 //export go_update_request_info
-func go_update_request_info(threadIndex C.uintptr_t, info *C.sapi_request_info) {
+func go_update_request_info(threadIndex C.uintptr_t, info *C.sapi_request_info) *C.char {
 	thread := phpThreads[threadIndex]
 	fc := thread.frankenPHPContext()
 	request := fc.request
 
 	if request == nil {
-		return
-	}
-
-	authUser, authPassword, ok := request.BasicAuth()
-	if ok {
-		if authPassword != "" {
-			info.auth_password = thread.pinCString(authPassword)
-		}
-		if authUser != "" {
-			info.auth_user = thread.pinCString(authUser)
-		}
+		return nil
 	}
 
 	info.request_method = thread.pinCString(request.Method)
@@ -311,6 +301,13 @@ func go_update_request_info(threadIndex C.uintptr_t, info *C.sapi_request_info) 
 	info.request_uri = thread.pinCString(request.URL.RequestURI())
 
 	info.proto_num = C.int(request.ProtoMajor*1000 + request.ProtoMinor)
+
+	authorizationHeader := request.Header.Get("Authorization")
+	if authorizationHeader == "" {
+		return nil
+	}
+
+	return thread.pinCString(authorizationHeader)
 }
 
 // SanitizedPathJoin performs filepath.Join(root, reqPath) that


### PR DESCRIPTION
I noticed that PHP likes to handle and free basic auth parameters internally (see [here](https://github.com/php/php-src/blob/9f774e3a85d34f4aa1558613a9df7703ad3bb513/main/main.c#L2739) and [here](https://github.com/php/php-src/blob/9f774e3a85d34f4aa1558613a9df7703ad3bb513/main/SAPI.c#L514-L525)). This PR changes it so the basic auth header is forwarded to PHP instead of resolving it in go.

I suspect that this might fix some crashes in shutdown functions (like #2121 and #1841) since it allows us freeing the `request_info` after shutdown is finished. I haven't been able to reproduce these crashes yet though.

