### PR TITLE
docs: Update Debian installation to `DEB822`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,13 @@ Our maintainers offer deb packages for all systems using `apt`. To install, run:
 ```console
 VERSION=85 # 82-85 available
 sudo curl https://pkg.henderkes.com/api/packages/${VERSION}/debian/repository.key -o /etc/apt/keyrings/static-php${VERSION}.asc
-echo "deb [signed-by=/etc/apt/keyrings/static-php${VERSION}.asc] https://pkg.henderkes.com/api/packages/${VERSION}/debian php-zts main" | sudo tee -a /etc/apt/sources.list.d/static-php${VERSION}.list
+sudo tee -a /etc/apt/sources.list.d/static-php${VERSION}.sources <<EOF
+Types: deb
+URIs: https://pkg.henderkes.com/api/packages/${VERSION}/debian
+Suites: php-zts
+Components: main
+Signed-By: /etc/apt/keyrings/static-php${VERSION}.asc
+EOF
 sudo apt update
 sudo apt install frankenphp
 ```


### PR DESCRIPTION
Change the Debian installation source format from `.list` to `.sources`.

Debian moving to a new source format, which is `DEB822`, see https://wiki.debian.org/SourcesList#APT_sources_format for more information.