### PR TITLE
fix(windows): ensure DLLs can always be located by PHP

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -1097,8 +1097,7 @@ static void *php_main(void *arg) {
         if (slash) {
           *slash = L'\0';
           if (!SetDllDirectoryW(filename)) {
-            fprintf(stderr,
-                    "Warning: SetDllDirectoryW failed (error %lu)\n",
+            fprintf(stderr, "Warning: SetDllDirectoryW failed (error %lu)\n",
                     GetLastError());
           }
         }


### PR DESCRIPTION
Prevent crashes when `php.ini` references PHP extensions using relative paths, and FrankenPHP is started from a different working directory than the one containing extensions, or with `caddy start` (instead of `caddy run`). 