### PR TITLE
metrics: only report workers ready when actually ready

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -98,7 +98,6 @@ func initWorkers(opt []workerOpt) error {
 	return nil
 }
 
-
 func newWorker(o workerOpt) (*worker, error) {
 	// Order is important!
 	// This order ensures that FrankenPHP started from inside a symlinked directory will properly resolve any paths.


### PR DESCRIPTION
In #2205 it appears that workers could be reported in metrics as "ready" before they are actually ready. This changes the reporting so that workers are only reported ready once they have completed booting. 