### PR TITLE
fix(caddy): reject invalid split_path at provision time

### DIFF
--- a/caddy/module.go
+++ b/caddy/module.go
@@ -117,11 +117,11 @@ func (f *FrankenPHPModule) Provision(ctx caddy.Context) error {
 		f.SplitPath = []string{".php"}
 	}
 
-	if opt, err := frankenphp.WithRequestSplitPath(f.SplitPath); err == nil {
-		f.requestOptions = append(f.requestOptions, opt)
-	} else {
-		f.requestOptions = append(f.requestOptions, opt)
+	opt, err := frankenphp.WithRequestSplitPath(f.SplitPath)
+	if err != nil {
+		return fmt.Errorf("invalid split_path: %w", err)
 	}
+	f.requestOptions = append(f.requestOptions, opt)
 
 	if f.ResolveRootSymlink == nil {
 		f.ResolveRootSymlink = new(true)


### PR DESCRIPTION
A non-ASCII `split_path` caused `WithRequestSplitPath`'s error to be swallowed and a nil `RequestOption` to be stored, panicking on the first request. The fix propagates the error from `Provision`, rejecting the config at startup with a clear message.