### PR TITLE
fix: remove cd before call to spc dump-extensions

### DIFF
--- a/build-static.sh
+++ b/build-static.sh
@@ -158,7 +158,6 @@ fi
 if [ -z "${PHP_EXTENSIONS}" ]; then
 	# enable EMBED mode, first check if project has dumped extensions
 	if [ -n "${EMBED}" ] && [ -f "${EMBED}/composer.json" ] && [ -f "${EMBED}/composer.lock" ] && [ -f "${EMBED}/vendor/composer/installed.json" ]; then
-		cd "${EMBED}"
 		# read the extensions using spc dump-extensions
 		PHP_EXTENSIONS=$(${spcCommand} dump-extensions "${EMBED}" --format=text --no-dev --no-ext-output="${defaultExtensions}")
 	else


### PR DESCRIPTION
Not sure why this `cd` is in place since this invalidates the previous `cd` calls for the `spcCommand` to work. It also makes no sense since the `${EMBED}` is passed as an argument here.

Or perhaps I am missing something?