### PR TITLE
fix: prevent worker starvation after max_execution_time restarts

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -385,6 +385,12 @@ static void frankenphp_cleanup_worker_state(void) {
 
 /* Adapted from php_request_shutdown */
 static void frankenphp_worker_request_shutdown() {
+#ifdef ZEND_MAX_EXECUTION_TIMERS
+  /* Disable any execution timer set during the request callback to prevent
+   * stale timers from firing between requests */
+  zend_unset_timeout();
+#endif
+
   /* Flush all output buffers */
   zend_try { php_output_end_all(); }
   zend_end_try();

--- a/testdata/worker-timeout-recovery.php
+++ b/testdata/worker-timeout-recovery.php
@@ -1,0 +1,21 @@
+<?php
+
+require_once __DIR__.'/_executor.php';
+
+return function () {
+    $action = $_GET['action'] ?? 'normal';
+
+    switch ($action) {
+        case 'timeout':
+            echo 'BEFORE_TIMEOUT';
+            set_time_limit(1);
+            while (true) {
+                // Infinite loop: will be killed by max_execution_time
+            }
+            break;
+
+        case 'ping':
+            echo 'pong';
+            break;
+    }
+};

--- a/worker_test.go
+++ b/worker_test.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -173,4 +174,39 @@ func TestKeepRunningOnConnectionAbort(t *testing.T) {
 
 		assert.Equal(t, "requests:2", body2, "should not have stopped execution after the first request was aborted")
 	}, &testOptions{workerScript: "worker-with-counter.php", nbWorkers: 1, nbParallelRequests: 1})
+}
+
+func TestWorkerRecoverFromTimeout(t *testing.T) {
+	if !frankenphp.Config().ZendMaxExecutionTimers {
+		t.Skip("requires ZEND_MAX_EXECUTION_TIMERS")
+	}
+
+	runTest(t, func(_ func(http.ResponseWriter, *http.Request), ts *httptest.Server, i int) {
+		client := &http.Client{Timeout: 5 * time.Second}
+
+		// Trigger a request that will hit max_execution_time and crash the worker
+		resp, err := client.Get(ts.URL + "/worker-timeout-recovery.php?action=timeout")
+		if err == nil {
+			_, _ = io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+		}
+
+		// After the worker restarts, it should be able to serve new requests
+		assert.Eventually(t, func() bool {
+			resp, err := client.Get(ts.URL + "/worker-timeout-recovery.php?action=ping")
+			if err != nil {
+				return false
+			}
+
+			body, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+
+			return string(body) == "pong"
+		}, 5*time.Second, 50*time.Millisecond, "worker should recover after max_execution_time timeout")
+	}, &testOptions{
+		workerScript:       "worker-timeout-recovery.php",
+		nbWorkers:          1,
+		nbParallelRequests: 1,
+		realServer:         true,
+	})
 }


### PR DESCRIPTION
Fixes #2205. At least I hope so. 

Disable the execution timer in `frankenphp_worker_request_shutdown()` to prevent stale timers from firing between requests. Also, fix evaluation order in `frankenphp_handle_request()` to check for shutdown before calling `frankenphp_worker_request_startup()`.