### PR TITLE
fix: avoid longjmp crash on ARM64/macOS when connection is aborted

### DIFF
--- a/frankenphp.c
+++ b/frankenphp.c
@@ -743,7 +743,18 @@ static size_t frankenphp_ub_write(const char *str, size_t str_length) {
       go_ub_write(thread_index, (char *)str, str_length);
 
   if (result.r1) {
-    php_handle_aborted_connection();
+    /*
+     * Inline the effect of php_handle_aborted_connection() without calling
+     * zend_bailout(). On ARM64/macOS, zend_bailout() triggers longjmp()
+     * which crashes due to PAC (Pointer Authentication) verification failure
+     * on the jmp_buf — the buffer was signed in a different stack frame.
+     *
+     * This matches Nginx Unit's approach (nxt_php_sapi.c): set the
+     * connection status and disable output, letting PHP detect the abort
+     * at safe points (e.g. between opcodes via zend_interrupt checks).
+     */
+    PG(connection_status) = PHP_CONNECTION_ABORTED;
+    php_output_set_status(PHP_OUTPUT_DISABLED);
   }
 
   return result.r0;
@@ -777,7 +788,8 @@ static int frankenphp_send_headers(sapi_headers_struct *sapi_headers) {
 static void frankenphp_sapi_flush(void *server_context) {
   sapi_send_headers();
   if (go_sapi_flush(thread_index)) {
-    php_handle_aborted_connection();
+    PG(connection_status) = PHP_CONNECTION_ABORTED;
+    php_output_set_status(PHP_OUTPUT_DISABLED);
   }
 }
 


### PR DESCRIPTION
`php_handle_aborted_connection()` calls `zend_bailout()` which does a `longjmp()`. On ARM64/macOS with Pointer Authentication (PAC), the jmp_buf signature check fails because the buffer was signed in a different stack frame, causing a SIGBUS crash.

Inline the effect of php_handle_aborted_connection() without calling zend_bailout(): 

```
set PG(connection_status) = PHP_CONNECTION_ABORTED 
php_output_set_status(PHP_OUTPUT_DISABLED)
```

PHP detects the abort at safe points (between opcodes via zend_interrupt checks) instead of longjmping out of the SAPI write handler. 

This matches the approach used by Nginx Unit's PHP SAPI: https://github.com/nginx/unit/blob/master/src/nxt_php_sapi.c#L271

Affects both frankenphp_ub_write and frankenphp_sapi_flush.