### PR TITLE
fix: work around GCC 12 false positive when building watcher on i386

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,8 @@ RUN --mount=type=secret,id=github-token \
     sed 's/"//g' | \
     xargs curl -L | \
     tar xz --strip-components 1 && \
-    cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && \
+    # -Wno-error=use-after-free: GCC 12 on Bookworm i386 emits a spurious warning in libstdc++ basic_string.h
+    cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wno-error=use-after-free" && \
     cmake --build build && \
     cmake --install build && \
     ldconfig


### PR DESCRIPTION
GCC 12 on Debian Bookworm i386 emits a spurious -Werror=use-after-free in libstdc++ basic_string.h when compiling e-dant/watcher, causing Docker builds to fail.