### PR TITLE
fix: race condition in thread shutdown during drain

### DIFF
--- a/phpthread.go
+++ b/phpthread.go
@@ -66,9 +66,11 @@ func (thread *phpThread) boot() {
 // shutdown the underlying PHP thread
 func (thread *phpThread) shutdown() {
 	if !thread.state.RequestSafeStateChange(state.ShuttingDown) {
-		// already shutting down or done
+		// already shutting down or done, wait for the C thread to finish
+		thread.state.WaitFor(state.Done, state.Reserved)
 		return
 	}
+
 	close(thread.drainChan)
 	thread.state.WaitFor(state.Done)
 	thread.drainChan = make(chan struct{})


### PR DESCRIPTION
Fix flaky `TestFinishBootingAWorkerScript` (ex: https://github.com/php/frankenphp/actions/runs/21907896079/job/63253074994)