### PR TITLE
worker: add test on lazy session save path

### DIFF
--- a/frankenphp_test.go
+++ b/frankenphp_test.go
@@ -1360,6 +1360,46 @@ func TestSessionNoLeakBetweenRequests_worker(t *testing.T) {
 	})
 }
 
+// TestSessionLazySavePath reproduces issue #2185:
+// When session.save_path is set lazily on the first request (not during worker boot),
+// frankenphp_restore_ini() resets it to empty on subsequent requests, causing session data loss.
+func TestSessionLazySavePath(t *testing.T) {
+	runTest(t, func(_ func(http.ResponseWriter, *http.Request), ts *httptest.Server, _ int) {
+		jar, err := cookiejar.New(&cookiejar.Options{})
+		assert.NoError(t, err)
+		client := &http.Client{Jar: jar}
+
+		// Request 1: session.save_path is set lazily (not during boot), session data is written.
+		resp1, err := client.Get(ts.URL + "/session-lazy-save-path.php?action=write&value=issue2185")
+		assert.NoError(t, err)
+		body1, _ := io.ReadAll(resp1.Body)
+		_ = resp1.Body.Close()
+
+		body1Str := string(body1)
+		assert.Contains(t, body1Str, "WRITTEN", "first request should write to session")
+		assert.Contains(t, body1Str, "VALUE:issue2185")
+
+		// Request 2: frankenphp_restore_ini() resets session.save_path to empty;
+		// the framework skips re-setting it → session data is lost.
+		resp2, err := client.Get(ts.URL + "/session-lazy-save-path.php?action=read")
+		assert.NoError(t, err)
+		body2, _ := io.ReadAll(resp2.Body)
+		_ = resp2.Body.Close()
+
+		body2Str := string(body2)
+
+		assert.Contains(t, body2Str, "VALUE:issue2185",
+			"BUG #2185: session data lost because session.save_path was reset to empty.\nRequest 1: %s\nRequest 2: %s",
+			body1Str, body2Str)
+	}, &testOptions{
+		workerScript:       "session-lazy-save-path.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+		realServer:         true,
+	})
+}
+
+
 func TestSessionNoLeakAfterExit_worker(t *testing.T) {
 	runTest(t, func(_ func(http.ResponseWriter, *http.Request), ts *httptest.Server, i int) {
 		// Client A: Set a secret value in session and call exit(1)


### PR DESCRIPTION
This small reproducer should reproduce the issue #2185 

This bug has probably be introduced with the PR #2139: we now reset ini settings between requests and symfony sets the save_path only on the first use of the session object.

We have a few possible ways to fix it here:
1. Rollback the ini reset, that would reintroduce some bugs
2. Exclude session settings from reset, that might do the trick but is fragile
3. Propose a fix on symfony to make sure `ini_set` are always called

I went through all the symfony code base, we have the following `ini_set`:
- A lot in [the cache component](https://github.com/symfony/symfony/tree/8.1/src/Symfony/Component/Cache) but all settings are rolled back after (like: `$unserializeCallbackHandler = ini_set('unserialize_callback_func', __CLASS__.'::handleUnserializeCallback'); /* do stuff */ ini_set('unserialize_callback_func', $unserializeCallbackHandler);`)
- [Error Handler](https://github.com/symfony/symfony/blob/8.1/src/Symfony/Component/ErrorHandler/Debug.php#L23-L34): in method `enable`: not normally used in worker mode
- [HttpFoundation\Response](https://github.com/symfony/symfony/blob/8.1/src/Symfony/Component/HttpFoundation/Response.php#L253) this should not have been persisted between requests
- Session:
  - [NativeSessionStorage](https://github.com/symfony/symfony/blob/8.1/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php) all options are set by construct only
  - [NativeFileSessionHandler](https://github.com/symfony/symfony/blob/8.1/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeFileSessionHandler.php) - save_path and save_handler
- [Symfony\Component\Messenger\Transport\Serialization\PhpSerializer](https://github.com/symfony/symfony/blob/8.1/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php#L78-L103) same pattern than cache: set + rollback after unserialize
- [Firewall](https://github.com/symfony/symfony/blob/8.1/src/Symfony/Component/Security/Http/Firewall/ContextListener.php#L262-L280): same pattern
- Runtime: [BasicErrorHandler](https://github.com/symfony/symfony/blob/8.1/src/Symfony/Component/Runtime/Internal/BasicErrorHandler.php) and [SymfonyErrorHandler](https://github.com/symfony/symfony/blob/8.1/src/Symfony/Component/Runtime/Internal/SymfonyErrorHandler.php):  the error handler is registered in construct of the [GenericRuntime](https://github.com/symfony/symfony/blob/8.1/src/Symfony/Component/Runtime/GenericRuntime.php#L79)

@dunglas @AlliBalliBaba @henderkes WDYT ?