### PR TITLE
fix: doc translation triggers

### DIFF
--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -25,7 +25,7 @@ jobs:
           # because this workflow needs to push a branch via git push
       - id: md_files
         run: |
-          FILES=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" -- 'docs/*.md')
+          FILES=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" -- 'docs/*.md' ':(exclude)docs/*/*.md')
           FILES=$(echo "$FILES" | xargs -n1 basename | tr '\n' ' ')
           [ -z "$FILES" ] && echo "found=false" >> "$GITHUB_OUTPUT" || echo "found=true" >> "$GITHUB_OUTPUT"
           echo "files=$FILES" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Prevents PRs like #2259 by fixing the `git diff` so it ignores nested translation files.